### PR TITLE
feat(formatters): Add HTML and CSV output formatters

### DIFF
--- a/src/lemma/commands/map.py
+++ b/src/lemma/commands/map.py
@@ -27,7 +27,7 @@ def map_command(
     ),
     output: str = typer.Option(
         "json",
-        help="Output format (json, oscal)",
+        help="Output format (json, oscal, html, csv)",
     ),
     threshold: float = typer.Option(
         0.6,

--- a/src/lemma/services/formatters.py
+++ b/src/lemma/services/formatters.py
@@ -3,11 +3,14 @@
 Provides serializers for mapping reports in different formats:
 - JSON: Plain JSON output
 - OSCAL: OSCAL Assessment Results document
+- CSV: Flat CSV export for spreadsheet import
+- HTML: Styled HTML report for stakeholder review
 """
 
 from __future__ import annotations
 
 import csv
+import html as html_mod
 import io
 import json
 from collections.abc import Callable
@@ -145,12 +148,14 @@ def format_html(report: MappingReport) -> str:
     Returns:
         HTML string of the report.
     """
+    esc = html_mod.escape
+    fw = esc(report.framework)
     html_parts = [
         "<!DOCTYPE html>",
         "<html>",
         "<head>",
         '  <meta charset="utf-8">',
-        f"  <title>Lemma Mapping Report — {report.framework}</title>",
+        f"  <title>Lemma Mapping Report — {fw}</title>",
         "  <style>",
         "    body { font-family: system-ui, -apple-system, sans-serif; "
         "line-height: 1.5; padding: 2rem; color: #333; }",
@@ -167,8 +172,8 @@ def format_html(report: MappingReport) -> str:
         "  </style>",
         "</head>",
         "<body>",
-        f"  <h1>Control Mapping — {report.framework}</h1>",
-        f"  <p>Automated mapping of policy documents to {report.framework} controls.</p>",
+        f"  <h1>Control Mapping — {fw}</h1>",
+        f"  <p>Automated mapping of policy documents to {fw} controls.</p>",
         "  <table>",
         "    <thead>",
         "      <tr>",
@@ -188,12 +193,12 @@ def format_html(report: MappingReport) -> str:
         html_parts.extend(
             [
                 "      <tr>",
-                f"        <td><code>{r.chunk_id}</code></td>",
-                f"        <td><strong>{r.control_id}</strong></td>",
-                f"        <td>{r.control_title}</td>",
+                f"        <td><code>{esc(r.chunk_id)}</code></td>",
+                f"        <td><strong>{esc(r.control_id)}</strong></td>",
+                f"        <td>{esc(r.control_title)}</td>",
                 f"        <td>{r.confidence}</td>",
-                f'        <td><span class="{status_class}">{r.status}</span></td>',
-                f"        <td>{r.rationale}</td>",
+                f'        <td><span class="{status_class}">{esc(r.status)}</span></td>',
+                f"        <td>{esc(r.rationale)}</td>",
                 "      </tr>",
             ]
         )
@@ -215,7 +220,7 @@ def get_formatter(format_name: str) -> Callable[[MappingReport], str]:
     """Get a formatter function by name.
 
     Args:
-        format_name: Format identifier ('json' or 'oscal').
+        format_name: Format identifier ('json', 'oscal', 'csv', or 'html').
 
     Returns:
         Formatter callable.

--- a/src/lemma/services/formatters.py
+++ b/src/lemma/services/formatters.py
@@ -7,6 +7,8 @@ Provides serializers for mapping reports in different formats:
 
 from __future__ import annotations
 
+import csv
+import io
 import json
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -94,9 +96,118 @@ def format_oscal(report: MappingReport) -> str:
     return json.dumps(oscal_doc, indent=2)
 
 
+def format_csv(report: MappingReport) -> str:
+    """Format mapping report as CSV.
+
+    Args:
+        report: The mapping report to format.
+
+    Returns:
+        CSV string of the report.
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # Write header
+    writer.writerow(
+        [
+            "Chunk ID",
+            "Control ID",
+            "Control Title",
+            "Confidence",
+            "Status",
+            "Rationale",
+        ]
+    )
+
+    # Write rows
+    for r in report.results:
+        writer.writerow(
+            [
+                r.chunk_id,
+                r.control_id,
+                r.control_title,
+                str(r.confidence),
+                r.status,
+                r.rationale,
+            ]
+        )
+
+    return output.getvalue()
+
+
+def format_html(report: MappingReport) -> str:
+    """Format mapping report as a styled HTML document.
+
+    Args:
+        report: The mapping report to format.
+
+    Returns:
+        HTML string of the report.
+    """
+    html_parts = [
+        "<!DOCTYPE html>",
+        "<html>",
+        "<head>",
+        '  <meta charset="utf-8">',
+        f"  <title>Lemma Mapping Report — {report.framework}</title>",
+        "  <style>",
+        "    body { font-family: system-ui, -apple-system, sans-serif; "
+        "line-height: 1.5; padding: 2rem; color: #333; }",
+        "    h1 { color: #111; border-bottom: 2px solid #eaeaea; padding-bottom: 0.5rem; }",
+        "    table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; "
+        "box-shadow: 0 1px 3px rgba(0,0,0,0.1); }",
+        "    th, td { padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #eaeaea; }",
+        "    th { background-color: #f8f9fa; font-weight: 600; color: #444; }",
+        "    tr:hover { background-color: #fcfcfc; }",
+        "    .status-mapped { color: #0f5132; background-color: #d1e7dd; padding: 0.25rem 0.5rem; "
+        "border-radius: 4px; font-size: 0.875em; }",
+        "    .status-low { color: #842029; background-color: #f8d7da; padding: 0.25rem 0.5rem; "
+        "border-radius: 4px; font-size: 0.875em; }",
+        "  </style>",
+        "</head>",
+        "<body>",
+        f"  <h1>Control Mapping — {report.framework}</h1>",
+        f"  <p>Automated mapping of policy documents to {report.framework} controls.</p>",
+        "  <table>",
+        "    <thead>",
+        "      <tr>",
+        "        <th>Chunk ID</th>",
+        "        <th>Control ID</th>",
+        "        <th>Control Title</th>",
+        "        <th>Confidence</th>",
+        "        <th>Status</th>",
+        "        <th>Rationale</th>",
+        "      </tr>",
+        "    </thead>",
+        "    <tbody>",
+    ]
+
+    for r in report.results:
+        status_class = "status-mapped" if r.status == "MAPPED" else "status-low"
+        html_parts.extend(
+            [
+                "      <tr>",
+                f"        <td><code>{r.chunk_id}</code></td>",
+                f"        <td><strong>{r.control_id}</strong></td>",
+                f"        <td>{r.control_title}</td>",
+                f"        <td>{r.confidence}</td>",
+                f'        <td><span class="{status_class}">{r.status}</span></td>',
+                f"        <td>{r.rationale}</td>",
+                "      </tr>",
+            ]
+        )
+
+    html_parts.extend(["    </tbody>", "  </table>", "</body>", "</html>"])
+
+    return "\n".join(html_parts) + "\n"
+
+
 _FORMATTERS: dict[str, Callable[[MappingReport], str]] = {
     "json": format_json,
     "oscal": format_oscal,
+    "csv": format_csv,
+    "html": format_html,
 }
 
 

--- a/tests/services/test_formatters.py
+++ b/tests/services/test_formatters.py
@@ -95,6 +95,7 @@ class TestFormatters:
         """CSV formatter produces valid CSV mapping."""
         import csv
         import io
+
         from lemma.models.mapping import MappingReport, MappingResult
         from lemma.services.formatters import format_csv
 

--- a/tests/services/test_formatters.py
+++ b/tests/services/test_formatters.py
@@ -90,3 +90,91 @@ class TestFormatters:
 
         with pytest.raises(ValueError, match=r"[Uu]nsupported"):
             get_formatter("xml")
+
+    def test_format_csv(self):
+        """CSV formatter produces valid CSV mapping."""
+        import csv
+        import io
+        from lemma.models.mapping import MappingReport, MappingResult
+        from lemma.services.formatters import format_csv
+
+        report = MappingReport(
+            framework="nist-800-53",
+            results=[
+                MappingResult(
+                    chunk_id="policy.md#1",
+                    chunk_text="Encrypt data.",
+                    control_id="sc-28",
+                    control_title="Protection of Information at Rest",
+                    confidence=0.9,
+                    rationale="Direct match.",
+                    status="MAPPED",
+                ),
+            ],
+            threshold=0.6,
+        )
+
+        output = format_csv(report)
+        lines = output.strip().split("\n")
+        assert len(lines) == 2  # header + 1 row
+
+        reader = csv.reader(io.StringIO(output))
+        rows = list(reader)
+
+        header = rows[0]
+        assert header == [
+            "Chunk ID",
+            "Control ID",
+            "Control Title",
+            "Confidence",
+            "Status",
+            "Rationale",
+        ]
+
+        data = rows[1]
+        assert data[0] == "policy.md#1"
+        assert data[1] == "sc-28"
+        assert data[3] == "0.9"
+
+    def test_format_html(self):
+        """HTML formatter produces a styled HTML document."""
+        from lemma.models.mapping import MappingReport, MappingResult
+        from lemma.services.formatters import format_html
+
+        report = MappingReport(
+            framework="nist-800-53",
+            results=[
+                MappingResult(
+                    chunk_id="policy.md#1",
+                    chunk_text="Encrypt data.",
+                    control_id="sc-28",
+                    control_title="Protection of Information at Rest",
+                    confidence=0.9,
+                    rationale="Direct match.",
+                    status="MAPPED",
+                ),
+            ],
+            threshold=0.6,
+        )
+
+        output = format_html(report)
+
+        assert "<html>" in output.lower()
+        assert "<table>" in output.lower()
+        assert "policy.md#1" in output
+        assert "sc-28" in output
+        assert "Protection of Information at Rest" in output
+
+    def test_get_formatter_csv(self):
+        """Registry returns CSV formatter."""
+        from lemma.services.formatters import get_formatter
+
+        formatter = get_formatter("csv")
+        assert callable(formatter)
+
+    def test_get_formatter_html(self):
+        """Registry returns HTML formatter."""
+        from lemma.services.formatters import get_formatter
+
+        formatter = get_formatter("html")
+        assert callable(formatter)


### PR DESCRIPTION
## Description

Adds CSV and styled HTML output formatters to the mapping engine, enabling non-technical stakeholders to consume compliance mapping results as spreadsheet-importable CSVs or self-contained HTML reports.

Follow-up from Issue #15 (Control Mapping Engine). The `_FORMATTERS` dict registry pattern was already in place — this PR extends it with two new format functions.

Fixes #64

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` (or equivalent) with no errors
- [x] I have run `ruff format` (or equivalent)
- [x] I have run `pytest` (or equivalent) and all tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors