### PR TITLE
feat(map): Add control mapping engine with LLM enrichment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "rich>=13.0",
     "pyyaml>=6.0",
     "chromadb>=0.5",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]
@@ -34,6 +35,9 @@ ingest = [
     "docling>=2.0",
     "pandas>=2.0",
     "openpyxl>=3.1",
+]
+cloud = [
+    "openai>=1.0",
 ]
 dev = [
     "pytest>=8.0",

--- a/src/lemma/cli.py
+++ b/src/lemma/cli.py
@@ -5,12 +5,14 @@ Usage:
     lemma status         Show compliance posture summary
     lemma validate       Validate an OSCAL JSON file
     lemma framework      Manage compliance frameworks
+    lemma map            Map policies to framework controls
 """
 
 import typer
 
 from lemma.commands.framework import framework_app
 from lemma.commands.init import init_command
+from lemma.commands.map import map_command
 from lemma.commands.status import status_command
 from lemma.commands.validate import validate_command
 
@@ -23,6 +25,7 @@ app = typer.Typer(
 app.command(name="init", help="Scaffold a compliance-as-code repository")(init_command)
 app.command(name="status", help="Show compliance posture summary")(status_command)
 app.command(name="validate", help="Validate an OSCAL JSON file")(validate_command)
+app.command(name="map", help="Map policies to framework controls")(map_command)
 app.add_typer(framework_app, name="framework", help="Manage compliance frameworks")
 
 

--- a/src/lemma/commands/map.py
+++ b/src/lemma/commands/map.py
@@ -1,0 +1,86 @@
+"""Implementation of the `lemma map` CLI command.
+
+Maps policy documents to indexed framework controls using
+vector similarity and LLM-generated rationales.
+"""
+
+from pathlib import Path
+
+import typer
+import yaml
+
+from lemma.services.formatters import get_formatter
+from lemma.services.llm import get_llm_client
+from lemma.services.mapper import map_policies
+
+
+def _error(message: str) -> None:
+    """Print error and exit with code 1."""
+    typer.echo(f"Error: {message}", err=False)
+    raise typer.Exit(code=1)
+
+
+def map_command(
+    framework: str = typer.Option(
+        ...,
+        help="Framework to map against (e.g., nist-800-53)",
+    ),
+    output: str = typer.Option(
+        "json",
+        help="Output format (json, oscal)",
+    ),
+    threshold: float = typer.Option(
+        0.6,
+        help="Confidence threshold for LOW_CONFIDENCE flagging",
+    ),
+) -> None:
+    """Map policy documents to framework controls with AI-generated rationales."""
+    cwd = Path.cwd()
+
+    # Validate Lemma project
+    if not (cwd / ".lemma").exists():
+        _error("Not a Lemma project. Run `lemma init` first.")
+
+    # Validate policies directory
+    policies_dir = cwd / "policies"
+    if not policies_dir.exists() or not list(policies_dir.glob("*.md")):
+        _error("No policy documents found. Add .md files to policies/.")
+
+    # Load AI config from lemma.config.yaml
+    config_file = cwd / "lemma.config.yaml"
+    ai_config: dict = {}
+    if config_file.exists():
+        full_config = yaml.safe_load(config_file.read_text()) or {}
+        ai_config = full_config.get("ai", {})
+
+    # Get LLM client
+    try:
+        llm_client = get_llm_client(ai_config)
+    except ImportError as e:
+        _error(str(e))
+
+    # Run mapping
+    try:
+        report = map_policies(
+            framework=framework,
+            project_dir=cwd,
+            llm_client=llm_client,
+            threshold=threshold,
+        )
+    except ValueError as e:
+        _error(str(e))
+
+    # Format and output
+    try:
+        formatter = get_formatter(output)
+    except ValueError as e:
+        _error(str(e))
+
+    formatted = formatter(report)
+    typer.echo(formatted)
+
+    typer.echo(
+        f"\nMapped {report.mapped_count}/{report.total_count} "
+        f"chunks to {framework} controls. "
+        f"({report.low_confidence_count} low confidence)"
+    )

--- a/src/lemma/models/mapping.py
+++ b/src/lemma/models/mapping.py
@@ -1,0 +1,63 @@
+"""Mapping domain models — structured output types for control mapping.
+
+Defines the data structures for mapping results, including
+individual chunk-to-control mappings and aggregated reports.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, computed_field
+
+
+class MappingResult(BaseModel):
+    """A single chunk-to-control mapping result.
+
+    Attributes:
+        chunk_id: Source policy chunk identifier (e.g., 'access-control.md#1').
+        chunk_text: The policy text that was mapped.
+        control_id: Target framework control identifier (e.g., 'ac-2').
+        control_title: Human-readable control title.
+        confidence: AI-generated confidence score (0.0-1.0).
+        rationale: AI-generated explanation of the mapping.
+        status: MAPPED, LOW_CONFIDENCE, or UNMAPPED.
+    """
+
+    chunk_id: str
+    chunk_text: str
+    control_id: str
+    control_title: str
+    confidence: float
+    rationale: str
+    status: str
+
+
+class MappingReport(BaseModel):
+    """Aggregated mapping report with metadata.
+
+    Attributes:
+        framework: Framework name that was mapped against.
+        results: List of individual mapping results.
+        threshold: Confidence threshold used for flagging.
+    """
+
+    framework: str
+    results: list[MappingResult] = Field(default_factory=list)
+    threshold: float = 0.6
+
+    @computed_field
+    @property
+    def mapped_count(self) -> int:
+        """Number of results with MAPPED status."""
+        return sum(1 for r in self.results if r.status == "MAPPED")
+
+    @computed_field
+    @property
+    def low_confidence_count(self) -> int:
+        """Number of results with LOW_CONFIDENCE status."""
+        return sum(1 for r in self.results if r.status == "LOW_CONFIDENCE")
+
+    @computed_field
+    @property
+    def total_count(self) -> int:
+        """Total number of mapping results."""
+        return len(self.results)

--- a/src/lemma/services/chunker.py
+++ b/src/lemma/services/chunker.py
@@ -1,0 +1,98 @@
+"""Policy document chunker — splits markdown into semantic chunks.
+
+Reads markdown files from a policies directory and splits them
+into sentence-aware chunks with source tracking for downstream
+vector embedding and mapping.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def chunk_policies(policies_dir: Path, max_chunk_size: int = 500) -> list[dict]:
+    """Split all markdown policy files into semantic chunks.
+
+    Args:
+        policies_dir: Path to the policies directory.
+        max_chunk_size: Maximum characters per chunk.
+
+    Returns:
+        List of chunk dicts with 'id', 'source', and 'text' keys.
+    """
+    chunks: list[dict] = []
+
+    md_files = sorted(policies_dir.glob("*.md"))
+    for md_file in md_files:
+        content = md_file.read_text().strip()
+        if not content:
+            continue
+
+        file_chunks = _split_into_chunks(content, max_chunk_size)
+        for i, text in enumerate(file_chunks):
+            chunks.append(
+                {
+                    "id": f"{md_file.name}#{i + 1}",
+                    "source": md_file.name,
+                    "text": text,
+                }
+            )
+
+    return chunks
+
+
+def _split_into_chunks(text: str, max_size: int) -> list[str]:
+    """Split text into sentence-aware chunks.
+
+    Splits on section boundaries (## headings) first, then
+    further splits long sections at sentence boundaries.
+    """
+    # Split on markdown headings to get logical sections
+    sections = re.split(r"\n(?=##?\s)", text)
+    chunks: list[str] = []
+
+    for section in sections:
+        section = section.strip()
+        if not section:
+            continue
+
+        # Remove heading-only sections with no body
+        lines = section.split("\n", 1)
+        if len(lines) == 1 and lines[0].startswith("#"):
+            continue
+
+        if len(section) <= max_size:
+            chunks.append(section)
+        else:
+            # Split long sections at sentence boundaries
+            chunks.extend(_split_at_sentences(section, max_size))
+
+    return chunks
+
+
+def _split_at_sentences(text: str, max_size: int) -> list[str]:
+    """Split text at sentence boundaries, keeping chunks under max_size."""
+    # Split on sentence-terminal punctuation followed by space
+    sentences = re.split(r"(?<=[.!?:])\s+", text)
+    current_chunk: list[str] = []
+    current_size = 0
+    result: list[str] = []
+
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+
+        if current_size + len(sentence) > max_size and current_chunk:
+            result.append(" ".join(current_chunk))
+            current_chunk = []
+            current_size = 0
+
+        current_chunk.append(sentence)
+        current_size += len(sentence)
+
+    if current_chunk:
+        result.append(" ".join(current_chunk))
+
+    return result

--- a/src/lemma/services/formatters.py
+++ b/src/lemma/services/formatters.py
@@ -1,0 +1,120 @@
+"""Output format registry for mapping results.
+
+Provides serializers for mapping reports in different formats:
+- JSON: Plain JSON output
+- OSCAL: OSCAL Assessment Results document
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from lemma.models.mapping import MappingReport
+
+
+def format_json(report: MappingReport) -> str:
+    """Format mapping report as JSON.
+
+    Args:
+        report: The mapping report to format.
+
+    Returns:
+        JSON string of the report.
+    """
+    return report.model_dump_json(indent=2)
+
+
+def format_oscal(report: MappingReport) -> str:
+    """Format mapping report as OSCAL Assessment Results.
+
+    Produces a minimal but valid OSCAL Assessment Results document
+    with findings derived from the mapping results.
+
+    Args:
+        report: The mapping report to format.
+
+    Returns:
+        JSON string of the OSCAL Assessment Results document.
+    """
+    now = datetime.now(tz=UTC).isoformat()
+
+    findings = []
+    for result in report.results:
+        finding = {
+            "uuid": str(uuid4()),
+            "title": f"Mapping: {result.chunk_id} → {result.control_id}",
+            "description": result.rationale,
+            "target": {
+                "type": "objective-id",
+                "target-id": result.control_id,
+                "title": result.control_title,
+                "status": {
+                    "state": "satisfied" if result.status == "MAPPED" else "not-satisfied",
+                },
+            },
+            "props": [
+                {
+                    "name": "confidence",
+                    "value": str(result.confidence),
+                },
+                {
+                    "name": "status",
+                    "value": result.status,
+                },
+            ],
+        }
+        findings.append(finding)
+
+    oscal_doc = {
+        "assessment-results": {
+            "uuid": str(uuid4()),
+            "metadata": {
+                "title": f"Lemma Mapping Results — {report.framework}",
+                "last-modified": now,
+                "version": "1.0.0",
+                "oscal-version": "1.1.2",
+            },
+            "results": [
+                {
+                    "uuid": str(uuid4()),
+                    "title": f"Control Mapping — {report.framework}",
+                    "description": (
+                        f"Automated mapping of policy documents to {report.framework} controls."
+                    ),
+                    "start": now,
+                    "findings": findings,
+                },
+            ],
+        },
+    }
+
+    return json.dumps(oscal_doc, indent=2)
+
+
+_FORMATTERS: dict[str, Callable[[MappingReport], str]] = {
+    "json": format_json,
+    "oscal": format_oscal,
+}
+
+
+def get_formatter(format_name: str) -> Callable[[MappingReport], str]:
+    """Get a formatter function by name.
+
+    Args:
+        format_name: Format identifier ('json' or 'oscal').
+
+    Returns:
+        Formatter callable.
+
+    Raises:
+        ValueError: If format_name is not supported.
+    """
+    if format_name not in _FORMATTERS:
+        available = ", ".join(sorted(_FORMATTERS.keys()))
+        msg = f"Unsupported output format '{format_name}'. Available: {available}"
+        raise ValueError(msg)
+
+    return _FORMATTERS[format_name]

--- a/src/lemma/services/indexer.py
+++ b/src/lemma/services/indexer.py
@@ -82,3 +82,44 @@ class ControlIndexer:
         """
         collections = self._client.list_collections()
         return [c.name for c in collections]
+
+    def query_similar(
+        self,
+        framework_name: str,
+        text: str,
+        n_results: int = 5,
+    ) -> list[dict]:
+        """Query a framework collection for controls similar to the given text.
+
+        Args:
+            framework_name: Collection name to query.
+            text: Query text to find similar controls for.
+            n_results: Maximum number of results to return.
+
+        Returns:
+            List of dicts with 'control_id', 'title', 'distance', 'document'.
+            Returns empty list if collection doesn't exist.
+        """
+        try:
+            collection = self._client.get_collection(name=framework_name)
+        except Exception:
+            return []
+
+        results = collection.query(
+            query_texts=[text],
+            n_results=min(n_results, collection.count()),
+        )
+
+        matches = []
+        if results and results["ids"] and results["ids"][0]:
+            for i, control_id in enumerate(results["ids"][0]):
+                matches.append(
+                    {
+                        "control_id": control_id,
+                        "title": results["metadatas"][0][i].get("title", ""),
+                        "distance": results["distances"][0][i] if results.get("distances") else 0.0,
+                        "document": results["documents"][0][i] if results.get("documents") else "",
+                    }
+                )
+
+        return matches

--- a/src/lemma/services/llm.py
+++ b/src/lemma/services/llm.py
@@ -1,0 +1,133 @@
+"""Pluggable LLM client abstraction.
+
+Provides a unified interface for LLM backends with two implementations:
+- OllamaClient: Local inference via HTTP API (default, no data leaves machine)
+- OpenAIClient: Cloud inference via OpenAI SDK (optional, requires API key)
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import httpx
+
+
+class LLMClient(Protocol):
+    """Protocol for LLM backends used in control mapping."""
+
+    def generate(self, prompt: str) -> str:
+        """Generate a completion for the given prompt.
+
+        Args:
+            prompt: The input prompt text.
+
+        Returns:
+            The generated response text.
+        """
+        ...
+
+
+class OllamaClient:
+    """Local Ollama LLM backend via HTTP API.
+
+    Args:
+        model: Ollama model name (e.g., 'llama3.2', 'mistral').
+        base_url: Ollama API base URL.
+    """
+
+    def __init__(
+        self,
+        model: str = "llama3.2",
+        base_url: str = "http://localhost:11434",
+    ) -> None:
+        self.model = model
+        self.base_url = base_url
+
+    def generate(self, prompt: str) -> str:
+        """Send prompt to Ollama and return the response.
+
+        Args:
+            prompt: The input prompt text.
+
+        Returns:
+            The generated response text.
+        """
+        response = httpx.post(
+            f"{self.base_url}/api/generate",
+            json={
+                "model": self.model,
+                "prompt": prompt,
+                "stream": False,
+            },
+            timeout=120.0,
+        )
+        response.raise_for_status()
+        return response.json()["response"]
+
+
+class OpenAIClient:
+    """OpenAI cloud LLM backend.
+
+    Args:
+        api_key: OpenAI API key.
+        model: Model name (e.g., 'gpt-4o-mini').
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        model: str = "gpt-4o-mini",
+    ) -> None:
+        self.model = model
+        try:
+            from openai import OpenAI
+
+            self._client = OpenAI(api_key=api_key)
+        except ImportError:
+            self._client = None
+
+    def generate(self, prompt: str) -> str:
+        """Send prompt to OpenAI and return the response.
+
+        Args:
+            prompt: The input prompt text.
+
+        Returns:
+            The generated response text.
+
+        Raises:
+            ImportError: If openai package is not installed.
+        """
+        if self._client is None:
+            msg = (
+                "OpenAI backend requires the [cloud] extras. "
+                "Install with: pip install lemma-grc[cloud]"
+            )
+            raise ImportError(msg)
+
+        response = self._client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1,
+        )
+        return response.choices[0].message.content
+
+
+def get_llm_client(config: dict) -> LLMClient:
+    """Factory — returns the appropriate LLM client based on config.
+
+    Args:
+        config: AI configuration dict from lemma.config.yaml.
+            Expected keys: 'provider', 'model', 'api_key' (for openai).
+
+    Returns:
+        An LLMClient instance.
+    """
+    provider = config.get("provider", "ollama")
+    model = config.get("model", "llama3.2")
+
+    if provider == "openai":
+        api_key = config.get("api_key", "")
+        return OpenAIClient(api_key=api_key, model=model)
+
+    return OllamaClient(model=model)

--- a/src/lemma/services/mapper.py
+++ b/src/lemma/services/mapper.py
@@ -1,0 +1,120 @@
+"""Control mapping engine — maps policy chunks to framework controls.
+
+Orchestrates the full mapping pipeline:
+1. Chunk policy documents
+2. Retrieve similar controls via vector search
+3. Enrich with LLM-generated rationales and confidence scores
+4. Aggregate results into a MappingReport
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lemma.models.mapping import MappingReport, MappingResult
+from lemma.services.chunker import chunk_policies
+from lemma.services.indexer import ControlIndexer
+from lemma.services.llm import LLMClient
+
+_MAPPING_PROMPT = """\
+You are a GRC compliance analyst. Given a policy excerpt and a security control, \
+determine how well the policy satisfies the control requirement.
+
+**Policy Excerpt:**
+{chunk_text}
+
+**Control ({control_id}): {control_title}**
+{control_prose}
+
+Respond ONLY with a JSON object containing:
+- "confidence": a float between 0.0 and 1.0 indicating how well the policy maps
+- "rationale": a brief explanation of the mapping (1-2 sentences)
+
+Example: {{"confidence": 0.85, "rationale": "The policy directly addresses..."}}
+"""
+
+
+def map_policies(
+    *,
+    framework: str,
+    project_dir: Path,
+    llm_client: LLMClient,
+    threshold: float = 0.6,
+    top_k: int = 3,
+    output_format: str = "json",
+) -> MappingReport:
+    """Run the full control mapping pipeline.
+
+    Args:
+        framework: Name of the indexed framework to map against.
+        project_dir: Root of the Lemma project.
+        llm_client: LLM client for rationale generation.
+        threshold: Confidence threshold for LOW_CONFIDENCE flagging.
+        top_k: Number of candidate controls per chunk.
+        output_format: Output format name (for future use).
+
+    Returns:
+        MappingReport with all mapping results.
+
+    Raises:
+        ValueError: If framework not indexed or no policies found.
+    """
+    # Validate framework is indexed
+    indexer = ControlIndexer(index_dir=project_dir / ".lemma" / "index")
+    stats = indexer.get_collection_stats(framework)
+    if stats["count"] == 0:
+        msg = f"Framework '{framework}' is not indexed. Run: lemma framework add {framework}"
+        raise ValueError(msg)
+
+    # Chunk policies
+    policies_dir = project_dir / "policies"
+    chunks = chunk_policies(policies_dir)
+    if not chunks:
+        msg = "No policy documents found in policies/. Add .md files and try again."
+        raise ValueError(msg)
+
+    # Map each chunk to controls
+    results: list[MappingResult] = []
+
+    for chunk in chunks:
+        # Retrieve candidate controls via vector similarity
+        candidates = indexer.query_similar(framework, chunk["text"], n_results=top_k)
+
+        for candidate in candidates:
+            # Enrich with LLM rationale
+            prompt = _MAPPING_PROMPT.format(
+                chunk_text=chunk["text"],
+                control_id=candidate["control_id"],
+                control_title=candidate["title"],
+                control_prose=candidate.get("document", ""),
+            )
+
+            try:
+                raw_response = llm_client.generate(prompt)
+                parsed = json.loads(raw_response)
+                confidence = float(parsed.get("confidence", 0.0))
+                rationale = parsed.get("rationale", "No rationale provided.")
+            except (json.JSONDecodeError, KeyError, TypeError):
+                confidence = 0.0
+                rationale = f"LLM response could not be parsed: {raw_response[:200]}"
+
+            status = "MAPPED" if confidence >= threshold else "LOW_CONFIDENCE"
+
+            results.append(
+                MappingResult(
+                    chunk_id=chunk["id"],
+                    chunk_text=chunk["text"][:200],
+                    control_id=candidate["control_id"],
+                    control_title=candidate["title"],
+                    confidence=confidence,
+                    rationale=rationale,
+                    status=status,
+                )
+            )
+
+    return MappingReport(
+        framework=framework,
+        results=results,
+        threshold=threshold,
+    )

--- a/tests/commands/test_map.py
+++ b/tests/commands/test_map.py
@@ -1,0 +1,125 @@
+"""Tests for the `lemma map` CLI command.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestMapCommand:
+    """Tests for `lemma map`."""
+
+    def test_map_not_initialized(self, tmp_path):
+        """Mapping in a non-Lemma directory fails with error."""
+        from lemma.cli import app
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(app, ["map", "--framework", "nist-800-53"])
+            assert result.exit_code == 1
+            stdout = result.stdout.lower()
+            assert "not a lemma project" in stdout or "lemma init" in stdout
+
+    def test_map_no_framework_indexed(self, tmp_path):
+        """Mapping without indexed framework fails with error."""
+        from lemma.cli import app
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(app, ["init"])
+            Path("policies/test.md").write_text("# Test\n\nPolicy text.\n")
+
+            result = runner.invoke(app, ["map", "--framework", "nist-800-53"])
+            assert result.exit_code == 1
+            assert "not indexed" in result.stdout.lower()
+
+    def test_map_no_policies(self, tmp_path):
+        """Mapping without policy files fails with error."""
+        from lemma.cli import app
+        from lemma.services.indexer import ControlIndexer
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(app, ["init"])
+
+            # Remove template README.md created by init
+            readme = Path("policies") / "README.md"
+            if readme.exists():
+                readme.unlink()
+
+            # Index a framework so the "not indexed" check passes
+            indexer = ControlIndexer(index_dir=Path(".lemma") / "index")
+            indexer.index_controls(
+                "nist-800-53",
+                [
+                    {
+                        "id": "ac-1",
+                        "title": "Policy",
+                        "prose": "Test.",
+                        "family": "AC",
+                    },
+                ],
+            )
+
+            result = runner.invoke(app, ["map", "--framework", "nist-800-53"])
+            assert result.exit_code == 1
+            stdout = result.stdout.lower()
+            assert "no polic" in stdout or "policies" in stdout
+
+    def test_map_command_success(self, tmp_path, monkeypatch):
+        """Successful mapping produces output with mocked LLM."""
+        from lemma.cli import app
+        from lemma.services.indexer import ControlIndexer
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {
+                "confidence": 0.85,
+                "rationale": "Policy maps to account management.",
+            }
+        )
+
+        monkeypatch.chdir(tmp_path)
+        runner.invoke(app, ["init"])
+
+        # Write a real policy file
+        Path("policies/access.md").write_text(
+            "# Access Control\n\nAll users must authenticate via SSO.\n"
+        )
+
+        # Index a framework — use absolute path to prevent ChromaDB
+        # PersistentClient path resolution issues across invocations
+        index_dir = (tmp_path / ".lemma" / "index").resolve()
+        indexer = ControlIndexer(index_dir=index_dir)
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-2",
+                    "title": "Account Management",
+                    "prose": "Manage system accounts.",
+                    "family": "AC",
+                },
+            ],
+        )
+        del indexer
+
+        with patch(
+            "lemma.commands.map.get_llm_client",
+            return_value=mock_llm,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "map",
+                    "--framework",
+                    "nist-800-53",
+                    "--output",
+                    "json",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "ac-2" in result.stdout or "nist-800-53" in result.stdout

--- a/tests/models/test_mapping.py
+++ b/tests/models/test_mapping.py
@@ -1,0 +1,71 @@
+"""Tests for the mapping Pydantic models.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+
+class TestMappingModels:
+    """Tests for mapping result and report models."""
+
+    def test_mapping_result_creation(self):
+        """MappingResult holds chunk, control, confidence, rationale, status."""
+        from lemma.models.mapping import MappingResult
+
+        result = MappingResult(
+            chunk_id="access-control.md#1",
+            chunk_text="All users must authenticate via SSO.",
+            control_id="ac-2",
+            control_title="Account Management",
+            confidence=0.87,
+            rationale="Policy requires SSO, which maps to account management.",
+            status="MAPPED",
+        )
+
+        assert result.chunk_id == "access-control.md#1"
+        assert result.control_id == "ac-2"
+        assert result.confidence == 0.87
+        assert result.status == "MAPPED"
+
+    def test_mapping_result_low_confidence_status(self):
+        """MappingResult can have LOW_CONFIDENCE status."""
+        from lemma.models.mapping import MappingResult
+
+        result = MappingResult(
+            chunk_id="policy.md#2",
+            chunk_text="We do things.",
+            control_id="ac-1",
+            control_title="Policy and Procedures",
+            confidence=0.3,
+            rationale="Weak semantic match.",
+            status="LOW_CONFIDENCE",
+        )
+
+        assert result.status == "LOW_CONFIDENCE"
+
+    def test_mapping_report_creation(self):
+        """MappingReport aggregates results with metadata."""
+        from lemma.models.mapping import MappingReport, MappingResult
+
+        results = [
+            MappingResult(
+                chunk_id="p.md#1",
+                chunk_text="Encrypt data at rest.",
+                control_id="sc-28",
+                control_title="Protection of Information at Rest",
+                confidence=0.92,
+                rationale="Direct encryption requirement.",
+                status="MAPPED",
+            ),
+        ]
+
+        report = MappingReport(
+            framework="nist-800-53",
+            results=results,
+            threshold=0.6,
+        )
+
+        assert report.framework == "nist-800-53"
+        assert len(report.results) == 1
+        assert report.threshold == 0.6
+        assert report.mapped_count == 1
+        assert report.low_confidence_count == 0

--- a/tests/services/test_chunker.py
+++ b/tests/services/test_chunker.py
@@ -1,0 +1,94 @@
+"""Tests for the policy document chunker.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+
+class TestChunker:
+    """Tests for splitting policy markdown into semantic chunks."""
+
+    def test_chunk_single_policy(self, tmp_path):
+        """Chunker splits a markdown document into multiple chunks."""
+        from lemma.services.chunker import chunk_policies
+
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "access-control.md").write_text(
+            "# Access Control Policy\n\n"
+            "## Purpose\n\n"
+            "This policy establishes access control requirements for all systems. "
+            "All users must authenticate via single sign-on before accessing "
+            "production resources.\n\n"
+            "## Scope\n\n"
+            "This policy applies to all employees and contractors. "
+            "Third-party vendors must comply with these requirements "
+            "when accessing company systems.\n\n"
+            "## Requirements\n\n"
+            "All privileged access must be logged and reviewed quarterly. "
+            "Multi-factor authentication is required for administrative accounts. "
+            "Service accounts must be rotated every 90 days.\n"
+        )
+
+        chunks = chunk_policies(policies_dir)
+        assert len(chunks) >= 2
+        assert all(c.get("text") for c in chunks)
+
+    def test_chunk_preserves_sentence_boundaries(self, tmp_path):
+        """Chunks do not split mid-sentence."""
+        from lemma.services.chunker import chunk_policies
+
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "test.md").write_text(
+            "# Test Policy\n\n"
+            "First sentence about security controls. "
+            "Second sentence about compliance requirements. "
+            "Third sentence about audit procedures.\n"
+        )
+
+        chunks = chunk_policies(policies_dir)
+        for chunk in chunks:
+            text = chunk["text"].strip()
+            # Should end with sentence-terminal punctuation
+            assert text[-1] in ".!?:", f"Chunk does not end at sentence boundary: {text!r}"
+
+    def test_chunk_assigns_ids(self, tmp_path):
+        """Each chunk has a source file and position-based ID."""
+        from lemma.services.chunker import chunk_policies
+
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "ir.md").write_text(
+            "# Incident Response\n\n"
+            "Incidents must be reported within 24 hours. "
+            "The security team investigates all reported incidents.\n"
+        )
+
+        chunks = chunk_policies(policies_dir)
+        assert len(chunks) >= 1
+        assert all("id" in c for c in chunks)
+        assert all("source" in c for c in chunks)
+        assert chunks[0]["source"] == "ir.md"
+
+    def test_chunk_empty_directory(self, tmp_path):
+        """Chunking an empty directory returns an empty list."""
+        from lemma.services.chunker import chunk_policies
+
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+
+        chunks = chunk_policies(policies_dir)
+        assert chunks == []
+
+    def test_chunk_skips_non_markdown(self, tmp_path):
+        """Chunker ignores non-markdown files."""
+        from lemma.services.chunker import chunk_policies
+
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "README.txt").write_text("Not a policy")
+        (policies_dir / "policy.md").write_text("# Policy\n\nThis is a real policy document.\n")
+
+        chunks = chunk_policies(policies_dir)
+        sources = {c["source"] for c in chunks}
+        assert "README.txt" not in sources

--- a/tests/services/test_formatters.py
+++ b/tests/services/test_formatters.py
@@ -1,0 +1,92 @@
+"""Tests for output formatters.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+import json
+
+import pytest
+
+
+class TestFormatters:
+    """Tests for mapping output format registry."""
+
+    def test_format_json(self):
+        """JSON formatter produces valid JSON string."""
+        from lemma.models.mapping import MappingReport, MappingResult
+        from lemma.services.formatters import format_json
+
+        report = MappingReport(
+            framework="nist-800-53",
+            results=[
+                MappingResult(
+                    chunk_id="p.md#1",
+                    chunk_text="Encrypt data.",
+                    control_id="sc-28",
+                    control_title="Protection of Information at Rest",
+                    confidence=0.9,
+                    rationale="Direct match.",
+                    status="MAPPED",
+                ),
+            ],
+            threshold=0.6,
+        )
+
+        output = format_json(report)
+        parsed = json.loads(output)
+
+        assert parsed["framework"] == "nist-800-53"
+        assert len(parsed["results"]) == 1
+        assert parsed["results"][0]["control_id"] == "sc-28"
+
+    def test_format_oscal(self):
+        """OSCAL formatter produces valid Assessment Results structure."""
+        from lemma.models.mapping import MappingReport, MappingResult
+        from lemma.services.formatters import format_oscal
+
+        report = MappingReport(
+            framework="nist-800-53",
+            results=[
+                MappingResult(
+                    chunk_id="p.md#1",
+                    chunk_text="Encrypt data.",
+                    control_id="sc-28",
+                    control_title="Protection of Information at Rest",
+                    confidence=0.9,
+                    rationale="Direct match.",
+                    status="MAPPED",
+                ),
+            ],
+            threshold=0.6,
+        )
+
+        output = format_oscal(report)
+        parsed = json.loads(output)
+
+        # OSCAL Assessment Results structure
+        assert "assessment-results" in parsed
+        ar = parsed["assessment-results"]
+        assert "uuid" in ar
+        assert "metadata" in ar
+        assert "results" in ar
+
+    def test_get_formatter_json(self):
+        """Registry returns JSON formatter for 'json' key."""
+        from lemma.services.formatters import get_formatter
+
+        formatter = get_formatter("json")
+        assert callable(formatter)
+
+    def test_get_formatter_oscal(self):
+        """Registry returns OSCAL formatter for 'oscal' key."""
+        from lemma.services.formatters import get_formatter
+
+        formatter = get_formatter("oscal")
+        assert callable(formatter)
+
+    def test_get_formatter_unknown_errors(self):
+        """Unknown format name raises ValueError."""
+        from lemma.services.formatters import get_formatter
+
+        with pytest.raises(ValueError, match=r"[Uu]nsupported"):
+            get_formatter("xml")

--- a/tests/services/test_llm.py
+++ b/tests/services/test_llm.py
@@ -1,0 +1,94 @@
+"""Tests for the LLM client abstraction.
+
+Follows TDD: tests written BEFORE the implementation.
+All LLM calls are mocked — no running LLM required for tests.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestOllamaClient:
+    """Tests for the local Ollama LLM backend."""
+
+    def test_ollama_client_generate(self):
+        """OllamaClient sends prompt to Ollama HTTP API and returns response."""
+        from lemma.services.llm import OllamaClient
+
+        client = OllamaClient(model="llama3.2", base_url="http://localhost:11434")
+
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"response": "This control maps to access management."},
+            )
+
+            result = client.generate("Map this policy to a control.")
+            assert "access management" in result.lower()
+            mock_post.assert_called_once()
+
+    def test_ollama_client_uses_configured_model(self):
+        """OllamaClient sends the configured model name in the request."""
+        from lemma.services.llm import OllamaClient
+
+        client = OllamaClient(model="mistral", base_url="http://localhost:11434")
+
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"response": "test"},
+            )
+
+            client.generate("test prompt")
+            call_kwargs = mock_post.call_args
+            body = call_kwargs.kwargs.get("json", call_kwargs[1].get("json", {}))
+            assert body["model"] == "mistral"
+
+
+class TestOpenAIClient:
+    """Tests for the OpenAI cloud backend."""
+
+    def test_openai_client_generate(self):
+        """OpenAIClient sends prompt via OpenAI SDK and returns response."""
+        from lemma.services.llm import OpenAIClient
+
+        mock_openai = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=MagicMock(content="Mapped to SC-28."))]
+        mock_openai.chat.completions.create.return_value = mock_response
+
+        client = OpenAIClient(api_key="test-key", model="gpt-4o-mini")
+        client._client = mock_openai
+
+        result = client.generate("Map this policy chunk.")
+        assert "SC-28" in result
+
+
+class TestLLMClientFactory:
+    """Tests for the LLM client factory function."""
+
+    def test_get_llm_client_ollama_default(self):
+        """Factory returns OllamaClient when provider is 'ollama'."""
+        from lemma.services.llm import OllamaClient, get_llm_client
+
+        config = {"provider": "ollama", "model": "llama3.2"}
+        client = get_llm_client(config)
+        assert isinstance(client, OllamaClient)
+
+    def test_get_llm_client_openai(self):
+        """Factory returns OpenAIClient when provider is 'openai'."""
+        from lemma.services.llm import OpenAIClient, get_llm_client
+
+        config = {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "api_key": "test-key",
+        }
+        client = get_llm_client(config)
+        assert isinstance(client, OpenAIClient)
+
+    def test_get_llm_client_default_is_ollama(self):
+        """Factory defaults to Ollama when no provider specified."""
+        from lemma.services.llm import OllamaClient, get_llm_client
+
+        client = get_llm_client({})
+        assert isinstance(client, OllamaClient)

--- a/tests/services/test_mapper.py
+++ b/tests/services/test_mapper.py
@@ -1,0 +1,190 @@
+"""Tests for the control mapping service.
+
+Follows TDD: tests written BEFORE the implementation.
+All LLM calls mocked — no running LLM required for tests.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestRetrieveControls:
+    """Tests for vector retrieval from indexed frameworks."""
+
+    def test_query_similar_returns_ranked_results(self, tmp_path):
+        """Indexer query returns controls ranked by similarity."""
+        from lemma.services.indexer import ControlIndexer
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        controls = [
+            {
+                "id": "ac-2",
+                "title": "Account Management",
+                "prose": "Manage system accounts including creating and disabling.",
+                "family": "Access Control",
+            },
+            {
+                "id": "sc-28",
+                "title": "Protection of Information at Rest",
+                "prose": "Protect the confidentiality of information at rest.",
+                "family": "System and Communications Protection",
+            },
+        ]
+        indexer.index_controls("test-fw", controls)
+
+        results = indexer.query_similar(
+            "test-fw",
+            "All data must be encrypted at rest.",
+            n_results=2,
+        )
+
+        assert len(results) >= 1
+        assert all("control_id" in r for r in results)
+        assert all("distance" in r for r in results)
+
+
+class TestMapper:
+    """Tests for the mapping pipeline."""
+
+    def test_map_policies_produces_results(self, tmp_path):
+        """Full pipeline produces mapping results with mocked LLM."""
+        from lemma.models.mapping import MappingReport
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+
+        # Setup: init project, add policies, index framework
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "access.md").write_text(
+            "# Access Control\n\nAll users must authenticate via SSO before accessing systems.\n"
+        )
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-2",
+                    "title": "Account Management",
+                    "prose": "Manage system accounts.",
+                    "family": "AC",
+                },
+            ],
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {
+                "confidence": 0.85,
+                "rationale": "Policy requires SSO which maps to account management.",
+            }
+        )
+
+        report = map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+        )
+
+        assert isinstance(report, MappingReport)
+        assert len(report.results) >= 1
+        assert report.framework == "nist-800-53"
+
+    def test_map_flags_low_confidence(self, tmp_path):
+        """Results below threshold are flagged LOW_CONFIDENCE."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "vague.md").write_text("# General Policy\n\nWe do security things.\n")
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-1",
+                    "title": "Policy and Procedures",
+                    "prose": "Develop access control policy.",
+                    "family": "AC",
+                },
+            ],
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {
+                "confidence": 0.3,
+                "rationale": "Weak semantic match.",
+            }
+        )
+
+        report = map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.6,
+        )
+
+        low_conf = [r for r in report.results if r.status == "LOW_CONFIDENCE"]
+        assert len(low_conf) >= 1
+
+    def test_map_no_framework_errors(self, tmp_path):
+        """Mapping without an indexed framework raises an error."""
+        from lemma.services.mapper import map_policies
+
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "test.md").write_text("# Test\n\nTest policy.\n")
+
+        mock_llm = MagicMock()
+
+        with pytest.raises(ValueError, match="not indexed"):
+            map_policies(
+                framework="nonexistent-fw",
+                project_dir=tmp_path,
+                llm_client=mock_llm,
+            )
+
+    def test_map_no_policies_errors(self, tmp_path):
+        """Mapping without policy files raises an error."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        # Empty policies dir — but framework IS indexed
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-1",
+                    "title": "Policy",
+                    "prose": "Test.",
+                    "family": "AC",
+                },
+            ],
+        )
+
+        mock_llm = MagicMock()
+
+        with pytest.raises(ValueError, match=r"[Nn]o polic"):
+            map_policies(
+                framework="nist-800-53",
+                project_dir=tmp_path,
+                llm_client=mock_llm,
+            )


### PR DESCRIPTION
## Description

Implement the Control Mapping Engine — the core AI-assisted mapping pipeline that connects policy documents to framework controls. This is the third major Phase 1 deliverable, building on the Framework Ingestion Pipeline (#14).

The engine provides a complete pipeline: policy document chunking → ChromaDB vector similarity retrieval → LLM-generated rationale enrichment → structured output formatting. All LLM interactions are abstracted behind a pluggable client interface with local-first defaults.

**New capabilities:**
- `lemma map --framework nist-800-53 --output json` — Map policies to controls
- Pluggable LLM backend: Ollama (local default), OpenAI (cloud optional via `[cloud]` extras)
- Output format registry: JSON and OSCAL Assessment Results
- Confidence scoring with configurable LOW_CONFIDENCE threshold
- Sentence-aware policy chunking with source tracking

Fixes #15

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` with no errors
- [x] I have run `ruff format`
- [x] I have run `pytest` and all tests pass (87 passing, 90.10% coverage)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (JSDoc/docstrings on all public APIs)
- [x] My changes generate no new warnings or errors