### PR TITLE
feat(parsers): Implement PDF and Excel/CSV framework parsers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.5",
+    "openpyxl>=3.1",
 ]
 
 [project.scripts]

--- a/src/lemma/services/parsers/excel.py
+++ b/src/lemma/services/parsers/excel.py
@@ -1,0 +1,160 @@
+"""Excel/CSV parser — extracts framework controls from spreadsheets.
+
+Supports .xlsx (via openpyxl) and .csv files with either:
+- Named columns matching known field patterns (id, title, prose, family)
+- Positional fallback (first 4 columns → id, title, prose, family)
+
+Requires the [ingest] optional extras for .xlsx:
+    pip install lemma-grc[ingest]
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+# Canonical field names and their common column name aliases
+_COLUMN_ALIASES: dict[str, set[str]] = {
+    "id": {"id", "control_id", "control id", "identifier", "ctrl_id", "number"},
+    "title": {"title", "name", "control_title", "control name", "control"},
+    "prose": {
+        "prose",
+        "description",
+        "text",
+        "detail",
+        "details",
+        "statement",
+        "requirement",
+    },
+    "family": {"family", "group", "category", "domain", "section", "class"},
+}
+
+
+def _resolve_columns(headers: list[str]) -> dict[str, int] | None:
+    """Map header names to canonical field names.
+
+    Returns:
+        Dict mapping canonical names to column indices, or None if
+        fewer than 2 columns could be matched (triggers positional fallback).
+    """
+    mapping: dict[str, int] = {}
+    normalized = [h.strip().lower() for h in headers]
+
+    for field, aliases in _COLUMN_ALIASES.items():
+        for i, header in enumerate(normalized):
+            if header in aliases:
+                mapping[field] = i
+                break
+
+    # Require at least id + one other field for a valid match
+    if "id" not in mapping or len(mapping) < 2:
+        return None
+
+    return mapping
+
+
+def _rows_to_controls(
+    rows: list[list[str]],
+    col_map: dict[str, int],
+) -> list[dict]:
+    """Convert raw rows to control dicts using column mapping."""
+    controls: list[dict] = []
+
+    for row in rows:
+        # Pad row to avoid index errors
+        padded = row + [""] * max(0, max(col_map.values()) + 1 - len(row))
+
+        control_id = padded[col_map["id"]].strip()
+        if not control_id:
+            continue
+
+        controls.append(
+            {
+                "id": control_id,
+                "title": padded[col_map.get("title", col_map["id"])].strip(),
+                "prose": padded[col_map.get("prose", col_map["id"])].strip(),
+                "family": padded[col_map.get("family", col_map["id"])].strip(),
+            }
+        )
+
+    return controls
+
+
+def parse_excel(file_path: Path) -> list[dict]:
+    """Parse an Excel or CSV file into a flat list of control records.
+
+    Each record contains:
+        - id: Control identifier
+        - title: Control title
+        - prose: Control description/prose
+        - family: Control group/family
+
+    Args:
+        file_path: Path to the .xlsx or .csv file.
+
+    Returns:
+        List of control record dicts ready for indexing.
+
+    Raises:
+        ValueError: If the file format is not supported.
+        ImportError: If openpyxl is not installed (for .xlsx files).
+    """
+    suffix = file_path.suffix.lower()
+
+    if suffix == ".xlsx":
+        headers, data_rows = _read_xlsx(file_path)
+    elif suffix == ".csv":
+        headers, data_rows = _read_csv(file_path)
+    else:
+        msg = f"Unsupported spreadsheet format '{suffix}'. Supported: .xlsx, .csv"
+        raise ValueError(msg)
+
+    # Try named columns first, fall back to positional
+    col_map = _resolve_columns(headers)
+    if col_map is None:
+        # Positional fallback: columns 0-3 → id, title, prose, family
+        col_map = {"id": 0, "title": 1, "prose": 2, "family": 3}
+
+    return _rows_to_controls(data_rows, col_map)
+
+
+def _read_xlsx(file_path: Path) -> tuple[list[str], list[list[str]]]:
+    """Read headers and data rows from an XLSX file."""
+    try:
+        import openpyxl
+    except ImportError as e:
+        msg = (
+            "Excel import requires the [ingest] extras. Install with: pip install lemma-grc[ingest]"
+        )
+        raise ImportError(msg) from e
+
+    wb = openpyxl.load_workbook(file_path, read_only=True, data_only=True)
+    ws = wb.active
+
+    rows_iter = ws.iter_rows(values_only=True)
+    header_row = next(rows_iter, None)
+
+    if header_row is None:
+        wb.close()
+        return [], []
+
+    headers = [str(cell) if cell is not None else "" for cell in header_row]
+    data_rows = [[str(cell) if cell is not None else "" for cell in row] for row in rows_iter]
+
+    wb.close()
+    return headers, data_rows
+
+
+def _read_csv(file_path: Path) -> tuple[list[str], list[list[str]]]:
+    """Read headers and data rows from a CSV file."""
+    with file_path.open(newline="") as f:
+        reader = csv.reader(f)
+        header_row = next(reader, None)
+
+        if header_row is None:
+            return [], []
+
+        headers = header_row
+        data_rows = list(reader)
+
+    return headers, data_rows

--- a/src/lemma/services/parsers/pdf.py
+++ b/src/lemma/services/parsers/pdf.py
@@ -1,0 +1,98 @@
+"""PDF parser — extracts framework controls from PDF documents via Docling.
+
+Uses IBM's Docling library for layout-aware document intelligence,
+extracting sections/headings as control boundaries and paragraphs
+as control prose.
+
+Requires the [ingest] optional extras:
+    pip install lemma-grc[ingest]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _get_converter():
+    """Create a Docling DocumentConverter.
+
+    Raises:
+        ImportError: If Docling is not installed.
+    """
+    try:
+        from docling.document_converter import DocumentConverter
+    except ImportError as e:
+        msg = "PDF import requires the [ingest] extras. Install with: pip install lemma-grc[ingest]"
+        raise ImportError(msg) from e
+
+    return DocumentConverter()
+
+
+def parse_pdf(file_path: Path) -> list[dict]:
+    """Parse a PDF file into a flat list of control records.
+
+    Walks the Docling document hierarchy, treating section headers
+    as control boundaries and subsequent paragraphs/tables as prose.
+
+    Each record contains:
+        - id: Generated from section index (e.g., 'ctrl-1', 'ctrl-2')
+        - title: Section heading text
+        - prose: Concatenated paragraph and table text
+        - family: Top-level section heading (if nested)
+
+    Args:
+        file_path: Path to the PDF file.
+
+    Returns:
+        List of control record dicts ready for indexing.
+
+    Raises:
+        ImportError: If Docling is not installed.
+    """
+    converter = _get_converter()
+    result = converter.convert(str(file_path))
+    doc = result.document
+
+    controls: list[dict] = []
+    current_title = ""
+    current_family = ""
+    current_prose_parts: list[str] = []
+    control_index = 0
+
+    def _flush_control() -> None:
+        nonlocal control_index
+        if current_title and current_prose_parts:
+            control_index += 1
+            controls.append(
+                {
+                    "id": f"ctrl-{control_index}",
+                    "title": current_title,
+                    "prose": " ".join(current_prose_parts),
+                    "family": current_family or current_title,
+                }
+            )
+
+    for item in doc.iterate_items():
+        label = getattr(item, "label", "")
+        text = getattr(item, "text", "")
+
+        if not text or not text.strip():
+            continue
+
+        if label in {"section_header", "title", "heading"}:
+            # Flush the previous control before starting a new one
+            _flush_control()
+
+            level = getattr(item, "level", 1)
+            if level <= 1:
+                current_family = text.strip()
+
+            current_title = text.strip()
+            current_prose_parts = []
+        elif label in {"paragraph", "text", "list_item", "table"}:
+            current_prose_parts.append(text.strip())
+
+    # Flush the last accumulated control
+    _flush_control()
+
+    return controls

--- a/src/lemma/services/parsers/pdf.py
+++ b/src/lemma/services/parsers/pdf.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def _get_converter():
+def _get_converter():  # pragma: no cover
     """Create a Docling DocumentConverter.
 
     Raises:

--- a/tests/services/parsers/test_excel_parser.py
+++ b/tests/services/parsers/test_excel_parser.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 
 class TestExcelParser:
@@ -14,7 +17,7 @@ class TestExcelParser:
 
     def test_parse_excel_xlsx_named_columns(self, tmp_path: Path):
         """parse_excel extracts controls from XLSX with named headers."""
-        import openpyxl
+        openpyxl = pytest.importorskip("openpyxl")
 
         from lemma.services.parsers.excel import parse_excel
 
@@ -92,8 +95,6 @@ class TestExcelParser:
 
     def test_parse_excel_unsupported_extension(self, tmp_path: Path):
         """parse_excel raises ValueError for unsupported file extensions."""
-        import pytest
-
         from lemma.services.parsers.excel import parse_excel
 
         bad_file = tmp_path / "framework.txt"
@@ -101,3 +102,30 @@ class TestExcelParser:
 
         with pytest.raises(ValueError, match=r"[Uu]nsupported"):
             parse_excel(bad_file)
+
+    def test_parse_excel_empty_csv(self, tmp_path: Path):
+        """parse_excel handles an empty CSV file gracefully."""
+        from lemma.services.parsers.excel import parse_excel
+
+        csv_path = tmp_path / "empty.csv"
+        csv_path.write_text("")
+
+        controls = parse_excel(csv_path)
+
+        assert controls == []
+
+    def test_parse_excel_xlsx_import_error(self, tmp_path: Path):
+        """parse_excel raises ImportError when openpyxl is unavailable for .xlsx."""
+        xlsx_path = tmp_path / "framework.xlsx"
+        xlsx_path.write_bytes(b"dummy")
+
+        with patch.dict("sys.modules", {"openpyxl": None}):
+            # Clear cached import in excel module
+            import importlib
+
+            import lemma.services.parsers.excel as excel_mod
+
+            importlib.reload(excel_mod)
+
+            with pytest.raises(ImportError, match=r"[Ii]ngest"):
+                excel_mod.parse_excel(xlsx_path)

--- a/tests/services/parsers/test_excel_parser.py
+++ b/tests/services/parsers/test_excel_parser.py
@@ -1,0 +1,103 @@
+"""Tests for the Excel/CSV parser.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+class TestExcelParser:
+    """Tests for Excel/CSV framework ingestion."""
+
+    def test_parse_excel_xlsx_named_columns(self, tmp_path: Path):
+        """parse_excel extracts controls from XLSX with named headers."""
+        import openpyxl
+
+        from lemma.services.parsers.excel import parse_excel
+
+        # Create a test XLSX with named columns
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["Control ID", "Title", "Description", "Family"])
+        ws.append(["AC-1", "Access Control Policy", "Define access policies.", "Access Control"])
+        ws.append(["AC-2", "Account Management", "Manage system accounts.", "Access Control"])
+
+        xlsx_path = tmp_path / "framework.xlsx"
+        wb.save(xlsx_path)
+
+        controls = parse_excel(xlsx_path)
+
+        assert len(controls) == 2
+        assert controls[0]["id"] == "AC-1"
+        assert controls[0]["title"] == "Access Control Policy"
+        assert controls[0]["prose"] == "Define access policies."
+        assert controls[0]["family"] == "Access Control"
+        assert controls[1]["id"] == "AC-2"
+
+    def test_parse_excel_csv_named_columns(self, tmp_path: Path):
+        """parse_excel extracts controls from CSV with named headers."""
+        from lemma.services.parsers.excel import parse_excel
+
+        csv_path = tmp_path / "framework.csv"
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["id", "title", "prose", "family"])
+            writer.writerow(["SC-1", "System Protection", "Protect systems.", "System Comms"])
+            writer.writerow(["SC-2", "Application Partitioning", "Separate apps.", "System Comms"])
+
+        controls = parse_excel(csv_path)
+
+        assert len(controls) == 2
+        assert controls[0]["id"] == "SC-1"
+        assert controls[0]["title"] == "System Protection"
+        assert controls[0]["prose"] == "Protect systems."
+        assert controls[0]["family"] == "System Comms"
+
+    def test_parse_excel_positional_fallback(self, tmp_path: Path):
+        """parse_excel falls back to positional columns when headers don't match."""
+        from lemma.services.parsers.excel import parse_excel
+
+        csv_path = tmp_path / "framework.csv"
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["Col A", "Col B", "Col C", "Col D"])
+            writer.writerow(["IR-1", "Incident Response", "Respond to incidents.", "Incident"])
+
+        controls = parse_excel(csv_path)
+
+        assert len(controls) == 1
+        assert controls[0]["id"] == "IR-1"
+        assert controls[0]["title"] == "Incident Response"
+        assert controls[0]["prose"] == "Respond to incidents."
+        assert controls[0]["family"] == "Incident"
+
+    def test_parse_excel_empty_rows_skipped(self, tmp_path: Path):
+        """parse_excel skips rows where the ID column is empty."""
+        from lemma.services.parsers.excel import parse_excel
+
+        csv_path = tmp_path / "framework.csv"
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["id", "title", "prose", "family"])
+            writer.writerow(["AC-1", "Access Control Policy", "Define access.", "Access Control"])
+            writer.writerow(["", "", "", ""])
+            writer.writerow(["AC-2", "Account Mgmt", "Manage accounts.", "Access Control"])
+
+        controls = parse_excel(csv_path)
+
+        assert len(controls) == 2
+
+    def test_parse_excel_unsupported_extension(self, tmp_path: Path):
+        """parse_excel raises ValueError for unsupported file extensions."""
+        import pytest
+
+        from lemma.services.parsers.excel import parse_excel
+
+        bad_file = tmp_path / "framework.txt"
+        bad_file.write_text("not a spreadsheet")
+
+        with pytest.raises(ValueError, match=r"[Uu]nsupported"):
+            parse_excel(bad_file)

--- a/tests/services/parsers/test_pdf_parser.py
+++ b/tests/services/parsers/test_pdf_parser.py
@@ -1,0 +1,130 @@
+"""Tests for the PDF parser (Docling integration).
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestPdfParser:
+    """Tests for PDF framework ingestion via Docling."""
+
+    def test_parse_pdf_returns_controls(self, tmp_path: Path):
+        """parse_pdf returns a list of control dicts from a PDF file."""
+        mock_heading = MagicMock()
+        mock_heading.label = "section_header"
+        mock_heading.text = "AC-1 Access Control Policy"
+        mock_heading.level = 2
+
+        mock_paragraph = MagicMock()
+        mock_paragraph.label = "paragraph"
+        mock_paragraph.text = (
+            "Organizations must define access control policies "
+            "that restrict system access to authorized users."
+        )
+
+        mock_table = MagicMock()
+        mock_table.label = "table"
+        mock_table.text = "Control: AC-1 | Family: Access Control"
+
+        # Build the mock document with iterate_items
+        mock_doc = MagicMock()
+        mock_doc.iterate_items.return_value = [
+            mock_heading,
+            mock_paragraph,
+            mock_table,
+        ]
+
+        # Build the mock conversion result
+        mock_result = MagicMock()
+        mock_result.document = mock_doc
+
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = mock_result
+
+        with patch(
+            "lemma.services.parsers.pdf._get_converter",
+            return_value=mock_converter,
+        ):
+            from lemma.services.parsers.pdf import parse_pdf
+
+            dummy_pdf = tmp_path / "test.pdf"
+            dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+            controls = parse_pdf(dummy_pdf)
+
+        assert isinstance(controls, list)
+        assert len(controls) == 1
+
+        control = controls[0]
+        assert control["id"] == "ctrl-1"
+        assert control["title"] == "AC-1 Access Control Policy"
+        assert "access control policies" in control["prose"]
+        assert "family" in control
+
+    def test_parse_pdf_multiple_sections(self, tmp_path: Path):
+        """parse_pdf handles multiple section headings correctly."""
+        items = []
+        for _section_id, title, prose in [
+            ("AC-1", "AC-1 Access Control Policy", "Define access policies."),
+            ("AC-2", "AC-2 Account Management", "Manage system accounts."),
+        ]:
+            heading = MagicMock()
+            heading.label = "section_header"
+            heading.text = title
+            heading.level = 2
+
+            paragraph = MagicMock()
+            paragraph.label = "paragraph"
+            paragraph.text = prose
+
+            items.extend([heading, paragraph])
+
+        mock_doc = MagicMock()
+        mock_doc.iterate_items.return_value = items
+
+        mock_result = MagicMock()
+        mock_result.document = mock_doc
+
+        mock_converter = MagicMock()
+        mock_converter.convert.return_value = mock_result
+
+        with patch(
+            "lemma.services.parsers.pdf._get_converter",
+            return_value=mock_converter,
+        ):
+            from lemma.services.parsers.pdf import parse_pdf
+
+            dummy_pdf = tmp_path / "test.pdf"
+            dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+            controls = parse_pdf(dummy_pdf)
+
+        assert len(controls) == 2
+        assert controls[0]["title"] == "AC-1 Access Control Policy"
+        assert controls[1]["title"] == "AC-2 Account Management"
+
+    def test_parse_pdf_import_error_without_docling(self, tmp_path: Path):
+        """parse_pdf raises ImportError with helpful message when Docling is missing."""
+
+        with patch(
+            "lemma.services.parsers.pdf._get_converter",
+            side_effect=ImportError(
+                "PDF import requires the [ingest] extras. "
+                "Install with: pip install lemma-grc[ingest]"
+            ),
+        ):
+            from lemma.services.parsers.pdf import parse_pdf
+
+            dummy_pdf = tmp_path / "test.pdf"
+            dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+            try:
+                parse_pdf(dummy_pdf)
+                msg = "Expected ImportError"
+                raise AssertionError(msg)
+            except ImportError as e:
+                assert "ingest" in str(e).lower()


### PR DESCRIPTION
## Description

Implements the PDF and Excel/CSV document parsers to complete the framework ingestion pipeline (Issue #14). These are the last missing pieces — the OSCAL catalog parser, ChromaDB indexer, CLI commands, and dispatch pattern were all built in earlier PRs.

The existing `import_framework()` function already dispatches to `parsers.pdf.parse_pdf` and `parsers.excel.parse_excel`, but those modules didn't exist until now. This PR fills the gap.

**PDF parser** — Uses IBM's Docling library for layout-aware extraction. Treats section headers as control boundaries and accumulates paragraphs/tables as prose. Docling is ~500MB, so it's gated behind `[ingest]` optional extras with a clean `ImportError` message.

**Excel/CSV parser** — Convention-based header detection (looks for columns matching `id`, `title`, `prose`, `family` and common aliases) with positional fallback for unrecognized headers. Supports `.xlsx` via openpyxl and `.csv` via stdlib.

Both parsers output the same `{id, title, prose, family}` record format consumed by the indexer.

Refs #14

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` (or equivalent) with no errors
- [x] I have run `ruff format` (or equivalent)
- [x] I have run `pytest` (or equivalent) and all tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
