### PR TITLE
chore(frameworks): Bundle NIST CSF 2.0 and SP 800-171 Rev 3 catalogs

### DIFF
--- a/src/lemma/data/frameworks/nist-800-171-rev3.json
+++ b/src/lemma/data/frameworks/nist-800-171-rev3.json
@@ -1,0 +1,21470 @@
+{
+  "catalog": {
+    "uuid": "98cf22b5-912b-4efc-a622-4cf49f42ac13",
+    "metadata": {
+      "title": "Electronic (OSCAL) Version of Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations",
+      "published": "2025-07-03T16:37:46.02276-04:00",
+      "last-modified": "2025-07-06T21:01:17.00000-00:00",
+      "version": "1.0.0",
+      "oscal-version": "v1.1.3",
+      "props": [
+        {
+          "name": "framework-identifier",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "SP_800_171"
+        },
+        {
+          "name": "framework-version-identifier",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "SP_800_171_3_0_0"
+        },
+        {
+          "name": "generated-by",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "Cybersecurity And Privacy Open Reference Datasets In OSCAL (CAPORDINO)"
+        },
+        {
+          "name": "publication-status",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "Final"
+        }
+      ],
+      "links": [
+        {
+          "href": "#6845eb53-a392-4552-83f4-04b129b40d3f",
+          "rel": "alternate"
+        },
+        {
+          "href": "#6957f4cd-7e2e-43a9-9f76-720c861efb45",
+          "rel": "canonical"
+        },
+        {
+          "href": "#e59e6d39-499f-4235-aa9f-8463b3bba156",
+          "rel": "cprt"
+        }
+      ],
+      "roles": [
+        {
+          "id": "creator",
+          "title": "OSCAL Document Creator"
+        },
+        {
+          "id": "publisher",
+          "title": "SP 800-171 Publisher"
+        },
+        {
+          "id": "contact-creator",
+          "title": "Contact Electronic Version Creator"
+        },
+        {
+          "id": "contact-publisher",
+          "title": "Contact Publisher"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "98c78f9b-5d50-4b01-b47f-d16801e8d0ab",
+          "type": "organization",
+          "name": "OSCAL Program",
+          "short-name": "NIST",
+          "email-addresses": [
+            "oscal@nist.gov"
+          ],
+          "addresses": [
+            {
+              "addr-lines": [
+                "National Institute of Standards and Technology",
+                "Attn: Computer Security Division",
+                "Information Technology Laboratory",
+                "100 Bureau Drive (Mail Stop 2000)"
+              ],
+              "city": "Gaithersburg",
+              "state": "MD",
+              "postal-code": "20899-2000"
+            }
+          ]
+        },
+        {
+          "uuid": "4809f9d2-fdb1-47b0-b444-11271f09ff22",
+          "type": "organization",
+          "name": "National Institute of Standards and Technology",
+          "short-name": "NIST",
+          "email-addresses": [
+            "800-171comments@list.nist.gov"
+          ],
+          "addresses": [
+            {
+              "addr-lines": [
+                "National Institute of Standards and Technology",
+                "Attn: Computer Security Division",
+                "Information Technology Laboratory",
+                "100 Bureau Drive (Mail Stop 2000)"
+              ],
+              "city": "Gaithersburg",
+              "state": "MD",
+              "postal-code": "20899-2000"
+            }
+          ]
+        }
+      ],
+      "responsible-parties": [
+        {
+          "role-id": "creator",
+          "party-uuids": [
+            "98c78f9b-5d50-4b01-b47f-d16801e8d0ab"
+          ]
+        },
+        {
+          "role-id": "publisher",
+          "party-uuids": [
+            "985fea3e-a6e5-4a57-ba3d-74f063bc8fa2"
+          ]
+        },
+        {
+          "role-id": "contact-publisher",
+          "party-uuids": [
+            "985fea3e-a6e5-4a57-ba3d-74f063bc8fa2"
+          ]
+        },
+        {
+          "role-id": "contact-creator",
+          "party-uuids": [
+            "98c78f9b-5d50-4b01-b47f-d16801e8d0ab"
+          ]
+        }
+      ]
+    },
+    "groups": [
+      {
+        "id": "SP_800_171_03.01",
+        "class": "family",
+        "title": "Access Control",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.01"
+          },
+          {
+            "name": "label",
+            "value": "Access Control (03.01)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.01.01",
+            "class": "requirement",
+            "title": "Account Management",
+            "params": [
+              {
+                "id": "A.03.01.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.01.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period for account inactivity before disabling is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.01.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.01.ODP[02]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which to notify account managers and designated personnel or roles when accounts are no longer required is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.01.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.01.ODP[03]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which to notify account managers and designated personnel or roles when users are terminated or transferred is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.01.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.01.ODP[04]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which to notify account managers and designated personnel or roles when system usage or the need-to-know changes for an individual is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.01.ODP.05",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.01.ODP[05]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period of expected inactivity requiring users to log out of the system is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.01.ODP.06",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.01.ODP[06]"
+                  }
+                ],
+                "label": "circumstances",
+                "usage": "organization-defined circumstances",
+                "guidelines": [
+                  {
+                    "prose": "circumstances requiring users to log out of the system are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.01"
+              },
+              {
+                "name": "label",
+                "value": "Account Management (03.01.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#13c67bb0-9c04-442b-8c7f-0e4f55f995a5",
+                "rel": "reference"
+              },
+              {
+                "href": "#78a467a2-9b1b-4d5f-a7e5-b2661a4374a0",
+                "rel": "reference"
+              },
+              {
+                "href": "#9197204c-0af8-4a31-9495-ae2ba8995fb9",
+                "rel": "reference"
+              },
+              {
+                "href": "#a21c08b1-1984-4b6a-b8eb-fa667b8fc7e8",
+                "rel": "reference"
+              },
+              {
+                "href": "#56cd2f5a-abf8-4810-b449-55de6ee5dbb1",
+                "rel": "reference"
+              },
+              {
+                "href": "#f509b76c-728e-4afa-9db3-ed09265f4723",
+                "rel": "reference"
+              },
+              {
+                "href": "#be88bb5c-d994-40f4-b273-3df87369c0ab",
+                "rel": "reference"
+              },
+              {
+                "href": "#68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+                "rel": "reference"
+              },
+              {
+                "href": "#da00e9f9-6829-46d6-bcec-a08ef5556e7f",
+                "rel": "reference"
+              },
+              {
+                "href": "#276c6996-e72e-409e-a5dc-f9a53435028b",
+                "rel": "reference"
+              },
+              {
+                "href": "#3d61b0ab-28ea-40e4-b231-ba750516968b",
+                "rel": "reference"
+              },
+              {
+                "href": "#72a57444-839c-4c52-8f18-3a710d23b5b6",
+                "rel": "reference"
+              },
+              {
+                "href": "#b684972f-48eb-4a6e-b581-b5e697b3bc19",
+                "rel": "reference"
+              },
+              {
+                "href": "#13290408-22ce-4afa-a0f0-ca438c1e932b",
+                "rel": "reference"
+              },
+              {
+                "href": "#e0aa4a13-03cc-4b86-be6c-80225af5c3af",
+                "rel": "reference"
+              },
+              {
+                "href": "#6aba579a-f262-4bf9-a8e7-6820ea63de34",
+                "rel": "reference"
+              },
+              {
+                "href": "#a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.a"
+                      }
+                    ],
+                    "prose": "Define the types of system accounts allowed and prohibited."
+                  },
+                  {
+                    "id": "SR-03.01.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.b"
+                      }
+                    ],
+                    "prose": "Create, enable, modify, disable, and remove system accounts in accordance with policy, procedures, prerequisites, and criteria."
+                  },
+                  {
+                    "id": "SR-03.01.01.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.c"
+                      }
+                    ],
+                    "prose": "Specify:",
+                    "parts": [
+                      {
+                        "id": "SR-03.01.01.c.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.c.01"
+                          }
+                        ],
+                        "prose": "Authorized users of the system,"
+                      },
+                      {
+                        "id": "SR-03.01.01.c.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.c.02"
+                          }
+                        ],
+                        "prose": "Group and role membership, and"
+                      },
+                      {
+                        "id": "SR-03.01.01.c.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.c.03"
+                          }
+                        ],
+                        "prose": "Access authorizations (i.e., privileges) for each account."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.01.01.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.d"
+                      }
+                    ],
+                    "prose": "Authorize access to the system based on:",
+                    "parts": [
+                      {
+                        "id": "SR-03.01.01.d.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.d.01"
+                          }
+                        ],
+                        "prose": "A valid access authorization and"
+                      },
+                      {
+                        "id": "SR-03.01.01.d.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.d.02"
+                          }
+                        ],
+                        "prose": "Intended system usage."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.01.01.e",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.e"
+                      }
+                    ],
+                    "prose": "Monitor the use of system accounts."
+                  },
+                  {
+                    "id": "SR-03.01.01.f",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.f"
+                      }
+                    ],
+                    "prose": "Disable system accounts when:",
+                    "parts": [
+                      {
+                        "id": "SR-03.01.01.f.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.f.01"
+                          }
+                        ],
+                        "prose": "The accounts have expired,"
+                      },
+                      {
+                        "id": "SR-03.01.01.f.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.f.02"
+                          }
+                        ],
+                        "prose": "The accounts have been inactive for {{ insert: param, A.03.01.01.ODP.01 }},"
+                      },
+                      {
+                        "id": "SR-03.01.01.f.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.f.03"
+                          }
+                        ],
+                        "prose": "The accounts are no longer associated with a user or individual,"
+                      },
+                      {
+                        "id": "SR-03.01.01.f.04",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.f.04"
+                          }
+                        ],
+                        "prose": "The accounts are in violation of organizational policy, or"
+                      },
+                      {
+                        "id": "SR-03.01.01.f.05",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.f.05"
+                          }
+                        ],
+                        "prose": "Significant risks associated with individuals are discovered."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.01.01.g",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.g"
+                      }
+                    ],
+                    "prose": "Notify account managers and designated personnel or roles within:",
+                    "parts": [
+                      {
+                        "id": "SR-03.01.01.g.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.g.01"
+                          }
+                        ],
+                        "prose": "{{ insert: param, A.03.01.01.ODP.02 }} when accounts are no longer required."
+                      },
+                      {
+                        "id": "SR-03.01.01.g.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.g.02"
+                          }
+                        ],
+                        "prose": "{{ insert: param, A.03.01.01.ODP.03 }} when users are terminated or transferred."
+                      },
+                      {
+                        "id": "SR-03.01.01.g.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.01.g.03"
+                          }
+                        ],
+                        "prose": "{{ insert: param, A.03.01.01.ODP.04 }} when system usage or the need-to-know changes for an individual."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.01.01.h",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.01.h"
+                      }
+                    ],
+                    "prose": "Require that users log out of the system after {{ insert: param, A.03.01.01.ODP.05 }} of expected inactivity or when {{ insert: param, A.03.01.01.ODP.06 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.01",
+                "name": "guidance",
+                "prose": "This requirement focuses on account management for systems and applications. The definition and enforcement of access authorizations other than those determined by account type (e.g., privileged access, non-privileged access) are addressed in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.02)03.01.02. System account types include individual, group, temporary, system, guest, anonymous, emergency, developer, and service. Users who require administrative privileges on system accounts receive additional scrutiny by personnel responsible for approving such accounts and privileged access. Types of accounts that organizations may prohibit due to increased risk include group, emergency, guest, anonymous, and temporary. Organizations may choose to define access privileges or other attributes by account, type of account, or a combination of both. Other attributes required for authorizing access include restrictions on the time of day, day of the week, and point of origin. When defining other system account attributes, organizations consider system requirements (e.g., system upgrades, scheduled maintenance) and mission and business requirements (e.g., time zone differences, remote access to facilitate travel requirements). Users who pose a significant security risk include individuals for whom reliable evidence indicates either the intention to use authorized access to the system to cause harm or that adversaries will cause harm through them. Close coordination among mission and business owners, system administrators, human resource managers, and legal staff is essential when disabling system accounts for high-risk individuals. Time periods for the notification of organizational personnel or roles may vary. Inactivity logout is behavior- or policy-based and requires users to take physical action to log out when they are expecting inactivity longer than the defined period. Automatic enforcement of inactivity logout is addressed by [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.10) 03.01.10."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.b.01",
+                "name": "assessment-objective",
+                "prose": "system accounts are created in accordance with organizational policy, procedures, prerequisites, and criteria.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.b.02",
+                "name": "assessment-objective",
+                "prose": "system accounts are enabled in accordance with organizational policy, procedures, prerequisites, and criteria.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.b.03",
+                "name": "assessment-objective",
+                "prose": "system accounts are modified in accordance with organizational policy, procedures, prerequisites, and criteria.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.b.04",
+                "name": "assessment-objective",
+                "prose": "system accounts are disabled in accordance with organizational policy, procedures, prerequisites, and criteria.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.b.05",
+                "name": "assessment-objective",
+                "prose": "system accounts are removed in accordance with organizational policy, procedures, prerequisites, and criteria.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.a.01",
+                "name": "assessment-objective",
+                "prose": "system account types allowed are defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.a.02",
+                "name": "assessment-objective",
+                "prose": "system account types prohibited are defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.c.01",
+                "name": "assessment-objective",
+                "prose": "authorized users of the system are specified.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.c.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.c.02",
+                "name": "assessment-objective",
+                "prose": "group and role memberships are specified.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.c.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.c.03",
+                "name": "assessment-objective",
+                "prose": "access authorizations (i.e., privileges) for each account are specified.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.c.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.d.01",
+                "name": "assessment-objective",
+                "prose": "access to the system is authorized based on a valid access authorization.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.d.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.d.02",
+                "name": "assessment-objective",
+                "prose": "access to the system is authorized based on intended system usage.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.d.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.e",
+                "name": "assessment-objective",
+                "prose": "the use of system accounts is monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.e",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.f.01",
+                "name": "assessment-objective",
+                "prose": "system accounts are disabled when the accounts have expired.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.f.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.f.02",
+                "name": "assessment-objective",
+                "prose": "system accounts are disabled when the accounts have been inactive for {{ insert: param, A.03.01.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.f.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.f.03",
+                "name": "assessment-objective",
+                "prose": "system accounts are disabled when the accounts are no longer associated with a user or individual.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.f.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.f.04",
+                "name": "assessment-objective",
+                "prose": "system accounts are disabled when the accounts violate organizational policy.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.f.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.g.01",
+                "name": "assessment-objective",
+                "prose": "account managers and designated personnel or roles are notified within {{ insert: param, A.03.01.01.ODP.02 }} when accounts are no longer required.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.g.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.g.02",
+                "name": "assessment-objective",
+                "prose": "account managers and designated personnel or roles are notified within {{ insert: param, A.03.01.01.ODP.03 }} when users are terminated or transferred.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.g.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.g.03",
+                "name": "assessment-objective",
+                "prose": "account managers and designated personnel or roles are notified within {{ insert: param, A.03.01.01.ODP.04 }} when system usage or the need-to-know changes for an individual.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.g.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.f.05",
+                "name": "assessment-objective",
+                "prose": "system accounts are disabled when significant risks associated with individuals are discovered.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.f.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.01.h",
+                "name": "assessment-objective",
+                "prose": "users are required to log out of the system after {{ insert: param, A.03.01.01.ODP.05 }} of expected inactivity or when the following circumstances occur: {{ insert: param, A.03.01.01.ODP.06 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.01.h",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\npersonnel termination or transfer policies and procedures\n\nprocedures for account management\n\nlist of active system accounts and the name of the individual associated with each account\n\nsystem design documentation\n\nlist of conditions for group and role membership\n\nsystem configuration settings\n\nnotifications of recent transfers, separations, or terminations of employees\n\nlist of recently disabled system accounts and the name of the individual associated with each account\n\nlist of user activities that pose significant organizational risks\n\naccess authorization records\n\naccount management compliance reviews\n\nsystem monitoring and audit records\n\nsystem security plan\n\nsystem-generated list of accounts removed\n\nsystem-generated list of emergency accounts disabled\n\nsystem-generated list of disabled accounts\n\nother relevant documents and records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with account management responsibilities\n\nsystem administrators\n\npersonnel with information security responsibilities\n\nsystem developers"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for account management on the system\n\nmechanisms for implementing account management"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.02",
+            "class": "requirement",
+            "title": "Access Enforcement",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.02"
+              },
+              {
+                "name": "label",
+                "value": "Access Enforcement (03.01.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#086c4c08-e24e-4a8d-96e8-d384f36acc62",
+                "rel": "reference"
+              },
+              {
+                "href": "#56cd2f5a-abf8-4810-b449-55de6ee5dbb1",
+                "rel": "reference"
+              },
+              {
+                "href": "#f509b76c-728e-4afa-9db3-ed09265f4723",
+                "rel": "reference"
+              },
+              {
+                "href": "#be88bb5c-d994-40f4-b273-3df87369c0ab",
+                "rel": "reference"
+              },
+              {
+                "href": "#68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+                "rel": "reference"
+              },
+              {
+                "href": "#da00e9f9-6829-46d6-bcec-a08ef5556e7f",
+                "rel": "reference"
+              },
+              {
+                "href": "#276c6996-e72e-409e-a5dc-f9a53435028b",
+                "rel": "reference"
+              },
+              {
+                "href": "#3d61b0ab-28ea-40e4-b231-ba750516968b",
+                "rel": "reference"
+              },
+              {
+                "href": "#72a57444-839c-4c52-8f18-3a710d23b5b6",
+                "rel": "reference"
+              },
+              {
+                "href": "#b684972f-48eb-4a6e-b581-b5e697b3bc19",
+                "rel": "reference"
+              },
+              {
+                "href": "#13290408-22ce-4afa-a0f0-ca438c1e932b",
+                "rel": "reference"
+              },
+              {
+                "href": "#e0aa4a13-03cc-4b86-be6c-80225af5c3af",
+                "rel": "reference"
+              },
+              {
+                "href": "#6aba579a-f262-4bf9-a8e7-6820ea63de34",
+                "rel": "reference"
+              },
+              {
+                "href": "#a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.02",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.01.02",
+                "name": "guidance",
+                "prose": "Access control policies control access between active entities or subjects (i.e., users or system processes acting on behalf of users) and passive entities or objects (i.e., devices, files, records, domains) in organizational systems. Types of system access include remote access and access to systems that communicate through external networks, such as the internet. Access enforcement mechanisms can also be employed at the application and service levels to provide increased protection for CUI. This recognizes that the system can host many applications and services in support of mission and business functions. Access control policies are defined in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.15.01) 03.15.01."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.02.01",
+                "name": "assessment-objective",
+                "prose": "approved authorizations for logical access to CUI are enforced in accordance with applicable access control policies.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.02.02",
+                "name": "assessment-objective",
+                "prose": "approved authorizations for logical access to system resources are enforced in accordance with applicable access control policies.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for access enforcement\n\nsystem design documentation\n\nsystem configuration settings\n\nlist of approved authorizations (i.e., user privileges)\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with access enforcement responsibilities\n\nsystem administrators\n\npersonnel with information security responsibilities\n\nsystem developers"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing the access control policy"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.03",
+            "class": "requirement",
+            "title": "Information Flow Enforcement",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.03"
+              },
+              {
+                "name": "label",
+                "value": "Information Flow Enforcement (03.01.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#a9f06e3c-3130-46ad-b51c-ff67f4d9b338",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#276c6996-e72e-409e-a5dc-f9a53435028b",
+                "rel": "reference"
+              },
+              {
+                "href": "#3d61b0ab-28ea-40e4-b231-ba750516968b",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.03",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.01.03",
+                "name": "guidance",
+                "prose": "Information flow control regulates where CUI can transit within a system and between systems (in contrast to who is allowed to access the information) and without regard to subsequent accesses to that information. Flow control restrictions include keeping CUI from being transmitted in the clear to the internet, blocking external communications traffic that claims to be sourced from within the organization, restricting requests to the internet that are not from the internal web proxy server, and limiting CUI transfers between organizations based on data structures and content. Transferring CUI between organizations may require an agreement that specifies how the information flow is enforced (see [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.12.05)03.12.05). Transferring CUI between systems that represent different security domains with different security policies introduces the risk that such transfers violate one or more domain security policies. In such situations, information owners or stewards provide guidance at designated policy enforcement points between interconnected systems. Organizations consider mandating specific architectural solutions when required to enforce specific security policies. Enforcement includes prohibiting CUI transfers between interconnected systems (i.e., allowing information access only), employing hardware mechanisms to enforce one-way information flows, and implementing trustworthy regrading mechanisms to reassign security attributes and security labels. Organizations commonly use information flow control policies and enforcement mechanisms to control the flow of CUI between designated sources and destinations (e.g., networks, individuals, and devices) within systems and between interconnected systems. Flow control is based on characteristics of the information or the information path. Enforcement occurs in boundary protection devices (e.g., encrypted tunnels, routers, gateways, and firewalls) that use rule sets or establish configuration settings that restrict system services, provide a packet-filtering capability based on header information, or provide a message-filtering capability based on message content (e.g., implementing key word searches or using document characteristics). Organizations also consider the trustworthiness of filtering and inspection mechanisms (i.e., hardware, firmware, and software components) that are critical to information flow enforcement."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.03.01",
+                "name": "assessment-objective",
+                "prose": "approved authorizations are enforced for controlling the flow of CUI within the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.03.02",
+                "name": "assessment-objective",
+                "prose": "approved authorizations are enforced for controlling the flow of CUI between connected systems.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\ninformation flow control policies\n\nprocedures for information flow enforcement\n\nsecurity architecture and design documentation\n\nsystem configuration settings\n\nsystem baseline configuration\n\nsystem audit records\n\nlist of information flow authorizations\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system administrators\n\npersonnel with security architecture responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing the information flow enforcement policy"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.04",
+            "class": "requirement",
+            "title": "Separation of Duties",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.04"
+              },
+              {
+                "name": "label",
+                "value": "Separation of Duties (03.01.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#f15afb9b-7fec-4178-bf5c-ab9b19643998",
+                "rel": "reference"
+              },
+              {
+                "href": "#276c6996-e72e-409e-a5dc-f9a53435028b",
+                "rel": "reference"
+              },
+              {
+                "href": "#3d61b0ab-28ea-40e4-b231-ba750516968b",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.04",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.04.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.04.a"
+                      }
+                    ],
+                    "prose": "Identify the duties of individuals requiring separation."
+                  },
+                  {
+                    "id": "SR-03.01.04.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.04.b"
+                      }
+                    ],
+                    "prose": "Define system access authorizations to support separation of duties."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.04",
+                "name": "guidance",
+                "prose": "Separation of duties addresses the potential for abuse of authorized privileges and reduces the risk of malevolent activity without collusion. Separation of duties includes dividing mission functions and support functions among different individuals or roles, conducting system support functions with different individuals or roles (e.g., quality assurance, configuration management, network security, system management, assessments, and programming), and ensuring that personnel who administer access control functions do not also administer audit functions. Because separation of duty violations can span systems and application domains, organizations consider the entirety of their systems and system components when developing policies on separation of duties. This requirement is enforced by [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.02) 03.01.02."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.04.a",
+                "name": "assessment-objective",
+                "prose": "duties of individuals requiring separation are identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.04.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.04.b",
+                "name": "assessment-objective",
+                "prose": "system access authorizations to support separation of duties are defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for the separation of duties and the division of responsibilities\n\nsystem configuration settings\n\nsystem audit records\n\nsystem access authorizations\n\nlist of divisions of responsibility and separation of duties\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for defining the separation of duties and the division of responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing the separation of duties policy"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.05",
+            "class": "requirement",
+            "title": "Least Privilege",
+            "params": [
+              {
+                "id": "A.03.01.05.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.05.ODP[01]"
+                  }
+                ],
+                "label": "security functions",
+                "usage": "organization-defined security functions",
+                "guidelines": [
+                  {
+                    "prose": "security functions for authorized access are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.05.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.05.ODP[02]"
+                  }
+                ],
+                "label": "security-relevant information",
+                "usage": "organization-defined security-relevant information",
+                "guidelines": [
+                  {
+                    "prose": "security-relevant information for authorized access is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.05.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.05.ODP[03]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review the privileges assigned to roles or classes of users is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.05"
+              },
+              {
+                "name": "label",
+                "value": "Least Privilege (03.01.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#1240a1b8-e785-4b78-b89f-929d67e50f8f",
+                "rel": "reference"
+              },
+              {
+                "href": "#b67dc576-0eb9-454f-9f8b-241e11d1e790",
+                "rel": "reference"
+              },
+              {
+                "href": "#d62abb9e-b573-4519-a5a0-869448c62c7a",
+                "rel": "reference"
+              },
+              {
+                "href": "#c3606a57-b8a7-4a26-9ba4-9dc3dbadd08c",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.05.a"
+                      }
+                    ],
+                    "prose": "Allow only authorized system access for users (or processes acting on behalf of users) that is necessary to accomplish assigned organizational tasks."
+                  },
+                  {
+                    "id": "SR-03.01.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.05.b"
+                      }
+                    ],
+                    "prose": "Authorize access to {{ insert: param, A.03.01.05.ODP.01 }} and {{ insert: param, A.03.01.05.ODP.02 }}."
+                  },
+                  {
+                    "id": "SR-03.01.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.05.c"
+                      }
+                    ],
+                    "prose": "Review the privileges assigned to roles or classes of users {{ insert: param, A.03.01.05.ODP.03 }} to validate the need for such privileges."
+                  },
+                  {
+                    "id": "SR-03.01.05.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.05.d"
+                      }
+                    ],
+                    "prose": "Reassign or remove privileges, as necessary."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.05",
+                "name": "guidance",
+                "prose": "Organizations employ the principle of least privilege for specific duties and authorized access for users and system processes. Least privilege is applied to the development, implementation, and operation of the system. Organizations consider creating additional processes, roles, and system accounts to achieve least privilege. Security functions include establishing system accounts and assigning privileges, installing software, configuring access authorizations, configuring settings for events to be audited, establishing vulnerability scanning parameters, establishing intrusion detection parameters, and managing audit information. Security-relevant information includes threat and vulnerability information, filtering rules for routers or firewalls, configuration parameters for security services, security architecture, cryptographic key management information, access control lists, and audit information."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.05.a",
+                "name": "assessment-objective",
+                "prose": "system access for users (or processes acting on behalf of users) is authorized only when necessary to accomplish assigned organizational tasks.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.05.b.01",
+                "name": "assessment-objective",
+                "prose": "access to {{ insert: param, A.03.01.05.ODP.01 }} is authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.05.b.02",
+                "name": "assessment-objective",
+                "prose": "access to {{ insert: param, A.03.01.05.ODP.02 }} is authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.05.c",
+                "name": "assessment-objective",
+                "prose": "the privileges assigned to roles or classes of users are reviewed {{ insert: param, A.03.01.05.ODP.03 }} to validate the need for such privileges.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.05.d",
+                "name": "assessment-objective",
+                "prose": "privileges are reassigned or removed, as necessary.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.05.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for least privilege\n\nlist of assigned access authorizations (i.e., privileges)\n\nsystem configuration settings\n\nsystem audit records\n\nlist of security functions (implemented in hardware, software, and firmware)\n\nsecurity-relevant information for which access must be explicitly authorized\n\nlist of system-generated roles or classes of users and assigned privileges\n\nvalidation reviews of privileges assigned to roles or classes of users\n\nrecords of privilege removals or reassignments for roles or classes of users\n\nsystem security plan\n\nsystem design documentation\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for defining least privileges\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing least privilege functions\n\nmechanisms for implementing reviews of user privileges"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.06",
+            "class": "requirement",
+            "title": "Least Privilege – Privileged Accounts",
+            "params": [
+              {
+                "id": "A.03.01.06.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.06.ODP[01]"
+                  }
+                ],
+                "label": "personnel or roles",
+                "usage": "organization-defined personnel or roles",
+                "guidelines": [
+                  {
+                    "prose": "personnel or roles to which privileged accounts on the system are to be restricted are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.06"
+              },
+              {
+                "name": "label",
+                "value": "Least Privilege – Privileged Accounts (03.01.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#3c84ba44-6fdd-45da-9176-3a018d3179e5",
+                "rel": "reference"
+              },
+              {
+                "href": "#e9163a6a-1231-4195-85ee-d8c7ef9cd552",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.06",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.06.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.06.a"
+                      }
+                    ],
+                    "prose": "Restrict privileged accounts on the system to {{ insert: param, A.03.01.06.ODP.01 }}.."
+                  },
+                  {
+                    "id": "SR-03.01.06.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.06.b"
+                      }
+                    ],
+                    "prose": "Require that users (or roles) with privileged accounts use non-privileged accounts when accessing non-security functions or non-security information."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.06",
+                "name": "guidance",
+                "prose": "Privileged accounts refer to accounts that are granted elevated privileges to access resources (including security functions or security-relevant information) that are otherwise restricted for non-privileged accounts. These accounts are typically described as system administrator or super user accounts. For example, a privileged account is often required in order to perform privileged functions such as executing commands that could modify system behavior. Restricting privileged accounts to specific personnel or roles ensures that only those authorized users can access and manipulate security functions or security-relevant information. Requiring the use of non-privileged accounts when such access is not needed can limit unauthorized access to and manipulation of security functions or security-relevant information."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.06.a",
+                "name": "assessment-objective",
+                "prose": "privileged accounts on the system are restricted to {{ insert: param, A.03.01.06.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.06.b",
+                "name": "assessment-objective",
+                "prose": "users (or roles) with privileged accounts are required to use non-privileged accounts when accessing non-security functions or non-security information.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for least privilege\n\nlist of system-generated privileged accounts\n\nlist of system administration personnel\n\nsystem audit records\n\nsystem configuration settings\n\nsystem security plan\n\nlist of system-generated security functions or security-relevant information assigned to system accounts or roles\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for defining least privileges\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing least privilege functions"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.07",
+            "class": "requirement",
+            "title": "Least Privilege – Privileged Functions",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.07"
+              },
+              {
+                "name": "label",
+                "value": "Least Privilege – Privileged Functions (03.01.07)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b3af0cb9-ee6e-45be-a855-0e28dbceedeb",
+                "rel": "reference"
+              },
+              {
+                "href": "#404238c1-fc3f-4d3b-9d50-923f5d676888",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.07",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.07.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.07.a"
+                      }
+                    ],
+                    "prose": "Prevent non-privileged users from executing privileged functions."
+                  },
+                  {
+                    "id": "SR-03.01.07.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.07.b"
+                      }
+                    ],
+                    "prose": "Log the execution of privileged functions."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.07",
+                "name": "guidance",
+                "prose": "Privileged functions include establishing system accounts, performing system integrity checks, conducting patching operations, changing system configuration settings, or administering cryptographic key management activities. Non-privileged users do not possess the authorizations to execute privileged functions. Bypassing intrusion detection and prevention mechanisms or malicious code protection mechanisms are examples of privileged functions that require protection from non-privileged users. This requirement represents a condition achieved by the definition of authorized privileges in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.01)03.01.01 and privilege enforcement in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.02)03.01.02. The misuse of privileged functions — whether intentionally or unintentionally by authorized users or by unauthorized external entities that have compromised system accounts — is a serious and ongoing concern that can have significant adverse impacts on organizations. Logging the use of privileged functions is one way to detect such misuse and mitigate risks from advanced persistent threats and insider threats."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.07.b",
+                "name": "assessment-objective",
+                "prose": "the execution of privileged functions is logged.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.07.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.07.a",
+                "name": "assessment-objective",
+                "prose": "non-privileged users are prevented from executing privileged functions.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.07.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.07_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for least privilege\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nlist of audited events\n\nlist of privileged functions to be audited and associated user account assignments\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.07_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for reviewing least privileges\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.07_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for auditing the execution of least privilege functions\n\nmechanisms for implementing least privilege functions for non-privileged users"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.08",
+            "class": "requirement",
+            "title": "Unsuccessful Logon Attempts",
+            "params": [
+              {
+                "id": "A.03.01.08.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.08.ODP[01]"
+                  }
+                ],
+                "label": "number",
+                "usage": "organization-defined number",
+                "guidelines": [
+                  {
+                    "prose": "the number of consecutive invalid logon attempts by a user allowed during a time period is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.08.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.08.ODP[02]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period to which the number of consecutive invalid logon attempts by a user is limited is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.01.08.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.08.ODP[03]"
+                  }
+                ],
+                "label": "SELECTED PARAMETER VALUES",
+                "select": {
+                  "how-many": "one-or-more",
+                  "choice": [
+                    "lock the account or node for an {{ insert: param, A.03.01.08.ODP.04 }}",
+                    "lock the account or node until released by an administrator",
+                    "delay next logon prompt",
+                    "notify system administrator",
+                    "take other action"
+                  ]
+                }
+              },
+              {
+                "id": "A.03.01.08.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.08.ODP[04]"
+                  }
+                ],
+                "label": "",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period for an account or node to be locked is defined (if selected)."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.08"
+              },
+              {
+                "name": "label",
+                "value": "Unsuccessful Logon Attempts (03.01.08)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#2734910e-c595-4116-8ccd-4a85a9c8eda7",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.08",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.08.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.08.a"
+                      }
+                    ],
+                    "prose": "Enforce a limit of {{ insert: param, A.03.01.08.ODP.01 }} consecutive invalid logon attempts by a user during a {{ insert: param, A.03.01.08.ODP.02 }}."
+                  },
+                  {
+                    "id": "SR-03.01.08.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.08.b"
+                      }
+                    ],
+                    "prose": "Automatically {{ insert: param, A.03.01.08.ODP.03 }} when the maximum number of unsuccessful attempts is exceeded."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.08",
+                "name": "guidance",
+                "prose": "Due to the potential for denial of service, automatic system lockouts are in most cases, temporary and automatically release after a predetermined time period established by the organization (i.e., using a delay algorithm). Organizations may employ different delay algorithms for different system components based on the capabilities of the respective components. Responses to unsuccessful system logon attempts may be implemented at the system and application levels. Organization-defined actions that may be taken include prompting the user to answer a secret question in addition to the username and password, invoking a lockdown mode with limited user capabilities (instead of a full lockout), allowing users to only logon from specified Internet Protocol (IP) addresses, requiring a CAPTCHA to prevent automated attacks, or applying user profiles, such as location, time of day, IP address, device, or Media Access Control (MAC) address."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.08.a",
+                "name": "assessment-objective",
+                "prose": "a limit of {{ insert: param, A.03.01.08.ODP.01 }} consecutive invalid logon attempts by a user during {{ insert: param, A.03.01.08.ODP.02 }} is enforced.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.08.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.08.b",
+                "name": "assessment-objective",
+                "prose": "{{ insert: param, A.03.01.08.ODP.03 }} when the maximum number of unsuccessful attempts is exceeded.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.08.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.08_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for unsuccessful logon attempts\n\nsystem design documentation\n\nsystem audit records\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.08_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.08_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing the access control policy for unsuccessful logon attempts"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.09",
+            "class": "requirement",
+            "title": "System Use Notification",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.09"
+              },
+              {
+                "name": "label",
+                "value": "System Use Notification (03.01.09)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#e8e9d62c-b3ca-4285-b88f-3db08a1509fa",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.09",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.01.09",
+                "name": "guidance",
+                "prose": "System use notifications can be implemented using messages or warning banners. The messages or warning banners are displayed before individuals log in to a system that processes, stores, or transmits CUI. System use notifications are used for access via logon interfaces with human users and are not required when human interfaces do not exist. Organizations consider whether a secondary use notification is needed to access applications or other system resources after the initial network logon. Posters or other printed materials may be used in lieu of an automated system message. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.15.03) 03.15.03."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.09",
+                "name": "assessment-objective",
+                "prose": "a system use notification message with privacy and security notices consistent with applicable CUI rules is displayed before granting access to the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.09",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.09_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprivacy and security policies, procedures for system use notification\n\ndocumented approval of system use notification messages\n\nsystem audit records\n\nuser acknowledgements of system use notification messages\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem use notification messages\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.09_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nlegal counsel\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.09_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing system use notifications"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.10",
+            "class": "requirement",
+            "title": "Device Lock",
+            "params": [
+              {
+                "id": "A.03.01.10.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.10.ODP[01]"
+                  }
+                ],
+                "label": "SELECTED PARAMETER VALUES",
+                "select": {
+                  "how-many": "one-or-more",
+                  "choice": [
+                    "initiating a device lock after {{ insert: param, A.03.01.10.ODP.02 }} of inactivity",
+                    "requiring the user to initiate a device lock before leaving the system unattended"
+                  ]
+                }
+              },
+              {
+                "id": "A.03.01.10.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.10.ODP[02]"
+                  }
+                ],
+                "label": "",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period of inactivity after which a device lock is initiated is defined (if selected)."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.10"
+              },
+              {
+                "name": "label",
+                "value": "Device Lock (03.01.10)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b3dcf788-1166-44ff-9abe-1c140f2975da",
+                "rel": "reference"
+              },
+              {
+                "href": "#3b4eda46-abb8-4dc0-8983-cb43c22e72ef",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.10",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.10.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.10.a"
+                      }
+                    ],
+                    "prose": "Prevent access to the system by {{ insert: param, A.03.01.10.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.01.10.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.10.b"
+                      }
+                    ],
+                    "prose": "Retain the device lock until the user reestablishes access using established identification and authentication procedures."
+                  },
+                  {
+                    "id": "SR-03.01.10.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.10.c"
+                      }
+                    ],
+                    "prose": "Conceal, via the device lock, information previously visible on the display with a publicly viewable image."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.10",
+                "name": "guidance",
+                "prose": "Device locks are temporary actions taken to prevent access to the system when users depart from the immediate vicinity of the system but do not want to log out due to the temporary nature of their absences. Device locks can be implemented at the operating system level or application level. User-initiated device locking is behavior- or policy-based and requires users to take physical action to initiate the device lock. Device locks are not an acceptable substitute for logging out of the system (e.g., when organizations require users to log out at the end of workdays). Publicly viewable images can include static or dynamic images, such as patterns used with screen savers, solid colors, photographic images, a clock, a battery life indicator, or a blank screen with the caveat that controlled unclassified information is not displayed."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.10.a",
+                "name": "assessment-objective",
+                "prose": "access to the system is prevented by {{ insert: param, A.03.01.10.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.10.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.10.c",
+                "name": "assessment-objective",
+                "prose": "information previously visible on the display is concealed via device lock with a publicly viewable image.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.10.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.10.b",
+                "name": "assessment-objective",
+                "prose": "the device lock is retained until the user reestablishes access using established identification and authentication procedures.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.10.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.10_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for session lock and identification and authentication\n\nsystem design documentation\n\nsystem configuration settings\n\ndisplay screen with session lock activated\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.10_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.10_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing the access control policy for session lock\n\nsession lock mechanisms"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.11",
+            "class": "requirement",
+            "title": "Session Termination",
+            "params": [
+              {
+                "id": "A.03.01.11.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.11.ODP[01]"
+                  }
+                ],
+                "label": "conditions or trigger events",
+                "usage": "organization-defined conditions or trigger events requiring session disconnect",
+                "guidelines": [
+                  {
+                    "prose": "conditions or trigger events that require session disconnect are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.11"
+              },
+              {
+                "name": "label",
+                "value": "Session Termination (03.01.11)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#fe6e872e-39da-4949-a8e4-63670f03386e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.11",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.01.11",
+                "name": "guidance",
+                "prose": "This requirement addresses the termination of user-initiated logical sessions in contrast to the termination of network connections that are associated with communications sessions (i.e., disconnecting from the network) in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.09)03.13.09. A logical session is initiated whenever a user (or processes acting on behalf of a user) accesses a system. Logical sessions can be terminated (and thus terminate user access) without terminating network sessions. Session termination ends all system processes associated with a user’s logical session except those processes that are created by the user (i.e., session owner) to continue after the session is terminated. Conditions or trigger events that require automatic session termination can include organization-defined periods of user inactivity, time-of-day restrictions on system use, and targeted responses to certain types of incidents."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.11",
+                "name": "assessment-objective",
+                "prose": "a user session is terminated automatically after {{ insert: param, A.03.01.11.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.11",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.11_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for session termination\n\nsystem design documentation\n\nsystem configuration settings\n\nlist of conditions or trigger events requiring session disconnect\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.11_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.11_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "automated mechanisms for implementing user session termination"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.12",
+            "class": "requirement",
+            "title": "Remote Access",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.12"
+              },
+              {
+                "name": "label",
+                "value": "Remote Access (03.01.12)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#4108e300-3475-4ccc-8e09-7a5bfdd282cf",
+                "rel": "reference"
+              },
+              {
+                "href": "#6a901397-ab79-4174-9af3-96040731a7e3",
+                "rel": "reference"
+              },
+              {
+                "href": "#002ac0fe-a790-4a93-be63-571ecb414e89",
+                "rel": "reference"
+              },
+              {
+                "href": "#f509b76c-728e-4afa-9db3-ed09265f4723",
+                "rel": "reference"
+              },
+              {
+                "href": "#be88bb5c-d994-40f4-b273-3df87369c0ab",
+                "rel": "reference"
+              },
+              {
+                "href": "#68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+                "rel": "reference"
+              },
+              {
+                "href": "#da00e9f9-6829-46d6-bcec-a08ef5556e7f",
+                "rel": "reference"
+              },
+              {
+                "href": "#b684972f-48eb-4a6e-b581-b5e697b3bc19",
+                "rel": "reference"
+              },
+              {
+                "href": "#a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.12",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.12.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.12.a"
+                      }
+                    ],
+                    "prose": "Establish usage restrictions, configuration requirements, and connection requirements for each type of allowable remote system access."
+                  },
+                  {
+                    "id": "SR-03.01.12.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.12.b"
+                      }
+                    ],
+                    "prose": "Authorize each type of remote system access prior to establishing such connections."
+                  },
+                  {
+                    "id": "SR-03.01.12.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.12.c"
+                      }
+                    ],
+                    "prose": "Route remote access to the system through authorized and managed access control points."
+                  },
+                  {
+                    "id": "SR-03.01.12.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.12.d"
+                      }
+                    ],
+                    "prose": "Authorize the remote execution of privileged commands and remote access to security-relevant information."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.12",
+                "name": "guidance",
+                "prose": "Remote access is access to systems (or processes acting on behalf of users) that communicate through external networks, such as the internet. Monitoring and controlling remote access methods allows organizations to detect attacks and ensure compliance with remote access policies. Routing remote access through managed access control points enhances explicit control over such connections and reduces susceptibility to unauthorized access to the system, which could result in the unauthorized disclosure of CUI. Remote access to the system represents a significant potential vulnerability that can be exploited by adversaries. Restricting the execution of privileged commands and access to security-relevant information via remote access reduces the exposure of the organization and its susceptibility to threats by adversaries. A privileged command is a human-initiated command executed on a system that involves the control, monitoring, or administration of the system, including security functions and security-relevant information. Security-relevant information is information that can potentially impact the operation of security functions or the provision of security services in a manner that could result in failure to enforce the system security policy or maintain isolation of code and data. Privileged commands give individuals the ability to execute sensitive, security-critical, or security-relevant system functions."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.a.01",
+                "name": "assessment-objective",
+                "prose": "types of allowable remote system access are defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.a.02",
+                "name": "assessment-objective",
+                "prose": "usage restrictions are established for each type of allowable remote system access.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.a.03",
+                "name": "assessment-objective",
+                "prose": "configuration requirements are established for each type of allowable remote system access.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.a.04",
+                "name": "assessment-objective",
+                "prose": "connection requirements are established for each type of allowable remote system access.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.b",
+                "name": "assessment-objective",
+                "prose": "each type of remote system access is authorized prior to establishing such connections.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.c.01",
+                "name": "assessment-objective",
+                "prose": "remote access to the system is routed through authorized access control points.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.c.02",
+                "name": "assessment-objective",
+                "prose": "remote access to the system is routed through managed access control points.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.d.1",
+                "name": "assessment-objective",
+                "prose": "remote execution of privileged commands is authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.12.d.2",
+                "name": "assessment-objective",
+                "prose": "remote access to security-relevant information is authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.12.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.12_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for remote system access\n\nremote system access configuration and connection requirements\n\nconfiguration management plan\n\nsystem configuration settings\n\nremote access authorizations\n\nsystem audit records\n\nsystem design documentation\n\nprocedures for remote access to the system\n\nsystem monitoring records\n\nlist of managed network access control points\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.12_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for managing remote access connections\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.12_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for monitoring and controlling remote access methods\n\nmechanisms for routing remote accesses through managed access control points\n\nremote access management capability for the system"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.13",
+            "class": "requirement",
+            "title": "03.01.13",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.13"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.13.08",
+                "rel": "addressed_by"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.14",
+            "class": "requirement",
+            "title": "03.01.14",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.14"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.12",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.15",
+            "class": "requirement",
+            "title": "03.01.15",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.15"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.12",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.16",
+            "class": "requirement",
+            "title": "Wireless Access",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.16"
+              },
+              {
+                "name": "label",
+                "value": "Wireless Access (03.01.16)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b22943e2-fcb6-43b7-8895-eeff60a3a222",
+                "rel": "reference"
+              },
+              {
+                "href": "#1db363ba-2f6c-43d9-aed7-37c23fd45f9d",
+                "rel": "reference"
+              },
+              {
+                "href": "#799f75c1-3e9a-47a1-994f-a7bf60460550",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#ad479a27-d988-4830-b855-5acf7c5a9efa",
+                "rel": "reference"
+              },
+              {
+                "href": "#ff9a9661-8d87-4750-a2c4-d781dd3c98dd",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.16",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.16.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.16.a"
+                      }
+                    ],
+                    "prose": "Establish usage restrictions, configuration requirements, and connection requirements for each type of wireless access to the system."
+                  },
+                  {
+                    "id": "SR-03.01.16.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.16.b"
+                      }
+                    ],
+                    "prose": "Authorize each type of wireless access to the system prior to establishing such connections."
+                  },
+                  {
+                    "id": "SR-03.01.16.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.16.c"
+                      }
+                    ],
+                    "prose": "Disable, when not intended for use, wireless networking capabilities prior to issuance and deployment."
+                  },
+                  {
+                    "id": "SR-03.01.16.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.16.d"
+                      }
+                    ],
+                    "prose": "Protect wireless access to the system using authentication and encryption."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.16",
+                "name": "guidance",
+                "prose": "Wireless networking capabilities represent a significant potential vulnerability that can be exploited by adversaries. Establishing usage restrictions, configuration requirements, and connection requirements for wireless access to the system provides criteria to support access authorization decisions. These restrictions and requirements reduce susceptibility to unauthorized system access through wireless technologies. Wireless networks use authentication protocols that provide credential protection and mutual authentication. Organizations authenticate individuals and devices to protect wireless access to the system. Special attention is given to the variety of devices with potential wireless access to the system, including small form factor mobile devices (e.g., smart phones, tablets, smart watches). Wireless networking capabilities that are embedded within system components represent a potential vulnerability that can be exploited by adversaries. Strong authentication of users and devices, strong encryption, and disabling wireless capabilities that are not needed for essential mission or business functions can reduce susceptibility to threats by adversaries involving wireless technologies."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.a.01",
+                "name": "assessment-objective",
+                "prose": "each type of wireless access to the system is defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.a.02",
+                "name": "assessment-objective",
+                "prose": "usage restrictions are established for each type of wireless access to the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.a.03",
+                "name": "assessment-objective",
+                "prose": "configuration requirements are established for each type of wireless access to the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.a.04",
+                "name": "assessment-objective",
+                "prose": "connection requirements are established for each type of wireless access to the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.b",
+                "name": "assessment-objective",
+                "prose": "each type of wireless access to the system is authorized prior to establishing such connections.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.c",
+                "name": "assessment-objective",
+                "prose": "wireless networking capabilities not intended for use are disabled prior to issuance and deployment.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.d.01",
+                "name": "assessment-objective",
+                "prose": "wireless access to the system is protected using authentication.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.16.d.02",
+                "name": "assessment-objective",
+                "prose": "wireless access to the system is protected using encryption.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.16.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.16_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for wireless system access\n\nwireless system access configuration and connection requirements\n\nconfiguration management plan\n\nsystem configuration settings\n\nwireless access authorizations\n\nsystem audit records\n\nsystem design documentation\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.16_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for managing wireless access connections\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.16_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "wireless access management capability for the system\n\nmechanisms for implementing wireless access protections to the system\n\nmechanisms for managing the disabling of wireless networking capabilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.17",
+            "class": "requirement",
+            "title": "03.01.17",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.17"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.16",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.18",
+            "class": "requirement",
+            "title": "Access Control for Mobile Devices",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.18"
+              },
+              {
+                "name": "label",
+                "value": "Access Control for Mobile Devices (03.01.18)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#600d351d-0d99-4789-abcd-3a1dfcce2d52",
+                "rel": "reference"
+              },
+              {
+                "href": "#c436a93b-debb-411e-a0d6-81e2f6cb49d5",
+                "rel": "reference"
+              },
+              {
+                "href": "#68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#b684972f-48eb-4a6e-b581-b5e697b3bc19",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.18",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.18.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.18.a"
+                      }
+                    ],
+                    "prose": "Establish usage restrictions, configuration requirements, and connection requirements for mobile devices."
+                  },
+                  {
+                    "id": "SR-03.01.18.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.18.b"
+                      }
+                    ],
+                    "prose": "Authorize the connection of mobile devices to the system."
+                  },
+                  {
+                    "id": "SR-03.01.18.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.18.c"
+                      }
+                    ],
+                    "prose": "Implement full-device or container-based encryption to protect the confidentiality of CUI on mobile devices."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.18",
+                "name": "guidance",
+                "prose": "A mobile device is a computing device with a small form factor such that it can be carried by a single individual; is designed to operate without a physical connection; possesses local, non-removable, or removable data storage; and includes a self-contained power source. Mobile device functionality may include on-board sensors that allow the device to capture information, voice communication capabilities, and/or built-in features for synchronizing local data with remote locations. Examples include smart phones, smart watches, and tablets. Mobile devices are typically associated with a single individual. The processing, storage, and transmission capabilities of mobile devices may be comparable to or a subset of notebook or desktop systems, depending on the nature and intended purpose of the device. Some organizations may consider notebook computers to be mobile devices. The protection and control of mobile devices are behavior- or policy-based and require users to take physical action to protect and control such devices when outside of controlled areas. Controlled areas are spaces for which the organization provides physical or procedural controls to meet the requirements established for protecting CUI. Due to the large variety of mobile devices with different characteristics and capabilities, organizational restrictions may vary for the different classes or types of such devices. Usage restrictions, configuration requirements, and connection requirements for mobile devices include configuration management, device identification and authentication, implementing mandatory protective software, scanning devices for malicious code, updating virus protection software, scanning for critical software updates and patches, conducting operating system and possibly other software integrity checks, and disabling unnecessary hardware. On mobile devices, secure containers provide software-based data isolation designed to segment enterprise applications and information from personal apps and data. Containers may present multiple user interfaces, one of the most common being a mobile application that acts as a portal to a suite of business productivity apps, such as email, contacts, and calendar. Organizations can employ full-device encryption or container-based encryption to protect the confidentiality of CUI on mobile devices."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.18.a.01",
+                "name": "assessment-objective",
+                "prose": "usage restrictions are established for mobile devices.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.18.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.18.a.02",
+                "name": "assessment-objective",
+                "prose": "configuration requirements are established for mobile devices.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.18.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.18.a.03",
+                "name": "assessment-objective",
+                "prose": "connection requirements are established for mobile devices.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.18.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.18.b",
+                "name": "assessment-objective",
+                "prose": "the connection of mobile devices to the system is authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.18.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.18.c",
+                "name": "assessment-objective",
+                "prose": "full-device or container-based encryption is implemented to protect the confidentiality of CUI on mobile devices.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.18.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.18_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for mobile device access control\n\nsystem design documentation\n\nconfiguration management plan\n\nsystem configuration settings\n\nauthorizations for mobile device connections to organizational systems\n\nsystem audit records\n\nencryption mechanisms and associated configuration documentation\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.18_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with access control responsibilities for mobile devices\n\npersonnel using mobile devices to access organizational systems\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.18_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control capability for mobile device connections to organizational systems\n\nencryption mechanisms for protecting the confidentiality of CUI on mobile devices\n\nconfigurations of mobile devices"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.19",
+            "class": "requirement",
+            "title": "03.01.19",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.19"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.18",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.20",
+            "class": "requirement",
+            "title": "Use of External Systems",
+            "params": [
+              {
+                "id": "A.03.01.20.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.01.20.ODP[01]"
+                  }
+                ],
+                "label": "security requirements",
+                "usage": "organization-defined security requirements",
+                "guidelines": [
+                  {
+                    "prose": "security requirements to be satisfied on external systems prior to allowing the use of or access to those systems by authorized individuals are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.20"
+              },
+              {
+                "name": "label",
+                "value": "Use of External Systems (03.01.20)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#45969a10-8816-4ae0-abc4-d0c1764bab75",
+                "rel": "reference"
+              },
+              {
+                "href": "#52fd9e23-defd-4647-a7d2-b96416edefc9",
+                "rel": "reference"
+              },
+              {
+                "href": "#50c6d509-5e60-4b57-802c-1c5253946ef4",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.20",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.20.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.20.a"
+                      }
+                    ],
+                    "prose": "Prohibit the use of external systems unless the systems are specifically authorized."
+                  },
+                  {
+                    "id": "SR-03.01.20.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.20.b"
+                      }
+                    ],
+                    "prose": "Establish the following security requirements to be satisfied on external systems prior to allowing use of or access to those systems by authorized individuals: {{ insert: param, A.03.01.20.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.01.20.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.20.c"
+                      }
+                    ],
+                    "prose": "Permit authorized individuals to use external systems to access the organizational system or to process, store, or transmit CUI only after:",
+                    "parts": [
+                      {
+                        "id": "SR-03.01.20.c.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.20.c.01"
+                          }
+                        ],
+                        "prose": "Verifying that the security requirements on the external systems as specified in the organization’s system security plans have been satisfied and"
+                      },
+                      {
+                        "id": "SR-03.01.20.c.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.01.20.c.02"
+                          }
+                        ],
+                        "prose": "Retaining approved system connection or processing agreements with the organizational entities hosting the external systems."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.01.20.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.20.d"
+                      }
+                    ],
+                    "prose": "Restrict the use of organization-controlled portable storage devices by authorized individuals on external systems."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.20",
+                "name": "guidance",
+                "prose": "External systems are systems that are used by but are not part of the organization. These systems include personally owned systems, system components, or devices; privately owned computing and communication devices in commercial or public facilities; systems owned or controlled by nonfederal organizations; and systems managed by contractors. Organizations have the option to prohibit the use of any type of external system or specified types of external systems (e.g., prohibit the use of external systems that are not organizationally owned). Terms and conditions are consistent with the trust relationships established with the entities that own, operate, or maintain external systems and include descriptions of shared responsibilities. Authorized individuals include organizational personnel, contractors, or other individuals with authorized access to the organizational system and over whom organizations have the authority to impose specific rules of behavior regarding system access. Restrictions that organizations impose on authorized individuals may vary depending on the trust relationships between organizations. Organizations need assurance that external systems satisfy the necessary security requirements so as not to compromise, damage, or harm the system. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.16.03) 03.16.03."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.20.b",
+                "name": "assessment-objective",
+                "prose": "the following security requirements to be satisfied on external systems prior to allowing the use of or access to those systems by authorized individuals are established: {{ insert: param, A.03.01.20.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.20.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.20.a",
+                "name": "assessment-objective",
+                "prose": "the use of external systems is prohibited unless the systems are specifically authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.20.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.20.c.01",
+                "name": "assessment-objective",
+                "prose": "authorized individuals are permitted to use external systems to access the organizational system or to process, store, or transmit CUI only after verifying that the security requirements on the external systems as specified in the organization’s system security plans have been satisfied.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.20.c.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.20.d",
+                "name": "assessment-objective",
+                "prose": "the use of organization-controlled portable storage devices by authorized individuals on external systems is restricted.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.20.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.20.c.02",
+                "name": "assessment-objective",
+                "prose": "authorized individuals are permitted to use external systems to access the organizational system or to process, store, or transmit CUI only after retaining approved system connection or processing agreements with the organizational entity hosting the external systems.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.20.c.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.01.20_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for the use of external systems\n\nterms and conditions for the use of external systems\n\nexternal systems security requirements\n\nlist of types of applications accessible from external systems\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.01.20_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for defining terms, conditions, and security requirements for the use of external systems\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.01.20_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing or enforcing terms, conditions, and security requirements for the use of external systems"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.21",
+            "class": "requirement",
+            "title": "03.01.21",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.21"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.20",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.01.22",
+            "class": "requirement",
+            "title": "Publicly Accessible Content",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.01.22"
+              },
+              {
+                "name": "label",
+                "value": "Publicly Accessible Content (03.01.22)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#08316684-be23-473a-abd0-22abe611ad1a",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.01.22",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.01.22.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.22.a"
+                      }
+                    ],
+                    "prose": "Train authorized individuals to ensure that publicly accessible information does not contain CUI."
+                  },
+                  {
+                    "id": "SR-03.01.22.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.01.22.b"
+                      }
+                    ],
+                    "prose": "Review the content on publicly accessible systems for CUI and remove such information, if discovered."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.01.22",
+                "name": "guidance",
+                "prose": "In accordance with applicable laws, Executive Orders, directives, policies, regulations, standards, and guidelines, the public is not authorized to have access to nonpublic information, including CUI."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.22.a",
+                "name": "assessment-objective",
+                "prose": "authorized individuals are trained to ensure that publicly accessible information does not contain CUI.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.22.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.22.b.01",
+                "name": "assessment-objective",
+                "prose": "the content on publicly accessible systems is reviewed for CUI.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.22.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.01.22.b.02",
+                "name": "assessment-objective",
+                "prose": "CUI is removed from publicly accessible systems, if discovered.",
+                "links": [
+                  {
+                    "href": "#SR-03.01.22.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.02",
+        "class": "family",
+        "title": "Awareness and Training",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.02"
+          },
+          {
+            "name": "label",
+            "value": "Awareness and Training (03.02)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.02.01",
+            "class": "requirement",
+            "title": "Literacy Training and Awareness",
+            "params": [
+              {
+                "id": "A.03.02.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to provide security literacy training to system users after initial training is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.02.01.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.01.ODP[02]"
+                  }
+                ],
+                "label": "events",
+                "usage": "organization-defined events",
+                "guidelines": [
+                  {
+                    "prose": "events that require security literacy training for system users are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.02.01.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.01.ODP[03]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to update security literacy training content is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.02.01.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.01.ODP[04]"
+                  }
+                ],
+                "label": "events",
+                "usage": "organization-defined events",
+                "guidelines": [
+                  {
+                    "prose": "events that require security literacy training content updates are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.02.01"
+              },
+              {
+                "name": "label",
+                "value": "Literacy Training and Awareness (03.02.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#1e4af45a-f817-429e-a939-be1e7238053a",
+                "rel": "reference"
+              },
+              {
+                "href": "#7caa0224-60eb-4edf-b9ee-b1ac525fad00",
+                "rel": "reference"
+              },
+              {
+                "href": "#e3551468-48c6-4be0-990d-6c9a8a23af0d",
+                "rel": "reference"
+              },
+              {
+                "href": "#fa117c16-587d-4163-a421-e35553768633",
+                "rel": "reference"
+              },
+              {
+                "href": "#6af8bc6f-a2ce-4b74-bc88-507d5bbc0c33",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.02.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.02.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.02.01.a"
+                      }
+                    ],
+                    "prose": "Provide security literacy training to system users:",
+                    "parts": [
+                      {
+                        "id": "SR-03.02.01.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.02.01.a.01"
+                          }
+                        ],
+                        "prose": "As part of initial training for new users and {{ insert: param, A.03.02.01.ODP.01 }} thereafter,"
+                      },
+                      {
+                        "id": "SR-03.02.01.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.02.01.a.02"
+                          }
+                        ],
+                        "prose": "When required by system changes or following {{ insert: param, A.03.02.01.ODP.02 }}, and"
+                      },
+                      {
+                        "id": "SR-03.02.01.a.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.02.01.a.03"
+                          }
+                        ],
+                        "prose": "On recognizing and reporting indicators of insider threat, social engineering, and social mining."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.02.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.02.01.b"
+                      }
+                    ],
+                    "prose": "Update security literacy training content {{ insert: param, A.03.02.01.ODP.03 }} and following {{ insert: param, A.03.02.01.ODP.04 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.02.01",
+                "name": "guidance",
+                "prose": "Organizations provide basic and advanced levels of security literacy training to system users (including managers, senior executives, system administrators, and contractors) and measures to test the knowledge level of users. Organizations determine the content of literacy training based on specific organizational requirements, the systems to which personnel have authorized access, and work environments (e.g., telework). The content includes an understanding of the need for security and the actions required of users to maintain security and respond to incidents. The content also addresses the need for operations security and the handling of CUI. Security awareness techniques include displaying posters, offering supplies inscribed with security reminders, generating email advisories or notices from organizational officials, displaying logon screen messages, and conducting awareness events using podcasts, videos, and webinars. Security literacy training is conducted at a frequency consistent with applicable laws, directives, regulations, and policies. Updating literacy training content on a regular basis ensures that the content remains relevant. Events that may precipitate an update to literacy training content include assessment or audit findings, security incidents or breaches, or changes in applicable laws, Executive Orders, directives, regulations, policies, standards, and guidelines. Potential indicators and possible precursors of insider threats include behaviors such as inordinate, long-term job dissatisfaction; attempts to gain access to information that is not required for job performance; unexplained access to financial resources; sexual harassment or bullying of fellow employees; workplace violence; and other serious violations of the policies, procedures, rules, directives, or practices of organizations. Organizations may consider tailoring insider threat awareness topics to roles (e.g., training for managers may be focused on specific changes in the behavior of team members, while training for employees may be focused on more general observations). Social engineering is an attempt to deceive an individual into revealing information or taking an action that can be used to breach, compromise, or otherwise adversely impact a system. Social engineering includes phishing, pretexting, impersonation, baiting, quid pro quo, threadjacking, social media exploitation, and tailgating. Social mining is an attempt to gather information about the organization that may be used to support future attacks. Security literacy training includes how to communicate employee and management concerns regarding potential indicators of insider threat and potential and actual instances of social engineering and data mining through appropriate organizational channels in accordance with established policies and procedures."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.01.01",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users as part of initial training for new users.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.01.02",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users {{ insert: param, A.03.02.01.ODP.01 }} after initial training.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.02",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users when required by system changes or following {{ insert: param, A.03.02.01.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.03.01",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users on recognizing indicators of insider threat.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.03.02",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users on reporting indicators of insider threat.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.03.03",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users on recognizing indicators of social engineering.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.03.04",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users on reporting indicators of social engineering.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.03.05",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users on recognizing indicators of social mining.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.a.03.06",
+                "name": "assessment-objective",
+                "prose": "security literacy training is provided to system users on reporting indicators of social mining.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.b.01",
+                "name": "assessment-objective",
+                "prose": "security literacy training content is updated {{ insert: param, A.03.02.01.ODP.03 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.01.b.02",
+                "name": "assessment-objective",
+                "prose": "security literacy training content is updated following {{ insert: param, A.03.02.01.ODP.04 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.02.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security literacy training and awareness policy and procedures\n\nprocedures for security literacy training and awareness implementation\n\ncodes of federal regulations\n\nsecurity literacy and awareness training curriculum\n\nsecurity literacy and awareness training materials\n\ntraining records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.02.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for security literacy training and awareness\n\npersonnel comprising the general system user community\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.02.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for managing information security literacy training and awareness"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.02.02",
+            "class": "requirement",
+            "title": "Role-Based Training",
+            "params": [
+              {
+                "id": "A.03.02.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.02.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to provide role-based security training to assigned personnel after initial training is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.02.02.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.02.ODP[02]"
+                  }
+                ],
+                "label": "events",
+                "usage": "organization-defined events",
+                "guidelines": [
+                  {
+                    "prose": "events that require role-based security training are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.02.02.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.02.ODP[03]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to update role-based security training content is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.02.02.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.02.02.ODP[04]"
+                  }
+                ],
+                "label": "events",
+                "usage": "organization-defined events",
+                "guidelines": [
+                  {
+                    "prose": "events that require role-based security training content updates are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.02.02"
+              },
+              {
+                "name": "label",
+                "value": "Role-Based Training (03.02.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#8ad19edd-17dd-4b97-af50-1e49d362148e",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              },
+              {
+                "href": "#2932aa8a-9447-435b-9fc8-98b82b6e617c",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.02.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.02.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.02.02.a"
+                      }
+                    ],
+                    "prose": "Provide role-based security training to organizational personnel:",
+                    "parts": [
+                      {
+                        "id": "SR-03.02.02.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.02.02.a.01"
+                          }
+                        ],
+                        "prose": "Before authorizing access to the system or CUI, before performing assigned duties, and {{ insert: param, A.03.02.02.ODP.01 }} thereafter"
+                      },
+                      {
+                        "id": "SR-03.02.02.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.02.02.a.02"
+                          }
+                        ],
+                        "prose": "When required by system changes or following {{ insert: param, A.03.02.02.ODP.02 }}."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.02.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.02.02.b"
+                      }
+                    ],
+                    "prose": "Update role-based training content {{ insert: param, A.03.02.02.ODP.03 }} and following {{ insert: param, A.03.02.02.ODP.04 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.02.02",
+                "name": "guidance",
+                "prose": "Organizations determine the content and frequency of security training based on the assigned duties, roles, and responsibilities of individuals and the security requirements of the systems to which personnel have authorized access. In addition, organizations provide system developers, enterprise architects, security architects, software developers, systems integrators, acquisition/procurement officials, system and network administrators, personnel conducting configuration management and auditing activities, personnel performing independent verification and validation, security assessors, and personnel with access to system-level software with security-related technical training specifically tailored for their assigned duties. Comprehensive role-based training addresses management, operational, and technical roles and responsibilities that cover physical, personnel, and technical controls. Such training can include policies, procedures, tools, and artifacts for the security roles defined. Organizations also provide the training necessary for individuals to carry out their responsibilities related to operations and supply chain security within the context of organizational information security programs."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.02.a.01.01",
+                "name": "assessment-objective",
+                "prose": "role-based security training is provided to organizational personnel before authorizing access to the system or CUI.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.02.a.01.02",
+                "name": "assessment-objective",
+                "prose": "role-based security training is provided to organizational personnel before performing assigned duties.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.02.a.01.03",
+                "name": "assessment-objective",
+                "prose": "role-based security training is provided to organizational personnel {{ insert: param, A.03.02.02.ODP.01 }} after initial training.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.02.a.02",
+                "name": "assessment-objective",
+                "prose": "role-based security training is provided to organizational personnel when required by system changes or following {{ insert: param, A.03.02.02.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.02.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.02.b.01",
+                "name": "assessment-objective",
+                "prose": "role-based security training content is updated {{ insert: param, A.03.02.02.ODP.03 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.02.02.b.02",
+                "name": "assessment-objective",
+                "prose": "role-based security training content is updated following {{ insert: param, A.03.02.02.ODP.04 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.02.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.02.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security awareness and training policy and procedures\n\nprocedures for security training implementation\n\ncodes of federal regulations\n\nsecurity training curriculum\n\nsecurity training materials\n\ntraining records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.02.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for role-based security training\n\npersonnel with assigned system security roles and responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.02.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for managing role-based security training and awareness"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.02.03",
+            "class": "requirement",
+            "title": "03.02.03",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.02.03"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.02.01",
+                "rel": "incorporated_into"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.03",
+        "class": "family",
+        "title": "Audit and Accountability",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.03"
+          },
+          {
+            "name": "label",
+            "value": "Audit and Accountability (03.03)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.03.01",
+            "class": "requirement",
+            "title": "Event Logging",
+            "params": [
+              {
+                "id": "A.03.03.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.03.01.ODP[01]"
+                  }
+                ],
+                "label": "event types",
+                "usage": "organization-defined event types",
+                "guidelines": [
+                  {
+                    "prose": "event types selected for logging within the system are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.03.01.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.03.01.ODP[02]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency of event types selected for logging are reviewed and updated."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.01"
+              },
+              {
+                "name": "label",
+                "value": "Event Logging (03.03.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b6f9285b-ea87-4695-bad2-90b412875f43",
+                "rel": "reference"
+              },
+              {
+                "href": "#96810306-d115-4307-ab9a-baf41aebfc18",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.01.a"
+                      }
+                    ],
+                    "prose": "Specify the following event types selected for logging within the system: {{ insert: param, A.03.03.01.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.03.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.01.b"
+                      }
+                    ],
+                    "prose": "Review and update the event types selected for logging {{ insert: param, A.03.03.01.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.01",
+                "name": "guidance",
+                "prose": "An event is any observable occurrence in a system, including unlawful or unauthorized system activity. Organizations identify event types for which a logging functionality is needed. This includes events that are relevant to the security of systems and the environments in which those systems operate to meet specific and ongoing auditing needs. Event types can include password changes, the execution of privileged functions, failed logons or accesses related to systems, administrative privilege usage, or third-party credential usage. In determining event types that require logging, organizations consider the system monitoring and auditing that are appropriate for each of the security requirements. When defining event types, organizations consider the logging necessary to cover related events, such as the steps in distributed, transaction-based processes (e.g., processes that are distributed across multiple organizations) and actions that occur in service-oriented or cloud-based architectures. Monitoring and auditing requirements can be balanced with other system needs. For example, organizations may determine that systems must have the capability to log every file access — both successful and unsuccessful — but only activate that capability under specific circumstances due to the potential burden on system performance. The event types that are logged by organizations may change over time. Reviewing and updating the set of logged event types are necessary to ensure that the current set of event types remains relevant."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.01.a",
+                "name": "assessment-objective",
+                "prose": "the following event types are specified for logging within the system: {{ insert: param, A.03.03.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.01.b.01",
+                "name": "assessment-objective",
+                "prose": "the event types selected for logging are reviewed {{ insert: param, A.03.03.01.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.01.b.02",
+                "name": "assessment-objective",
+                "prose": "the event types selected for logging are updated {{ insert: param, A.03.03.01.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for auditable events\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem auditable events\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit and accountability responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing system auditing"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.02",
+            "class": "requirement",
+            "title": "Audit Record Content",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.02"
+              },
+              {
+                "name": "label",
+                "value": "Audit Record Content (03.03.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#31e8b262-8a1c-4609-871f-6b0edfc18b5d",
+                "rel": "reference"
+              },
+              {
+                "href": "#d32c0a1b-6b01-4370-906d-c2787796a25a",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.02.a"
+                      }
+                    ],
+                    "prose": "Include the following content in audit records:",
+                    "parts": [
+                      {
+                        "id": "SR-03.03.02.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.03.02.a.01"
+                          }
+                        ],
+                        "prose": "What type of event occurred"
+                      },
+                      {
+                        "id": "SR-03.03.02.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.03.02.a.02"
+                          }
+                        ],
+                        "prose": "When the event occurred"
+                      },
+                      {
+                        "id": "SR-03.03.02.a.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.03.02.a.03"
+                          }
+                        ],
+                        "prose": "Where the event occurred"
+                      },
+                      {
+                        "id": "SR-03.03.02.a.04",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.03.02.a.04"
+                          }
+                        ],
+                        "prose": "Source of the event"
+                      },
+                      {
+                        "id": "SR-03.03.02.a.05",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.03.02.a.05"
+                          }
+                        ],
+                        "prose": "Outcome of the event"
+                      },
+                      {
+                        "id": "SR-03.03.02.a.06",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.03.02.a.06"
+                          }
+                        ],
+                        "prose": "Identity of the individuals, subjects, objects, or entities associated with the event"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.03.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.02.b"
+                      }
+                    ],
+                    "prose": "Provide additional information for audit records as needed."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.02",
+                "name": "guidance",
+                "prose": "Audit record content that may be necessary to support the auditing function includes time stamps, source and destination addresses, user or process identifiers, event descriptions, file names, and the access control or flow control rules that are invoked. Event outcomes can include indicators of event success or failure and event-specific results (e.g., the security state of the system after the event occurred). Detailed information that organizations consider in audit records may include a full text recording of privileged commands or the individual identities of group account users."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.a.01",
+                "name": "assessment-objective",
+                "prose": "audit records contain information that establishes what type of event occurred.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.a.02",
+                "name": "assessment-objective",
+                "prose": "audit records contain information that establishes when the event occurred.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.a.03",
+                "name": "assessment-objective",
+                "prose": "audit records contain information that establishes where the event occurred.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.a.04",
+                "name": "assessment-objective",
+                "prose": "audit records contain information that establishes the source of the event.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.a.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.a.05",
+                "name": "assessment-objective",
+                "prose": "audit records contain information that establishes the outcome of the event.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.a.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.a.06",
+                "name": "assessment-objective",
+                "prose": "audit records contain information that establishes the identity of the individuals, subjects, objects, or entities associated with the event.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.a.06",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.02.b",
+                "name": "assessment-objective",
+                "prose": "additional information for audit records is provided, as needed.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for the content of audit records\n\nlist of organization-defined auditable events\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem incident reports\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit and accountability responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing system auditing of auditable events\n\nsystem audit capability"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.03",
+            "class": "requirement",
+            "title": "Audit Record Generation",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.03"
+              },
+              {
+                "name": "label",
+                "value": "Audit Record Generation (03.03.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#c6c510a7-6932-4d6d-9d1e-f51196efded7",
+                "rel": "reference"
+              },
+              {
+                "href": "#9389a9df-1134-499e-8d25-c55eb991f169",
+                "rel": "reference"
+              },
+              {
+                "href": "#96810306-d115-4307-ab9a-baf41aebfc18",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.03",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.03.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.03.a"
+                      }
+                    ],
+                    "prose": "Generate audit records for the selected event types and audit record content specified in 03.03.01 and 03.03.02."
+                  },
+                  {
+                    "id": "SR-03.03.03.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.03.b"
+                      }
+                    ],
+                    "prose": "Retain audit records for a time period consistent with the records retention policy."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.03",
+                "name": "guidance",
+                "prose": "Audit records can be generated at various levels of abstraction, including at the packet level as information traverses the network. Selecting the appropriate level of abstraction is a critical aspect of an audit logging capability and can facilitate the identification of root causes to problems. The ability to add information generated in audit records is dependent on system functionality to configure the audit record content. Organizations may consider additional information in audit records, including the access control or flow control rules invoked and the individual identities of group account users. Organizations may also consider limiting additional audit record information to only information that is explicitly needed for audit requirements."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.03.a",
+                "name": "assessment-objective",
+                "prose": "audit records for the selected event types and audit record content specified in 03.03.01 and 03.03.02 are generated.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.03.b",
+                "name": "assessment-objective",
+                "prose": "audit records are retained for a time period consistent with the records retention policy.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for audit record generation\n\nsystem design documentation\n\nlist of auditable events\n\nsystem audit records\n\naudit record retention policy and procedures\n\norganization-defined retention period for audit records\n\naudit record archives\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit record generation responsibilities\n\npersonnel with audit record retention responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing the audit record generation capability"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.04",
+            "class": "requirement",
+            "title": "Response to Audit Logging Process Failures",
+            "params": [
+              {
+                "id": "A.03.03.04.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.03.04.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period for organizational personnel or roles receiving audit logging process failure alerts is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.03.04.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.03.04.ODP[02]"
+                  }
+                ],
+                "label": "additional actions",
+                "usage": "organization-defined additional actions",
+                "guidelines": [
+                  {
+                    "prose": "additional actions to be taken in the event of an audit logging process failure are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.04"
+              },
+              {
+                "name": "label",
+                "value": "Response to Audit Logging Process Failures (03.03.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#146e7fde-bdf0-409f-958f-9c7bad66a557",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.04",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.04.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.04.a"
+                      }
+                    ],
+                    "prose": "Alert organizational personnel or roles within {{ insert: param, A.03.03.04.ODP.01 }} in the event of an audit logging process failure."
+                  },
+                  {
+                    "id": "SR-03.03.04.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.04.b"
+                      }
+                    ],
+                    "prose": "Take the following additional actions: {{ insert: param, A.03.03.04.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.04",
+                "name": "guidance",
+                "prose": "Audit logging process failures include software and hardware errors, failures in audit log capturing mechanisms, and reaching or exceeding audit log storage capacity. Response actions include overwriting the oldest audit records, shutting down the system, and stopping the generation of audit records. Organizations may choose to define additional actions for audit logging process failures based on the type of failure, the location of the failure, the severity of the failure, or a combination of such factors. When the audit logging process failure is related to storage, the response is carried out for the audit log storage repository (i.e., the distinct system component where the audit logs are stored), the system on which the audit logs reside, the total audit log storage capacity of the organization (i.e., all audit log storage repositories combined), or all three. Organizations may decide to take no additional actions after alerting designated roles or personnel."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.04.a",
+                "name": "assessment-objective",
+                "prose": "organizational personnel or roles are alerted in the event of an audit logging process failure within {{ insert: param, A.03.03.04.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.04.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.04.b",
+                "name": "assessment-objective",
+                "prose": "the following additional actions are taken: {{ insert: param, A.03.03.04.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for responding to audit processing failures\n\nsystem design documentation\n\nsystem configuration settings\n\nlist of personnel to be notified in case of an audit processing failure\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit and accountability responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing system response to audit processing failures"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.05",
+            "class": "requirement",
+            "title": "Audit Record Review, Analysis, and Reporting",
+            "params": [
+              {
+                "id": "A.03.03.05.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.03.05.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which system audit records are reviewed and analyzed is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.05"
+              },
+              {
+                "name": "label",
+                "value": "Audit Record Review, Analysis, and Reporting (03.03.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#af41f34c-51be-4909-aa89-fe15ac8a12c9",
+                "rel": "reference"
+              },
+              {
+                "href": "#8d9b081e-58b2-4178-a69d-5372d29a8e7e",
+                "rel": "reference"
+              },
+              {
+                "href": "#390132ba-7532-4fb8-83fc-58b930857b77",
+                "rel": "reference"
+              },
+              {
+                "href": "#d1d734b3-9384-42b3-968c-5ba2939626ee",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.05.a"
+                      }
+                    ],
+                    "prose": "Review and analyze system audit records {{ insert: param, A.03.03.05.ODP.01 }} for indications and the potential impact of inappropriate or unusual activity."
+                  },
+                  {
+                    "id": "SR-03.03.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.05.b"
+                      }
+                    ],
+                    "prose": "Report findings to organizational personnel or roles."
+                  },
+                  {
+                    "id": "SR-03.03.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.05.c"
+                      }
+                    ],
+                    "prose": "Analyze and correlate audit records across different repositories to gain organization-wide situational awareness."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.05",
+                "name": "guidance",
+                "prose": "Audit record review, analysis, and reporting cover information security logging performed by organizations and can include logging that results from the monitoring of account usage, remote access, wireless connectivity, configuration settings, the use of maintenance tools and nonlocal maintenance, system component inventory, mobile device connection, equipment delivery and removal, physical access, temperature and humidity, communications at system interfaces, and the use of mobile code. Findings can be reported to organizational entities, such as the incident response team, help desk, and security or privacy offices. If organizations are prohibited from reviewing and analyzing audit records or unable to conduct such activities, the review or analysis may be carried out by other organizations granted such authority. The scope, frequency, and/or depth of the audit record review, analysis, and reporting may be adjusted to meet organizational needs based on new information received. Correlating audit record review, analysis, and reporting processes helps to ensure that audit records collectively create a more complete view of events."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.05.a",
+                "name": "assessment-objective",
+                "prose": "system audit records are reviewed and analyzed {{ insert: param, A.03.03.05.ODP.01 }} for indications and the potential impact of inappropriate or unusual activity.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.05.b",
+                "name": "assessment-objective",
+                "prose": "findings are reported to organizational personnel or roles.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.05.c.01",
+                "name": "assessment-objective",
+                "prose": "audit records across different repositories are analyzed to gain organization-wide situational awareness.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.05.c.02",
+                "name": "assessment-objective",
+                "prose": "audit records across different repositories are correlated to gain organization-wide situational awareness.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for audit record review, analysis, and reporting\n\nreports of audit record findings\n\nrecords of actions taken in response to reviews and analyses of audit records\n\nsystem design documentation\n\nsystem audit records across different repositories\n\nsystem security plan\n\nsystem configuration settings\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit record review, analysis, and reporting responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting the analysis and correlation of audit records"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.06",
+            "class": "requirement",
+            "title": "Audit Record Reduction and Report Generation",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.06"
+              },
+              {
+                "name": "label",
+                "value": "Audit Record Reduction and Report Generation (03.03.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#6ee136ad-bb59-42aa-8f60-7d3a7b6fecdd",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.06",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.06.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.06.a"
+                      }
+                    ],
+                    "prose": "Implement an audit record reduction and report generation capability that supports audit record review, analysis, reporting requirements, and after-the-fact investigations of incidents."
+                  },
+                  {
+                    "id": "SR-03.03.06.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.06.b"
+                      }
+                    ],
+                    "prose": "Preserve the original content and time ordering of audit records."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.06",
+                "name": "guidance",
+                "prose": "Audit records are generated in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.03.03)03.03.03. Audit record reduction and report generation occur after audit record generation. Audit record reduction is a process that manipulates collected audit information and organizes it in a summary format that is more meaningful to analysts. Audit record reduction and report generation capabilities do not always come from the same system or organizational entities that conduct auditing activities. An audit record reduction capability can include, for example, modern data mining techniques with advanced data filters to identify anomalous behavior in audit records. The report generation capability provided by the system can help generate customizable reports. The time ordering of audit records can be a significant issue if the granularity of the time stamp in the record is insufficient."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.06.a.01",
+                "name": "assessment-objective",
+                "prose": "an audit record reduction and report generation capability that supports audit record review is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.06.a.02",
+                "name": "assessment-objective",
+                "prose": "an audit record reduction and report generation capability that supports audit record analysis is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.06.a.03",
+                "name": "assessment-objective",
+                "prose": "an audit record reduction and report generation capability that supports audit record reporting requirements is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.06.a.04",
+                "name": "assessment-objective",
+                "prose": "an audit record reduction and report generation capability that supports after-the-fact investigations of incidents is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.06.b.01",
+                "name": "assessment-objective",
+                "prose": "the original content of audit records is preserved.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.06.b.02",
+                "name": "assessment-objective",
+                "prose": "the original time ordering of audit records is preserved.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for audit record reduction and report generation\n\naudit record reduction, review, analysis, and reporting tools\n\nsystem audit records\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit record reduction and report generation responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting audit record reduction and report generation capability"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.07",
+            "class": "requirement",
+            "title": "Time Stamps",
+            "params": [
+              {
+                "id": "A.03.03.07.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.03.07.ODP[01]"
+                  }
+                ],
+                "label": "granularity of time measurement",
+                "usage": "organization-defined granularity of time measurement",
+                "guidelines": [
+                  {
+                    "prose": "granularity of time measurement for audit record time stamps is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.07"
+              },
+              {
+                "name": "label",
+                "value": "Time Stamps (03.03.07)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#7cbbdd86-07a1-4477-b0ed-d38b6f416a3b",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.07",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.07.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.07.a"
+                      }
+                    ],
+                    "prose": "Use internal system clocks to generate time stamps for audit records."
+                  },
+                  {
+                    "id": "SR-03.03.07.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.07.b"
+                      }
+                    ],
+                    "prose": "Record time stamps for audit records that meet {{ insert: param, A.03.03.07.ODP.01 }} and that use Coordinated Universal Time (UTC), have a fixed local time offset from UTC, or include the local time offset as part of the time stamp."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.07",
+                "name": "guidance",
+                "prose": "Time stamps generated by the system include the date and time. Time is often expressed in Coordinated Universal Time (UTC) — a modern continuation of Greenwich Mean Time (GMT) — or local time with an offset from UTC. The granularity of time measurements refers to the degree of synchronization between system clocks and reference clocks (e.g., clocks synchronizing within hundreds or tens of milliseconds). Organizations may define different time granularities for system components. Time service can be critical to other security capabilities (e.g., access control and identification and authentication), depending on the nature of the mechanisms used to support those capabilities."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.07.a",
+                "name": "assessment-objective",
+                "prose": "internal system clocks are used to generate time stamps for audit records.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.07.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.07.b.02",
+                "name": "assessment-objective",
+                "prose": "time stamps are recorded for audit records that use Coordinated Universal Time (UTC), have a fixed local time offset from UTC, or include the local time offset as part of the time stamp.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.07.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.07.b.01",
+                "name": "assessment-objective",
+                "prose": "time stamps are recorded for audit records that meet {{ insert: param, A.03.03.07.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.07.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.07_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\nprocedures for timestamp generation\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.07_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.07_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing timestamp generation"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.08",
+            "class": "requirement",
+            "title": "Protection of Audit Information",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.08"
+              },
+              {
+                "name": "label",
+                "value": "Protection of Audit Information (03.03.08)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#425d5b83-149c-4292-b7f5-14308d80823e",
+                "rel": "reference"
+              },
+              {
+                "href": "#c3606a57-b8a7-4a26-9ba4-9dc3dbadd08c",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.03.08",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.03.08.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.08.a"
+                      }
+                    ],
+                    "prose": "Protect audit information and audit logging tools from unauthorized access, modification, and deletion."
+                  },
+                  {
+                    "id": "SR-03.03.08.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.03.08.b"
+                      }
+                    ],
+                    "prose": "Authorize access to management of audit logging functionality to only a subset of privileged users or roles."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.03.08",
+                "name": "guidance",
+                "prose": "Audit information includes the information needed to successfully audit system activity, such as audit records, audit log settings, audit reports, and personally identifiable information. Audit logging tools are programs and devices used to conduct audit and logging activities. The protection of audit information focuses on technical protection and limits the ability to access and execute audit logging tools to authorized individuals. The physical protection of audit information is addressed by media and physical protection requirements. Individuals or roles with privileged access to a system and who are also the subject of an audit by that system may affect the reliability of the audit information by inhibiting audit activities or modifying audit records. Requiring privileged access to be further defined between audit-related privileges and other privileges limits the number of users or roles with audit-related privileges."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.08.b",
+                "name": "assessment-objective",
+                "prose": "access to management of audit logging functionality is authorized to only a subset of privileged users or roles.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.08.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.08.a.01",
+                "name": "assessment-objective",
+                "prose": "audit information is protected from unauthorized access, modification, and deletion.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.08.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.03.08.a.02",
+                "name": "assessment-objective",
+                "prose": "audit logging tools are protected from unauthorized access, modification, and deletion.",
+                "links": [
+                  {
+                    "href": "#SR-03.03.08.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.03.08_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "audit and accountability policy and procedures\n\naccess control policy and procedures\n\nprocedures for the protection of audit information\n\nsystem configuration settings\n\nsystem audit records\n\naudit tools\n\nsystem-generated list of privileged users with access to the management of audit functionality\n\naccess authorizations\n\naccess control list\n\nsystem design documentation\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.03.08_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with audit and accountability responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.03.08_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing audit information protection\n\nmechanisms for managing access to audit functionality"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.03.09",
+            "class": "requirement",
+            "title": "03.03.09",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.03.09"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.03.08",
+                "rel": "incorporated_into"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.04",
+        "class": "family",
+        "title": "Configuration Management",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.04"
+          },
+          {
+            "name": "label",
+            "value": "Configuration Management (03.04)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.04.01",
+            "class": "requirement",
+            "title": "Baseline Configuration",
+            "params": [
+              {
+                "id": "A.03.04.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency of baseline configuration review and update is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.01"
+              },
+              {
+                "name": "label",
+                "value": "Baseline Configuration (03.04.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#4e5dd76f-13cb-4cb6-84f8-da66c566b988",
+                "rel": "reference"
+              },
+              {
+                "href": "#2c17a971-f0a2-47df-9f91-d752a39a4b56",
+                "rel": "reference"
+              },
+              {
+                "href": "#64230fd9-c88b-4288-82a4-2c1e5e490a4a",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.01.a"
+                      }
+                    ],
+                    "prose": "Develop and maintain under configuration control, a current baseline configuration of the system."
+                  },
+                  {
+                    "id": "SR-03.04.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.01.b"
+                      }
+                    ],
+                    "prose": "Review and update the baseline configuration of the system {{ insert: param, A.03.04.01.ODP.01 }} and when system components are installed or modified."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.01",
+                "name": "guidance",
+                "prose": "Baseline configurations for the system and system components include aspects of connectivity, operation, and communications. Baseline configurations are documented, formally reviewed, and agreed-upon specifications for the system or configuration items within the system. Baseline configurations serve as a basis for future builds, releases, or changes to the system and include information about system components, operational procedures, network topology, and the placement of components in the system architecture. Maintaining baseline configurations requires creating new baselines as the system changes over time. Baseline configurations of the system reflect the current enterprise architecture."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.01.a.01",
+                "name": "assessment-objective",
+                "prose": "a current baseline configuration of the system is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.01.a.02",
+                "name": "assessment-objective",
+                "prose": "a current baseline configuration of the system is maintained under configuration control.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.01.b.02",
+                "name": "assessment-objective",
+                "prose": "the baseline configuration of the system is updated {{ insert: param, A.03.04.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.01.b.03",
+                "name": "assessment-objective",
+                "prose": "the baseline configuration of the system is reviewed when system components are installed or modified.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.01.b.04",
+                "name": "assessment-objective",
+                "prose": "the baseline configuration of the system is updated when system components are installed or modified.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.01.b.01",
+                "name": "assessment-objective",
+                "prose": "the baseline configuration of the system is reviewed {{ insert: param, A.03.04.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for the baseline system configuration\n\nconfiguration management plan\n\nenterprise architecture\n\nsystem design documentation\n\nsystem architecture\n\nsystem configuration settings\n\nsystem component inventory\n\nchange control records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with configuration management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for managing baseline configurations\n\nmechanisms for supporting configuration control of the baseline configuration"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.02",
+            "class": "requirement",
+            "title": "Configuration Settings",
+            "params": [
+              {
+                "id": "A.03.04.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.02.ODP[01]"
+                  }
+                ],
+                "label": "configuration settings",
+                "usage": "organization-defined configuration settings",
+                "guidelines": [
+                  {
+                    "prose": "configuration settings for the system that reflect the most restrictive mode consistent with operational requirements are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.02"
+              },
+              {
+                "name": "label",
+                "value": "Configuration Settings (03.04.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#3c484dac-6220-4f09-9afb-d31fd47269d2",
+                "rel": "reference"
+              },
+              {
+                "href": "#7d1055bb-574a-4487-b0c7-5791a0509fc8",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              },
+              {
+                "href": "#bb27dd66-aa0b-42d9-952a-7bab2fe8047e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.02.a"
+                      }
+                    ],
+                    "prose": "Establish, document, and implement the following configuration settings for the system that reflect the most restrictive mode consistent with operational requirements: {{ insert: param, A.03.04.02.ODP.01 }} ."
+                  },
+                  {
+                    "id": "SR-03.04.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.02.b"
+                      }
+                    ],
+                    "prose": "Identify, document, and approve any deviations from established configuration settings."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.02",
+                "name": "guidance",
+                "prose": "Configuration settings are the set of parameters that can be changed in hardware, software, or firmware components of the system and that affect the security posture or functionality of the system. Security-related configuration settings can be defined for systems (e.g., servers, workstations), input and output devices (e.g., scanners, copiers, printers), network components (e.g., firewalls, routers, gateways, voice and data switches, wireless access points, network appliances, sensors), operating systems, middleware, and applications. Security parameters are those parameters that impact the security state of the system, including the parameters required to satisfy other security requirements. Security parameters include registry settings; account, file, and directory permission settings (i.e., privileges); and settings for functions, ports, protocols, and remote connections. Organizations establish organization-wide configuration settings and subsequently derive specific configuration settings for the system. The established settings become part of the system’s configuration baseline. Common secure configurations (also referred to as security configuration checklists, lockdown and hardening guides, security reference guides, and security technical implementation guides) provide recognized, standardized, and established benchmarks that stipulate secure configuration settings for specific information technology platforms/products and instructions for configuring those system components to meet operational requirements. Common secure configurations can be developed by a variety of organizations, including information technology product developers, manufacturers, vendors, consortia, academia, industry, federal agencies, and other organizations in the public and private sectors."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.02.a.01",
+                "name": "assessment-objective",
+                "prose": "the following configuration settings for the system that reflect the most restrictive mode consistent with operational requirements are established and documented: {{ insert: param, A.03.04.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.02.b.01",
+                "name": "assessment-objective",
+                "prose": "any deviations from established configuration settings are identified and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.02.b.02",
+                "name": "assessment-objective",
+                "prose": "any deviations from established configuration settings are approved.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.02.a.02",
+                "name": "assessment-objective",
+                "prose": "the following configuration settings for the system are implemented: {{ insert: param, A.03.04.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for system configuration settings\n\nconfiguration management plan\n\nsystem design documentation\n\nsystem configuration settings\n\ncommon secure configuration checklists\n\nsystem component inventory\n\nevidence supporting approved deviations from established configuration settings\n\nchange control records\n\nsystem data processing and retention permissions\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with security configuration management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for managing configuration settings\n\nmechanisms that implement, monitor, or control system configuration settings\n\nmechanisms that identify or document deviations from established configuration settings"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.03",
+            "class": "requirement",
+            "title": "Configuration Change Control",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.03"
+              },
+              {
+                "name": "label",
+                "value": "Configuration Change Control (03.04.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#02cf8bfa-85d5-4738-9dac-e6ac625f05ca",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.03",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.03.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.03.a"
+                      }
+                    ],
+                    "prose": "Define the types of changes to the system that are configuration-controlled."
+                  },
+                  {
+                    "id": "SR-03.04.03.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.03.b"
+                      }
+                    ],
+                    "prose": "Review proposed configuration-controlled changes to the system, and approve or disapprove such changes with explicit consideration for security impacts."
+                  },
+                  {
+                    "id": "SR-03.04.03.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.03.c"
+                      }
+                    ],
+                    "prose": "Implement and document approved configuration-controlled changes to the system."
+                  },
+                  {
+                    "id": "SR-03.04.03.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.03.d"
+                      }
+                    ],
+                    "prose": "Monitor and review activities associated with configuration-controlled changes to the system."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.03",
+                "name": "guidance",
+                "prose": "Configuration change control refers to tracking, reviewing, approving or disapproving, and logging changes to the system. Specifically, it involves the systematic proposal, justification, implementation, testing, review, and disposition of changes to the system, including system upgrades and modifications. Configuration change control includes changes to baseline configurations for system components (e.g., operating systems, applications, firewalls, routers, mobile devices) and configuration items of the system, changes to configuration settings, unscheduled and unauthorized changes, and changes to remediate vulnerabilities. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.04.04) 03.04.04."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.a",
+                "name": "assessment-objective",
+                "prose": "the types of changes to the system that are configuration-controlled are defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.b.01",
+                "name": "assessment-objective",
+                "prose": "proposed configuration-controlled changes to the system are reviewed with explicit consideration for security impacts.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.b.02",
+                "name": "assessment-objective",
+                "prose": "proposed configuration-controlled changes to the system are approved or disapproved with explicit consideration for security impacts.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.d.01",
+                "name": "assessment-objective",
+                "prose": "activities associated with configuration-controlled changes to the system are monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.d.02",
+                "name": "assessment-objective",
+                "prose": "activities associated with configuration-controlled changes to the system are reviewed.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.c.01",
+                "name": "assessment-objective",
+                "prose": "approved configuration-controlled changes to the system are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.03.c.02",
+                "name": "assessment-objective",
+                "prose": "approved configuration-controlled changes to the system are documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.03.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for system configuration change control\n\nconfiguration management plan\n\nsystem architecture\n\nconfiguration settings\n\nchange control records\n\nsystem audit records\n\nchange control audit and review reports\n\nagenda, minutes, and documentation from configuration change control oversight meetings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with configuration change control responsibilities\n\npersonnel with information security responsibilities\n\nmembers of change control board or similar\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for configuration change control\n\nmechanisms that implement configuration change control"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.04",
+            "class": "requirement",
+            "title": "Impact Analyses",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.04"
+              },
+              {
+                "name": "label",
+                "value": "Impact Analyses (03.04.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#971156e2-ba52-4418-a4ca-179886d6bc3b",
+                "rel": "reference"
+              },
+              {
+                "href": "#d8227f66-d7ed-461a-ba6b-e36ef724de9f",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.04",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.04.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.04.a"
+                      }
+                    ],
+                    "prose": "Analyze changes to the system to determine potential security impacts prior to change implementation."
+                  },
+                  {
+                    "id": "SR-03.04.04.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.04.b"
+                      }
+                    ],
+                    "prose": "Verify that the security requirements for the system continue to be satisfied after the system changes have been implemented."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.04",
+                "name": "guidance",
+                "prose": "Organizational personnel with security responsibilities conduct impact analyses that include reviewing system security plans, policies, and procedures to understand security requirements; reviewing system design documentation and operational procedures to understand how system changes might affect the security state of the system; reviewing the impacts of system changes on supply chain partners with stakeholders; and determining how potential changes to a system create new risks and the ability to mitigate those risks. Impact analyses also include risk assessments to understand the impacts of changes and determine whether additional security requirements are needed. Changes to the system may affect the safeguards and countermeasures previously implemented. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.04.03)03.04.03. Not all changes to the system are configuration controlled."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.04.b",
+                "name": "assessment-objective",
+                "prose": "the security requirements for the system continue to be satisfied after the system changes have been implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.04.a",
+                "name": "assessment-objective",
+                "prose": "changes to the system are analyzed to determine potential security impacts prior to change implementation.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.04.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for security impact analyses for system changes\n\nconfiguration management plan\n\nsecurity impact analysis documentation\n\nsystem design documentation\n\nanalysis tools and outputs\n\nchange control records\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with security impact analysis responsibilities\n\npersonnel with information security responsibilities\n\nmembers of change control board\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for security impact analyses"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.05",
+            "class": "requirement",
+            "title": "Access Restrictions for Change",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.05"
+              },
+              {
+                "name": "label",
+                "value": "Access Restrictions for Change (03.04.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#55ed1dd1-b4cb-4df9-964a-eae7f44e0be1",
+                "rel": "reference"
+              },
+              {
+                "href": "#ee7a6c0f-4d87-4bef-a353-ca0e7ee09073",
+                "rel": "reference"
+              },
+              {
+                "href": "#e95ca7ce-1251-4a4c-ad90-296e3895001b",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.05",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.04.05",
+                "name": "guidance",
+                "prose": "Changes to the hardware, software, or firmware components of the system or the operational procedures related to the system can have potentially significant effects on the security of the system. Therefore, organizations permit only qualified and authorized individuals to access the system for the purpose of initiating changes. Access restrictions include physical and logical access controls, software libraries, workflow automation, media libraries, abstract layers (i.e., changes implemented into external interfaces rather than directly into the system), and change windows (i.e., changes occur only during specified times)."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.05.01",
+                "name": "assessment-objective",
+                "prose": "physical access restrictions associated with changes to the system are defined and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.05.02",
+                "name": "assessment-objective",
+                "prose": "physical access restrictions associated with changes to the system are approved.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.05.03",
+                "name": "assessment-objective",
+                "prose": "physical access restrictions associated with changes to the system are enforced.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.05.04",
+                "name": "assessment-objective",
+                "prose": "logical access restrictions associated with changes to the system are defined and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.05.05",
+                "name": "assessment-objective",
+                "prose": "logical access restrictions associated with changes to the system are approved.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.05.06",
+                "name": "assessment-objective",
+                "prose": "logical access restrictions associated with changes to the system are enforced.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for access restrictions for system changes\n\nconfiguration management plan\n\nsystem design documentation\n\nsystem architecture\n\nsystem configuration settings\n\nlogical access approvals\n\nphysical access approvals\n\naccess credentials\n\nchange control records\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with logical access control responsibilities\n\npersonnel with physical access control responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for managing access restrictions for system changes\n\nmechanisms for supporting, implementing, or enforcing access restrictions associated with system changes"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.06",
+            "class": "requirement",
+            "title": "Least Functionality",
+            "params": [
+              {
+                "id": "A.03.04.06.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.06.ODP[01]"
+                  }
+                ],
+                "label": "functions",
+                "usage": "organization-defined functions, ports, protocols, connections, and services",
+                "guidelines": [
+                  {
+                    "prose": "functions to be prohibited or restricted are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.04.06.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.06.ODP[02]"
+                  }
+                ],
+                "label": "ports",
+                "usage": "organization-defined functions, ports, protocols, connections, and services",
+                "guidelines": [
+                  {
+                    "prose": "ports to be prohibited or restricted are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.04.06.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.06.ODP[03]"
+                  }
+                ],
+                "label": "protocols",
+                "usage": "organization-defined functions, ports, protocols, connections, and services",
+                "guidelines": [
+                  {
+                    "prose": "protocols to be prohibited or restricted are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.04.06.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.06.ODP[04]"
+                  }
+                ],
+                "label": "connections",
+                "usage": "organization-defined functions, ports, protocols, connections, and services",
+                "guidelines": [
+                  {
+                    "prose": "connections to be prohibited or restricted are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.04.06.ODP.05",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.06.ODP[05]"
+                  }
+                ],
+                "label": "services",
+                "usage": "organization-defined functions, ports, protocols, connections, and services",
+                "guidelines": [
+                  {
+                    "prose": "services to be prohibited or restricted are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.04.06.ODP.06",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.06.ODP[06]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review the system to identify unnecessary or nonsecure functions, ports, protocols, connections, or services is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.06"
+              },
+              {
+                "name": "label",
+                "value": "Least Functionality (03.04.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#925f7cfa-84ca-42f7-98e4-13eaa5ee57d5",
+                "rel": "reference"
+              },
+              {
+                "href": "#fa702319-e39d-485e-b0bb-d33e9071ca91",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#3beee199-43e4-4679-91dc-e94270b125f4",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.06",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.06.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.06.a"
+                      }
+                    ],
+                    "prose": "Configure the system to provide only mission-essential capabilities."
+                  },
+                  {
+                    "id": "SR-03.04.06.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.06.b"
+                      }
+                    ],
+                    "prose": "Prohibit or restrict use of the following functions, ports, protocols, connections, and services: {{ insert: param, A.03.04.06.ODP.01 }} ."
+                  },
+                  {
+                    "id": "SR-03.04.06.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.06.c"
+                      }
+                    ],
+                    "prose": "Review the system {{ insert: param, A.03.04.06.ODP.06 }} to identify unnecessary or nonsecure functions, ports, protocols, connections, and services."
+                  },
+                  {
+                    "id": "SR-03.04.06.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.06.d"
+                      }
+                    ],
+                    "prose": "Disable or remove functions, ports, protocols, connections, and services that are unnecessary or nonsecure."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.06",
+                "name": "guidance",
+                "prose": "Systems can provide a variety of functions and services. Some functions and services that are routinely provided by default may not be necessary to support essential organizational missions, functions, or operations. It may be convenient to provide multiple services from single system components. However, doing so increases risk over limiting the services provided by any one component. Where feasible, organizations limit functionality to a single function per component. Organizations review the functions and services provided by the system or system components to determine which functions and services are candidates for elimination. Organizations disable unused or unnecessary physical and logical ports and protocols to prevent the unauthorized connection of devices, the transfer of information, and tunneling. Organizations can employ network scanning tools, intrusion detection and prevention systems, and endpoint protection systems (e.g., firewalls and host-based intrusion detection systems) to identify and prevent the use of prohibited functions, ports, protocols, system connections, and services. Bluetooth, File Transfer Protocol (FTP), and peer-to-peer networking are examples of the types of protocols that organizations consider eliminating, restricting, or disabling."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.b.01",
+                "name": "assessment-objective",
+                "prose": "the use of the following functions is prohibited or restricted: {{ insert: param, A.03.04.06.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.b.02",
+                "name": "assessment-objective",
+                "prose": "the use of the following ports is prohibited or restricted: {{ insert: param, A.03.04.06.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.b.03",
+                "name": "assessment-objective",
+                "prose": "the use of the following protocols is prohibited or restricted: {{ insert: param, A.03.04.06.ODP.03 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.b.04",
+                "name": "assessment-objective",
+                "prose": "the use of the following connections is prohibited or restricted: {{ insert: param, A.03.04.06.ODP.04 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.b.05",
+                "name": "assessment-objective",
+                "prose": "the use of the following services is prohibited or restricted: {{ insert: param, A.03.04.06.ODP.05 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.c",
+                "name": "assessment-objective",
+                "prose": "the system is reviewed {{ insert: param, A.03.04.06.ODP.06 }} to identify unnecessary or nonsecure functions, ports, protocols, connections, and services.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.d",
+                "name": "assessment-objective",
+                "prose": "unnecessary or nonsecure functions, ports, protocols, connections, and services are disabled or removed.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.06.a",
+                "name": "assessment-objective",
+                "prose": "the system is configured to provide only mission-essential capabilities.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for least functionality in the system\n\nconfiguration management plan\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem component inventory\n\ncommon secure configuration checklists\n\ndocumented reviews of functions, ports, protocols, and services\n\nchange control records\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with configuration management responsibilities\n\npersonnel with responsibilities for reviewing functions, ports, protocols, and services\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for prohibiting or restricting functions, ports, protocols, and services\n\nprocesses for reviewing or disabling functions, ports, protocols, and services\n\nmechanisms for implementing the review and disabling of functions, ports, protocols, and services\n\nmechanisms for implementing restrictions on or the prohibition of functions, ports, protocols, and services"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.07",
+            "class": "requirement",
+            "title": "03.04.07",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.07"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.04.06",
+                "rel": "incorporated_into"
+              },
+              {
+                "href": "03.04.08",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.08",
+            "class": "requirement",
+            "title": "Authorized Software – Allow by Exception",
+            "params": [
+              {
+                "id": "A.03.04.08.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.08.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review and update the list of authorized software programs is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.08"
+              },
+              {
+                "name": "label",
+                "value": "Authorized Software – Allow by Exception (03.04.08)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#a24d80b7-67d9-4657-8701-987487af6a6a",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#3beee199-43e4-4679-91dc-e94270b125f4",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.08",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.08.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.08.a"
+                      }
+                    ],
+                    "prose": "Identify software programs authorized to execute on the system."
+                  },
+                  {
+                    "id": "SR-03.04.08.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.08.b"
+                      }
+                    ],
+                    "prose": "Implement a deny-all, allow-by-exception policy for the execution of authorized software programs on the system."
+                  },
+                  {
+                    "id": "SR-03.04.08.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.08.c"
+                      }
+                    ],
+                    "prose": "Review and update the list of authorized software programs {{ insert: param, A.03.04.08.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.08",
+                "name": "guidance",
+                "prose": "If provided with the necessary privileges, users can install software in organizational systems. To maintain control over the software installed, organizations identify permitted and prohibited actions regarding software installation. Permitted software installations include updates and security patches to existing software and downloading new applications from organization-approved “app stores.” The policies selected for governing user-installed software are organization-developed or provided by some external entity. Policy enforcement methods can include procedural methods and automated methods. Authorized software programs can be limited to specific versions or come from specific sources. To facilitate a comprehensive authorized software process and increase the strength of protection against attacks that bypass application-level authorized software, software programs may be decomposed into and monitored at different levels of detail. These levels include applications, application programming interfaces, application modules, scripts, system processes, system services, kernel functions, registries, drivers, and dynamic link libraries."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.08.a",
+                "name": "assessment-objective",
+                "prose": "software programs authorized to execute on the system are identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.08.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.08.b",
+                "name": "assessment-objective",
+                "prose": "a deny-all, allow-by-exception policy for the execution of authorized software programs on the system is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.08.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.08.c",
+                "name": "assessment-objective",
+                "prose": "the list of authorized software programs is reviewed and updated {{ insert: param, A.03.04.08.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.08.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.08_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for least functionality in the system\n\nconfiguration management plan\n\nsystem design documentation\n\nsystem configuration settings\n\nlist of software programs authorized to execute on the system\n\nsystem component inventory\n\nrecords associated with the review and update of the list of authorized software programs\n\ncommon secure configuration checklists\n\nchange control records\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.08_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for identifying software authorized to execute on the system\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.08_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for identifying, reviewing, and updating programs authorized to execute on the system\n\nprocesses for implementing authorized software policy\n\nmechanisms for supporting or implementing authorized software policy"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.09",
+            "class": "requirement",
+            "title": "03.04.09",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.09"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.05",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.06",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.07",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.04.08",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.12.03",
+                "rel": "addressed_by"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.10",
+            "class": "requirement",
+            "title": "System Component Inventory",
+            "params": [
+              {
+                "id": "A.03.04.10.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.10.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review and update the system component inventory is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.10"
+              },
+              {
+                "name": "label",
+                "value": "System Component Inventory (03.04.10)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#8d0ba78d-a7c0-4141-b24a-8afc5366ef65",
+                "rel": "reference"
+              },
+              {
+                "href": "#9b7a1b97-6c78-4ca6-b053-f421162e63bd",
+                "rel": "reference"
+              },
+              {
+                "href": "#2c17a971-f0a2-47df-9f91-d752a39a4b56",
+                "rel": "reference"
+              },
+              {
+                "href": "#64230fd9-c88b-4288-82a4-2c1e5e490a4a",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.10",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.10.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.10.a"
+                      }
+                    ],
+                    "prose": "Develop and document an inventory of system components."
+                  },
+                  {
+                    "id": "SR-03.04.10.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.10.b"
+                      }
+                    ],
+                    "prose": "Review and update the system component inventory {{ insert: param, A.03.04.10.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.04.10.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.10.c"
+                      }
+                    ],
+                    "prose": "Update the system component inventory as part of installations, removals, and system updates."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.10",
+                "name": "guidance",
+                "prose": "System components are discrete, identifiable assets (i.e., hardware, software, and firmware elements) that compose a system. Organizations may implement centralized system component inventories that include components from all systems. In such situations, organizations ensure that the inventories include the system-specific information required for component accountability. The information necessary for effective accountability of system components includes the system name, software owners, software version numbers, software license information, hardware inventory specifications, and — for networked components — the machine names and network addresses for all implemented protocols (e.g., IPv4, IPv6). Inventory specifications include component type, physical location, date of receipt, manufacturer, cost, model, serial number, and supplier information."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.10.a",
+                "name": "assessment-objective",
+                "prose": "an inventory of system components is developed and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.10.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.10.b.01",
+                "name": "assessment-objective",
+                "prose": "the system component inventory is reviewed {{ insert: param, A.03.04.10.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.10.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.10.b.02",
+                "name": "assessment-objective",
+                "prose": "the system component inventory is updated {{ insert: param, A.03.04.10.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.10.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.10.c.01",
+                "name": "assessment-objective",
+                "prose": "the system component inventory is updated as part of component installations.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.10.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.10.c.02",
+                "name": "assessment-objective",
+                "prose": "the system component inventory is updated as part of component removals.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.10.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.10.c.03",
+                "name": "assessment-objective",
+                "prose": "the system component inventory is updated as part of system updates.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.10.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.10_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nprocedures for system component inventory\n\nconfiguration management plan\n\nsystem design documentation\n\nsystem component inventory\n\ninventory reviews and update records\n\ncomponent installation records\n\nchange control records\n\ncomponent removal records\n\nsystem change records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.10_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with component inventory management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.10_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for managing the system component inventory\n\nmechanisms for supporting or implementing the system component inventory\n\nprocesses for updating the system component inventory\n\nmechanisms for supporting or implementing the system component inventory updates"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.11",
+            "class": "requirement",
+            "title": "Information Location",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.11"
+              },
+              {
+                "name": "label",
+                "value": "Information Location (03.04.11)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#cba05591-32fa-439a-9f3c-c72b11c18b11",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.11",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.11.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.11.a"
+                      }
+                    ],
+                    "prose": "Identify and document the location of CUI and the system components on which the information is processed and stored."
+                  },
+                  {
+                    "id": "SR-03.04.11.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.11.b"
+                      }
+                    ],
+                    "prose": "Document changes to the system or system component location where CUI is processed and stored."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.11",
+                "name": "guidance",
+                "prose": "Information location addresses the need to understand the specific system components where CUI is being processed and stored and the users who have access to CUI so that appropriate protection mechanisms can be provided, including information flow controls, access controls, and information management."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.11.a.01",
+                "name": "assessment-objective",
+                "prose": "the location of CUI is identified and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.11.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.11.a.02",
+                "name": "assessment-objective",
+                "prose": "the system components on which CUI is processed are identified and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.11.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.11.a.03",
+                "name": "assessment-objective",
+                "prose": "the system components on which CUI is stored are identified and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.11.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.11.b.01",
+                "name": "assessment-objective",
+                "prose": "changes to the system or system component location where CUI is processed are documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.11.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.11.b.02",
+                "name": "assessment-objective",
+                "prose": "changes to the system or system component location where CUI is stored are documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.11.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.11_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nconfiguration management plan\n\nprocedures for identification and documentation of information location\n\nsystem audit records\n\narchitecture documentation\n\nsystem design documentation\n\nlist of users with system and system component access\n\nchange control records\n\nsystem component inventory\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.11_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for managing information location and user access\n\npersonnel with responsibilities for operating, using, or maintaining the system\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.11_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes governing information location\n\nmechanisms for enforcing policies and methods for governing information location"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.04.12",
+            "class": "requirement",
+            "title": "System and Component Configuration for High-Risk Areas",
+            "params": [
+              {
+                "id": "A.03.04.12.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.12.ODP[01]"
+                  }
+                ],
+                "label": "configurations",
+                "usage": "organization-defined system configurations",
+                "guidelines": [
+                  {
+                    "prose": "configurations for systems or system components to be issued to individuals traveling to high-risk locations are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.04.12.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.04.12.ODP[02]"
+                  }
+                ],
+                "label": "security requirements",
+                "usage": "organization-defined security requirements",
+                "guidelines": [
+                  {
+                    "prose": "security requirements to be applied to the system or system components when individuals return from travel are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.04.12"
+              },
+              {
+                "name": "label",
+                "value": "System and Component Configuration for High-Risk Areas (03.04.12)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#a342e082-b4de-44d7-b461-80eed2c111aa",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.04.12",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.04.12.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.12.a"
+                      }
+                    ],
+                    "prose": "Issue systems or system components with the following configurations to individuals traveling to high-risk locations: {{ insert: param, A.03.04.12.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.04.12.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.04.12.b"
+                      }
+                    ],
+                    "prose": "Apply the following security requirements to the systems or components when the individuals return from travel: {{ insert: param, A.03.04.12.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.04.12",
+                "name": "guidance",
+                "prose": "When it is known that a system or a system component will be in a high-risk area, additional security requirements may be needed to counter the increased threat. Organizations can implement protective measures on the systems or system components used by individuals departing on and returning from travel. Actions include determining whether the locations are of concern, defining the required configurations for the components, ensuring that the components are configured as intended before travel is initiated, and taking additional actions after travel is completed. For example, systems going into high-risk areas can be configured with sanitized hard drives, limited applications, and more stringent configuration settings. Actions applied to mobile devices upon return from travel include examining the device for signs of physical tampering and purging and reimaging the device storage."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.12.a",
+                "name": "assessment-objective",
+                "prose": "systems or system components with the following configurations are issued to individuals traveling to high-risk locations: {{ insert: param, A.03.04.12.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.04.12.b",
+                "name": "assessment-objective",
+                "prose": "the following security requirements are applied to the system or system components when the individuals return from travel: {{ insert: param, A.03.04.12.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.04.12.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.04.12_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "configuration management policy and procedures\n\nconfiguration management plan\n\nprocedures for the baseline configuration of the system\n\nprocedures for system component installations and upgrades\n\nsystem component inventory\n\nsystem component installations or upgrades and associated records\n\nrecords of system baseline configuration reviews and updates\n\nsystem configuration settings\n\nsystem architecture\n\nchange control records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.04.12_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with configuration management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.04.12_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for managing baseline configurations"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.05",
+        "class": "family",
+        "title": "Identification and Authentication",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.05"
+          },
+          {
+            "name": "label",
+            "value": "Identification and Authentication (03.05)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.05.01",
+            "class": "requirement",
+            "title": "User Identification and Authentication",
+            "params": [
+              {
+                "id": "A.03.05.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.01.ODP[01]"
+                  }
+                ],
+                "label": "circumstances or situations",
+                "usage": "organization-defined circumstances or situations requiring re-authentication",
+                "guidelines": [
+                  {
+                    "prose": "circumstances or situations that require re-authentication are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.01"
+              },
+              {
+                "name": "label",
+                "value": "User Identification and Authentication (03.05.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#194c51c5-c474-4dd5-ae82-1a37c891a746",
+                "rel": "reference"
+              },
+              {
+                "href": "#35f942bb-4765-4a2a-9049-d1c4efb56dc9",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.05.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.01.a"
+                      }
+                    ],
+                    "prose": "Uniquely identify and authenticate system users, and associate that unique identification with processes acting on behalf of those users."
+                  },
+                  {
+                    "id": "SR-03.05.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.01.b"
+                      }
+                    ],
+                    "prose": "Re-authenticate users when {{ insert: param, A.03.05.01.ODP.01 }} ."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.05.01",
+                "name": "guidance",
+                "prose": "System users include individuals (or system processes acting on behalf of individuals) who are authorized to access a system. Typically, individual identifiers are the usernames associated with the system accounts assigned to those individuals. Since system processes execute on behalf of groups and roles, organizations may require the unique identification of individuals in group accounts or the accountability of individual activity. The unique identification and authentication of users apply to all system accesses. Organizations use passwords, physical authenticators, biometrics, or some combination thereof to authenticate user identities. Organizations may re-authenticate individuals in certain situations, including when roles, authenticators, or credentials change; when the execution of privileged functions occurs; after a fixed time period; or periodically."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.01.a.01",
+                "name": "assessment-objective",
+                "prose": "system users are uniquely identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.01.a.02",
+                "name": "assessment-objective",
+                "prose": "system users are authenticated.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.01.a.03",
+                "name": "assessment-objective",
+                "prose": "processes acting on behalf of users are associated with uniquely identified and authenticated system users.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.01.b",
+                "name": "assessment-objective",
+                "prose": "users are reauthenticated when {{ insert: param, A.03.05.01.ODP.01 }} .",
+                "links": [
+                  {
+                    "href": "#SR-03.05.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nlist of circumstances or situations requiring re-authentication\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nlist of system accounts\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with identification and authentication responsibilities\n\npersonnel with system operations responsibilities\n\npersonnel with account management responsibilities\n\nsystem developers\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for uniquely identifying and authenticating users\n\nmechanisms for supporting or implementing identification and authentication capabilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.02",
+            "class": "requirement",
+            "title": "Device Identification and Authentication",
+            "params": [
+              {
+                "id": "A.03.05.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.02.ODP[01]"
+                  }
+                ],
+                "label": "devices or types of devices",
+                "usage": "organization-defined devices or types of devices",
+                "guidelines": [
+                  {
+                    "prose": "devices or types of devices to be uniquely identified and authenticated before establishing a connection are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.02"
+              },
+              {
+                "name": "label",
+                "value": "Device Identification and Authentication (03.05.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#ecd0479b-72b6-42cd-b678-cebc75d87b1f",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.02",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.05.02",
+                "name": "guidance",
+                "prose": "Devices that require unique device-to-device identification and authentication are defined by type, device, or a combination of type and device. Organization-defined device types include devices that are not owned by the organization. Systems use shared known information (e.g., Media Access Control .MAC, Transmission Control Protocol/Internet Protocol .TCP/IP addresses) for device identification or organizational authentication solutions (e.g., Institute of Electrical and Electronics Engineers .IEEE 802.1x and Extensible Authentication Protocol .EAP, RADIUS server with EAP-Transport Layer Security .TLS authentication, Kerberos) to identify and authenticate devices on local and wide area networks. Public Key Infrastructure (PKI) and certificate revocation checking for the certificates exchanged can be included as part of device authentication."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.02.02",
+                "name": "assessment-objective",
+                "prose": "{{ insert: param, A.03.05.02.ODP.01 }} are authenticated before establishing a system connection.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.02.01",
+                "name": "assessment-objective",
+                "prose": "{{ insert: param, A.03.05.02.ODP.01 }} are uniquely identified before establishing a system connection.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nprocedures for device identification and authentication\n\nsystem design documentation\n\nlist of devices requiring unique identification and authentication\n\ndevice connection reports\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for device identification and authentication\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing device identification and authentication capabilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.03",
+            "class": "requirement",
+            "title": "Multi-Factor Authentication",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.03"
+              },
+              {
+                "name": "label",
+                "value": "Multi-Factor Authentication (03.05.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#67ce4ecf-5a60-4cfa-8df9-b4eb26bf8e49",
+                "rel": "reference"
+              },
+              {
+                "href": "#47920758-65e0-4635-84ee-cab9044da725",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.03",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.05.03",
+                "name": "guidance",
+                "prose": "This requirement applies to user accounts. Multi-factor authentication requires the use of two or more different factors to achieve authentication. The authentication factors are defined as follows: something you know (e.g., a personal identification number .PIN), something you have (e.g., a physical authenticator, such as a cryptographic private key), or something you are (e.g., a biometric). Multi-factor authentication solutions that feature physical authenticators include hardware authenticators that provide time-based or challenge-response outputs and smart cards. In addition to authenticating users at the system level, organizations may also employ authentication mechanisms at the application level to provide increased information security."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.03.01",
+                "name": "assessment-objective",
+                "prose": "multi-factor authentication for access to privileged accounts is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.03.02",
+                "name": "assessment-objective",
+                "prose": "multi-factor authentication for access to non-privileged accounts is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nsystem design documentation\n\nlist of system accounts\n\nsystem configuration settings\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system operations responsibilities\n\npersonnel with account management responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing a multi-factor authentication capability"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.04",
+            "class": "requirement",
+            "title": "Replay-Resistant Authentication",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.04"
+              },
+              {
+                "name": "label",
+                "value": "Replay-Resistant Authentication (03.05.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#0c5cc89a-d10f-42cf-a8c3-ef84141eef50",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.04",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.05.04",
+                "name": "guidance",
+                "prose": "Authentication processes resist replay attacks if it is impractical to successfully authenticate by recording or replaying previous authentication messages. Replay-resistant techniques include protocols that use nonces or challenges, such as time synchronous or challenge-response one-time authenticators."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.04.01",
+                "name": "assessment-objective",
+                "prose": "replay-resistant authentication mechanisms for access to privileged accounts are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.04.02",
+                "name": "assessment-objective",
+                "prose": "replay-resistant authentication mechanisms for access to non-privileged accounts are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nsystem design documentation\n\nsystem audit records\n\nsystem configuration settings\n\nlist of privileged system accounts\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system operations responsibilities\n\npersonnel with account management responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing identification and authentication capabilities\n\nmechanisms for supporting or implementing replay-resistance"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.05",
+            "class": "requirement",
+            "title": "Identifier Management",
+            "params": [
+              {
+                "id": "A.03.05.05.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.05.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period for preventing the reuse of identifiers is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.05.05.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.05.ODP[02]"
+                  }
+                ],
+                "label": "characteristic",
+                "usage": "organization-defined characteristic identifying individual status",
+                "guidelines": [
+                  {
+                    "prose": "characteristic used to identify individual status are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.05"
+              },
+              {
+                "name": "label",
+                "value": "Identifier Management (03.05.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#d98d8156-6f69-462f-bba2-cd1e37bfa460",
+                "rel": "reference"
+              },
+              {
+                "href": "#0db27841-8671-492d-bbec-b859058550ad",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.05.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.05.a"
+                      }
+                    ],
+                    "prose": "Receive authorization from organizational personnel or roles to assign an individual, group, role, service, or device identifier."
+                  },
+                  {
+                    "id": "SR-03.05.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.05.b"
+                      }
+                    ],
+                    "prose": "Select and assign an identifier that identifies an individual, group, role, service, or device."
+                  },
+                  {
+                    "id": "SR-03.05.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.05.c"
+                      }
+                    ],
+                    "prose": "Prevent the reuse of identifiers for {{ insert: param, A.03.05.05.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.05.05.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.05.d"
+                      }
+                    ],
+                    "prose": "Manage individual identifiers by uniquely identifying each individual as {{ insert: param, A.03.05.05.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.05.05",
+                "name": "guidance",
+                "prose": "Identifiers are provided for users, processes acting on behalf of users, and devices. Prohibiting the reuse of identifiers prevents the assignment of previously used individual, group, role, service, or device identifiers to different individuals, groups, roles, services, or devices. Characteristics that identify the status of individuals include contractors, foreign nationals, and non-organizational users. Identifying the status of individuals by these characteristics provides information about the people with whom organizational personnel are communicating. For example, it is useful for an employee to know that one of the individuals on an email message is a contractor."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.05.a",
+                "name": "assessment-objective",
+                "prose": "authorization is received from organizational personnel or roles to assign an individual, group, role, service, or device identifier.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.05.b.01",
+                "name": "assessment-objective",
+                "prose": "an identifier that identifies an individual, group, role, service, or device is selected.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.05.b.02",
+                "name": "assessment-objective",
+                "prose": "an identifier that identifies an individual, group, role, service, or device is assigned.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.05.c",
+                "name": "assessment-objective",
+                "prose": "the reuse of identifiers for {{ insert: param, A.03.05.05.ODP.01 }} is prevented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.05.d",
+                "name": "assessment-objective",
+                "prose": "individual identifiers are managed by uniquely identifying each individual as {{ insert: param, A.03.05.05.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.05.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nprocedures for identifier management\n\nprocedures for account management\n\nsystem design documentation\n\nlist of system accounts\n\nlist of characteristics identifying individual status\n\nsystem configuration settings\n\nlist of identifiers generated from physical access control devices\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with identifier management responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing identifier management"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.06",
+            "class": "requirement",
+            "title": "03.05.06",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.06"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.07",
+            "class": "requirement",
+            "title": "Password Management",
+            "params": [
+              {
+                "id": "A.03.05.07.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.07.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to update the list of commonly used, expected, or compromised passwords is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.05.07.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.07.ODP[02]"
+                  }
+                ],
+                "label": "rules",
+                "usage": "organization-defined composition and complexity rules",
+                "guidelines": [
+                  {
+                    "prose": "password composition and complexity rules are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.07"
+              },
+              {
+                "name": "label",
+                "value": "Password Management (03.05.07)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#d858bece-144b-4fc6-8110-27777b48eebc",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.07",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.05.07.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.07.a"
+                      }
+                    ],
+                    "prose": "Maintain a list of commonly-used, expected, or compromised passwords, and update the list {{ insert: param, A.03.05.07.ODP.01 }} and when organizational passwords are suspected to have been compromised."
+                  },
+                  {
+                    "id": "SR-03.05.07.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.07.b"
+                      }
+                    ],
+                    "prose": "Verify that passwords are not found on the list of commonly used, expected, or compromised passwords when users create or update passwords."
+                  },
+                  {
+                    "id": "SR-03.05.07.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.07.c"
+                      }
+                    ],
+                    "prose": "Transmit passwords only over cryptographically protected channels."
+                  },
+                  {
+                    "id": "SR-03.05.07.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.07.d"
+                      }
+                    ],
+                    "prose": "Store passwords in a cryptographically protected form."
+                  },
+                  {
+                    "id": "SR-03.05.07.e",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.07.e"
+                      }
+                    ],
+                    "prose": "Select a new password upon first use after account recovery."
+                  },
+                  {
+                    "id": "SR-03.05.07.f",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.07.f"
+                      }
+                    ],
+                    "prose": "Enforce the following composition and complexity rules for passwords: {{ insert: param, A.03.05.07.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.05.07",
+                "name": "guidance",
+                "prose": "Password-based authentication applies to passwords used in single-factor or multi-factor authentication. Long passwords or passphrases are preferable to shorter passwords. Enforced composition rules provide marginal security benefits while decreasing usability. However, organizations may choose to establish and enforce certain rules for password generation (e.g., minimum character length) under certain circumstances. For example, account recovery can occur when a password is forgotten. Cryptographically protected passwords include salted one-way cryptographic hashes of passwords. The list of commonly used, compromised, or expected passwords includes passwords obtained from previous breach corpuses, dictionary words, and repetitive or sequential characters. The list includes context-specific words, such as the name of the service, username, and derivatives thereof. Changing temporary passwords to permanent passwords immediately after system logon ensures that the necessary strength of the authentication mechanism is implemented at the earliest opportunity and reduces susceptibility to authenticator compromises. Long passwords and passphrases can be used to increase the complexity of passwords."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.a.01",
+                "name": "assessment-objective",
+                "prose": "a list of commonly used, expected, or compromised passwords is maintained.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.a.02",
+                "name": "assessment-objective",
+                "prose": "a list of commonly used, expected, or compromised passwords is updated {{ insert: param, A.03.05.07.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.a.03",
+                "name": "assessment-objective",
+                "prose": "a list of commonly used, expected, or compromised passwords is updated when organizational passwords are suspected to have been compromised.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.b",
+                "name": "assessment-objective",
+                "prose": "passwords are verified not to be found on the list of commonly used, expected, or compromised passwords when they are created or updated by users.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.c",
+                "name": "assessment-objective",
+                "prose": "passwords are only transmitted over cryptographically protected channels.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.d",
+                "name": "assessment-objective",
+                "prose": "passwords are stored in a cryptographically protected form.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.e",
+                "name": "assessment-objective",
+                "prose": "a new password is selected upon first use after account recovery.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.e",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.07.f",
+                "name": "assessment-objective",
+                "prose": "the following composition and complexity rules for passwords are enforced: {{ insert: param, A.03.05.07.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.07.f",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.07_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\npassword policy\n\nprocedures for authenticator management\n\nsystem design documentation\n\nsystem configuration settings\n\npassword configurations\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.07_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with authenticator management responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.07_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing a password-based authenticator management capability"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.08",
+            "class": "requirement",
+            "title": "03.05.08",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.08"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.09",
+            "class": "requirement",
+            "title": "03.05.09",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.09"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.10",
+            "class": "requirement",
+            "title": "03.05.10",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.10"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.05.07",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.11",
+            "class": "requirement",
+            "title": "Authentication Feedback",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.11"
+              },
+              {
+                "name": "label",
+                "value": "Authentication Feedback (03.05.11)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#2648e6d1-8618-48f6-8847-be83a99e0818",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.11",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.05.11",
+                "name": "guidance",
+                "prose": "Authentication feedback does not provide information that would allow unauthorized individuals to compromise authentication mechanisms. For example, for desktop or notebook systems with relatively large monitors, the threat may be significant (commonly referred to as shoulder surfing). For mobile devices with small displays, this threat may be less significant and is balanced against the increased likelihood of input errors due to small keyboards. Therefore, the means of obscuring authenticator feedback is selected accordingly. Obscuring feedback includes displaying asterisks when users type passwords into input devices or displaying feedback for a limited time before fully obscuring it."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.11",
+                "name": "assessment-objective",
+                "prose": "feedback of authentication information during the authentication process is obscured.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.11",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.11_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nprocedures for authenticator feedback\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.11_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.11_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing the obscuring of feedback of authentication information during authentication"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.05.12",
+            "class": "requirement",
+            "title": "Authenticator Management",
+            "params": [
+              {
+                "id": "A.03.05.12.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.12.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency for changing or refreshing authenticators is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.05.12.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.05.12.ODP[02]"
+                  }
+                ],
+                "label": "events",
+                "usage": "organization-defined events",
+                "guidelines": [
+                  {
+                    "prose": "events that trigger the change or refreshment of authenticators are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.05.12"
+              },
+              {
+                "name": "label",
+                "value": "Authenticator Management (03.05.12)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#46b414e1-a9d3-4cd5-a77c-fc146be57299",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.05.12",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.05.12.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.12.a"
+                      }
+                    ],
+                    "prose": "Verify the identity of the individual, group, role, service, or device receiving the authenticator as part of the initial authenticator distribution."
+                  },
+                  {
+                    "id": "SR-03.05.12.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.12.b"
+                      }
+                    ],
+                    "prose": "Establish initial authenticator content for any authenticators issued by the organization."
+                  },
+                  {
+                    "id": "SR-03.05.12.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.12.c"
+                      }
+                    ],
+                    "prose": "Establish and implement administrative procedures for initial authenticator distribution; for lost, compromised, or damaged authenticators; and for revoking authenticators."
+                  },
+                  {
+                    "id": "SR-03.05.12.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.12.d"
+                      }
+                    ],
+                    "prose": "Change default authenticators at first use."
+                  },
+                  {
+                    "id": "SR-03.05.12.e",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.12.e"
+                      }
+                    ],
+                    "prose": "Change or refresh authenticators {{ insert: param, A.03.05.12.ODP.01 }} or when the following events occur: {{ insert: param, A.03.05.12.ODP.02 }}."
+                  },
+                  {
+                    "id": "SR-03.05.12.f",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.05.12.f"
+                      }
+                    ],
+                    "prose": "Protect authenticator content from unauthorized disclosure and modification."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.05.12",
+                "name": "guidance",
+                "prose": "Authenticators include passwords, cryptographic devices, biometrics, certificates, one-time password devices, and ID badges. The initial authenticator content is the actual content of the authenticator (e.g., the initial password). In contrast, requirements for authenticator content contain specific characteristics. Authenticator management is supported by organization-defined settings and restrictions for various authenticator characteristics (e.g., password complexity and composition rules, validation time window for time synchronous one-time tokens, and the number of allowed rejections during the verification stage of biometric authentication). The requirement to protect individual authenticators may be implemented by [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.15.03)03.15.03 for authenticators in the possession of individuals and by [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.01) 03.01.01, [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.02) 03.01.02, [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.05)03.01.05, and [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.08)03.13.08 for authenticators stored in organizational systems. This includes passwords stored in hashed or encrypted formats or files that contain hashed or encrypted passwords that are accessible with administrator privileges. Actions can be taken to protect authenticators, including maintaining possession of authenticators, not sharing authenticators with others, and immediately reporting lost, stolen, or compromised authenticators. Developers may deliver system components with factory default authentication credentials to allow for initial installation and configuration. Default authentication credentials are often well-known, easily discoverable, and present a significant risk. Authenticator management includes issuing and revoking authenticators for temporary access when they are no longer needed. The use of long passwords or passphrases may obviate the need to periodically change authenticators."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.a",
+                "name": "assessment-objective",
+                "prose": "the identity of the individual, group, role, service, or device receiving the authenticator as part of the initial authenticator distribution is verified.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.b",
+                "name": "assessment-objective",
+                "prose": "initial authenticator content for any authenticators issued by the organization is established.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.c.01",
+                "name": "assessment-objective",
+                "prose": "administrative procedures for initial authenticator distribution are established.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.c.02",
+                "name": "assessment-objective",
+                "prose": "administrative procedures for lost, compromised, or damaged authenticators are established.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.c.03",
+                "name": "assessment-objective",
+                "prose": "administrative procedures for revoking authenticators are established.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.c.04",
+                "name": "assessment-objective",
+                "prose": "administrative procedures for initial authenticator distribution are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.c.05",
+                "name": "assessment-objective",
+                "prose": "administrative procedures for lost, compromised, or damaged authenticators are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.c.06",
+                "name": "assessment-objective",
+                "prose": "administrative procedures for revoking authenticators are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.d",
+                "name": "assessment-objective",
+                "prose": "default authenticators are changed at first use.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.e",
+                "name": "assessment-objective",
+                "prose": "authenticators are changed or refreshed {{ insert: param, A.03.05.12.ODP.01 }} or when the following events occur: {{ insert: param, A.03.05.12.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.e",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.f.01",
+                "name": "assessment-objective",
+                "prose": "authenticator content is protected from unauthorized disclosure.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.f",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.05.12.f.02",
+                "name": "assessment-objective",
+                "prose": "authenticator content is protected from unauthorized modification.",
+                "links": [
+                  {
+                    "href": "#SR-03.05.12.f",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.05.12_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "identification and authentication policy and procedures\n\nprocedures for authenticator management\n\nsystem configuration settings\n\nlist of system authenticator types\n\nsystem design documentation\n\nsystem audit records\n\nchange control records associated with managing system authenticators\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.05.12_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with authenticator management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.05.12_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing the authenticator management capability"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.06",
+        "class": "family",
+        "title": "Incident Response",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.06"
+          },
+          {
+            "name": "label",
+            "value": "Incident Response (03.06)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.06.01",
+            "class": "requirement",
+            "title": "Incident Handling",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.06.01"
+              },
+              {
+                "name": "label",
+                "value": "Incident Handling (03.06.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#3437202e-3b72-4cec-83c4-3b03a9e267a8",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              },
+              {
+                "href": "#6af8bc6f-a2ce-4b74-bc88-507d5bbc0c33",
+                "rel": "reference"
+              },
+              {
+                "href": "#46da9c8c-ae0f-4088-85a8-aa218b7f4de0",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.06.01",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.06.01",
+                "name": "guidance",
+                "prose": "Incident-related information can be obtained from a variety of sources, including audit monitoring, network monitoring, physical access monitoring, user and administrator reports, and reported supply chain events. An effective incident handling capability involves coordination among many organizational entities, including mission and business owners, system owners, human resources offices, physical and personnel security offices, legal departments, operations personnel, and procurement offices."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.01.01",
+                "name": "assessment-objective",
+                "prose": "an incident-handling capability that is consistent with the incident response plan is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.01.02",
+                "name": "assessment-objective",
+                "prose": "the incident handling capability includes preparation.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.01.03",
+                "name": "assessment-objective",
+                "prose": "the incident handling capability includes detection and analysis.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.01.04",
+                "name": "assessment-objective",
+                "prose": "the incident handling capability includes containment.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.01.05",
+                "name": "assessment-objective",
+                "prose": "the incident handling capability includes eradication.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.01.06",
+                "name": "assessment-objective",
+                "prose": "the incident handling capability includes recovery.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.06.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident response policy and procedures\n\ncontingency planning policy and procedures\n\nprocedures for incident handling\n\nprocedures for incident response planning\n\nincident response plan\n\ncontingency plan\n\nrecords of incident response plan reviews and approvals\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.06.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with incident handling responsibilities\n\npersonnel with incident response planning responsibilities\n\npersonnel with contingency planning responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.06.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident handling capability for the organization\n\nincident response plan"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.06.02",
+            "class": "requirement",
+            "title": "Incident Monitoring, Reporting, and Response Assistance",
+            "params": [
+              {
+                "id": "A.03.06.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.02.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period to report suspected incidents to the organizational incident response capability is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.06.02.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.02.ODP[02]"
+                  }
+                ],
+                "label": "authorities",
+                "usage": "organization-defined authorities",
+                "guidelines": [
+                  {
+                    "prose": "authorities to whom incident information is to be reported are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.06.02"
+              },
+              {
+                "name": "label",
+                "value": "Incident Monitoring, Reporting, and Response Assistance (03.06.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b4c05da9-c9cb-49c0-819b-0076c26f417e",
+                "rel": "reference"
+              },
+              {
+                "href": "#18730fb2-20c1-4ef7-b271-88a69d2091d6",
+                "rel": "reference"
+              },
+              {
+                "href": "#96f470cf-a8a3-407b-b531-db686248d67b",
+                "rel": "reference"
+              },
+              {
+                "href": "#46da9c8c-ae0f-4088-85a8-aa218b7f4de0",
+                "rel": "reference"
+              },
+              {
+                "href": "#d1d734b3-9384-42b3-968c-5ba2939626ee",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.06.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.06.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.02.a"
+                      }
+                    ],
+                    "prose": "Track and document system security incidents."
+                  },
+                  {
+                    "id": "SR-03.06.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.02.b"
+                      }
+                    ],
+                    "prose": "Report suspected incidents to the organizational incident response capability within {{ insert: param, A.03.06.02.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.06.02.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.02.c"
+                      }
+                    ],
+                    "prose": "Report incident information to {{ insert: param, A.03.06.02.ODP.02 }}."
+                  },
+                  {
+                    "id": "SR-03.06.02.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.02.d"
+                      }
+                    ],
+                    "prose": "Provide an incident response support resource that offers advice and assistance to system users on handling and reporting incidents."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.06.02",
+                "name": "guidance",
+                "prose": "Documenting incidents includes maintaining records about each incident, the status of the incident, and other pertinent information necessary for forensics as well as evaluating incident details, trends, and handling. Incident information can be obtained from many sources, including network monitoring, incident reports, incident response teams, user complaints, supply chain partners, audit monitoring, physical access monitoring, and user and administrator reports. [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.06.01)03.06.01 provides information on the types of incidents that are appropriate for monitoring. The types of incidents reported, the content and timeliness of the reports, and the reporting authorities reflect applicable laws, Executive Orders, directives, regulations, policies, standards, and guidelines. Incident information informs risk assessments, the effectiveness of security assessments, the security requirements for acquisitions, and the selection criteria for technology products. Incident response support resources provided by organizations include help desks, assistance groups, automated ticketing systems to open and track incident response tickets, and access to forensic services or consumer redress services, when required."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.02.a.01",
+                "name": "assessment-objective",
+                "prose": "system security incidents are tracked.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.02.a.02",
+                "name": "assessment-objective",
+                "prose": "system security incidents are documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.02.b",
+                "name": "assessment-objective",
+                "prose": "suspected incidents are reported to the organizational incident response capability within {{ insert: param, A.03.06.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.02.c",
+                "name": "assessment-objective",
+                "prose": "incident information is reported to {{ insert: param, A.03.06.02.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.02.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.02.d",
+                "name": "assessment-objective",
+                "prose": "an incident response support resource that offers advice and assistance to system users on handling and reporting incidents is provided.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.02.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.06.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident response policy and procedures\n\nprocedures for incident monitoring\n\nprocedures for incident response assistance\n\nincident response records and documentation\n\nincident response plan\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.06.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with incident monitoring responsibilities\n\npersonnel with incident response assistance and support responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.06.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for incident reporting\n\nincident monitoring capability\n\nmechanisms for supporting or implementing the tracking and documenting of system security incidents\n\nmechanisms for supporting or implementing incident reporting\n\nmechanisms for supporting or implementing incident response assistance\n\nprocesses for incident response assistance"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.06.03",
+            "class": "requirement",
+            "title": "Incident Response Testing",
+            "params": [
+              {
+                "id": "A.03.06.03.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.03.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to test the effectiveness of the incident response capability for the system is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.06.03"
+              },
+              {
+                "name": "label",
+                "value": "Incident Response Testing (03.06.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#5e56bdf5-cedb-42ae-988e-feec7f3ae98b",
+                "rel": "reference"
+              },
+              {
+                "href": "#49c62ac0-6eb3-4bce-ae3d-4bffd33290fe",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.06.03",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.06.03",
+                "name": "guidance",
+                "prose": "Organizations test incident response capabilities to determine their effectiveness and identify potential weaknesses or deficiencies. Incident response testing includes the use of checklists, walk-through or tabletop exercises, and simulations. Incident response testing can include a determination of the effects of incident response on organizational operations, organizational assets, and individuals. Qualitative and quantitative data can help determine the effectiveness of incident response processes."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.03",
+                "name": "assessment-objective",
+                "prose": "the effectiveness of the incident response capability is tested {{ insert: param, A.03.06.03.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.06.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident response policy and procedures\n\ncontingency planning policy and procedures\n\nprocedures for incident response testing\n\nprocedures for contingency plan testing\n\nincident response testing material\n\nincident response test results\n\nincident response test plan\n\nincident response plan\n\ncontingency plan\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.06.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with incident response testing responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.06.04",
+            "class": "requirement",
+            "title": "Incident Response Training",
+            "params": [
+              {
+                "id": "A.03.06.04.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.04.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which incident response training is to be provided to system users is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.06.04.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.04.ODP[02]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to provide incident response training to users after initial training is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.06.04.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.04.ODP[04]"
+                  }
+                ],
+                "label": "events",
+                "usage": "organization-defined events",
+                "guidelines": [
+                  {
+                    "prose": "events that initiate a review of the incident response training content are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.06.04.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.06.04.ODP[03]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review and update incident response training content is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.06.04"
+              },
+              {
+                "name": "label",
+                "value": "Incident Response Training (03.06.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#478afc24-d6f6-45f6-b020-b55706df5241",
+                "rel": "reference"
+              },
+              {
+                "href": "#a07d3a28-bdd3-4161-b724-485cb436eba0",
+                "rel": "reference"
+              },
+              {
+                "href": "#d1d734b3-9384-42b3-968c-5ba2939626ee",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.06.04",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.06.04.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.04.a"
+                      }
+                    ],
+                    "prose": "Provide incident response training to system users consistent with assigned roles and responsibilities:",
+                    "parts": [
+                      {
+                        "id": "SR-03.06.04.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.04.a.01"
+                          }
+                        ],
+                        "prose": "Within {{ insert: param, A.03.06.04.ODP.01 }} of assuming an incident response role or responsibility or acquiring system access,"
+                      },
+                      {
+                        "id": "SR-03.06.04.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.04.a.02"
+                          }
+                        ],
+                        "prose": "When required by system changes, and"
+                      },
+                      {
+                        "id": "SR-03.06.04.a.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.04.a.03"
+                          }
+                        ],
+                        "prose": "{{ insert: param, A.03.06.04.ODP.02 }} thereafter."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.06.04.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.04.b"
+                      }
+                    ],
+                    "prose": "Review and update incident response training content {{ insert: param, A.03.06.04.ODP.03 }} and following {{ insert: param, A.03.06.04.ODP.04 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.06.04",
+                "name": "guidance",
+                "prose": "Incident response training is associated with the assigned roles and responsibilities of organizational personnel to ensure that the appropriate content and level of detail are included in such training. For example, users may only need to know how to recognize an incident or whom to call; system administrators may require additional training on how to handle incidents; and incident responders may receive specific training on data collection techniques, forensics, reporting, system recovery, and system restoration. Incident response training includes user training in identifying and reporting suspicious activities from external and internal sources. Incident response training for users may be provided as part of [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.02.02)03.02.02. Events that may cause an update to incident response training content include incident response plan testing, response to an actual incident, audit or assessment findings, or changes in applicable laws, Executive Orders, policies, directives, regulations, standards, and guidelines."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.a.01",
+                "name": "assessment-objective",
+                "prose": "incident response training for system users consistent with assigned roles and responsibilities is provided within {{ insert: param, A.03.06.04.ODP.01 }} of assuming an incident response role or responsibility or acquiring system access.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.a.02",
+                "name": "assessment-objective",
+                "prose": "incident response training for system users consistent with assigned roles and responsibilities is provided when required by system changes.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.a.03",
+                "name": "assessment-objective",
+                "prose": "incident response training for system users consistent with assigned roles and responsibilities is provided {{ insert: param, A.03.06.04.ODP.02 }} thereafter.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.b.04",
+                "name": "assessment-objective",
+                "prose": "incident response training content is updated following {{ insert: param, A.03.06.04.ODP.04 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.b.02",
+                "name": "assessment-objective",
+                "prose": "incident response training content is updated {{ insert: param, A.03.06.04.ODP.03 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.b.03",
+                "name": "assessment-objective",
+                "prose": "incident response training content is reviewed following {{ insert: param, A.03.06.04.ODP.04 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.04.b.01",
+                "name": "assessment-objective",
+                "prose": "incident response training content is reviewed {{ insert: param, A.03.06.04.ODP.03 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.06.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident response policy and procedures\n\nprocedures for incident response training\n\nincident response training curriculum\n\nincident response training materials\n\nincident response plan\n\nincident response training records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.06.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with incident response training and operational responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.06.05",
+            "class": "requirement",
+            "title": "Incident Response Plan",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.06.05"
+              },
+              {
+                "name": "label",
+                "value": "Incident Response Plan (03.06.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#0279cdf8-f523-4b59-98ad-25352980e72d",
+                "rel": "reference"
+              },
+              {
+                "href": "#a07d3a28-bdd3-4161-b724-485cb436eba0",
+                "rel": "reference"
+              },
+              {
+                "href": "#d1d734b3-9384-42b3-968c-5ba2939626ee",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.06.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.06.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.05.a"
+                      }
+                    ],
+                    "prose": "Develop an incident response plan that:",
+                    "parts": [
+                      {
+                        "id": "SR-03.06.05.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.05.a.01"
+                          }
+                        ],
+                        "prose": "Provides the organization with a roadmap for implementing its incident response capability,"
+                      },
+                      {
+                        "id": "SR-03.06.05.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.05.a.02"
+                          }
+                        ],
+                        "prose": "Describes the structure and organization of the incident response capability,"
+                      },
+                      {
+                        "id": "SR-03.06.05.a.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.05.a.03"
+                          }
+                        ],
+                        "prose": "Provides a high-level approach for how the incident response capability fits into the overall organization,"
+                      },
+                      {
+                        "id": "SR-03.06.05.a.04",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.05.a.04"
+                          }
+                        ],
+                        "prose": "Defines reportable incidents,"
+                      },
+                      {
+                        "id": "SR-03.06.05.a.05",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.05.a.05"
+                          }
+                        ],
+                        "prose": "Addresses the sharing of incident information, and"
+                      },
+                      {
+                        "id": "SR-03.06.05.a.06",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.06.05.a.06"
+                          }
+                        ],
+                        "prose": "Designates responsibilities to organizational entities, personnel, or roles."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.06.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.05.b"
+                      }
+                    ],
+                    "prose": "Distribute copies of the incident response plan to designated incident response personnel (identified by name and/or by role) and organizational elements."
+                  },
+                  {
+                    "id": "SR-03.06.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.05.c"
+                      }
+                    ],
+                    "prose": "Update the incident response plan to address system and organizational changes or problems encountered during plan implementation, execution, or testing."
+                  },
+                  {
+                    "id": "SR-03.06.05.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.06.05.d"
+                      }
+                    ],
+                    "prose": "Protect the incident response plan from unauthorized disclosure."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.06.05",
+                "name": "guidance",
+                "prose": "It is important that organizations develop and implement a coordinated approach to incident response. Organizational mission and business functions determine the structure of incident response capabilities. As part of the incident response capabilities, organizations consider the coordination and sharing of information with external organizations, including external service providers and other organizations involved in the supply chain."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.a.01",
+                "name": "assessment-objective",
+                "prose": "an incident response plan is developed that provides the organization with a roadmap for implementing its incident response capability.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.a.02",
+                "name": "assessment-objective",
+                "prose": "an incident response plan is developed that describes the structure and organization of the incident response capability.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.a.03",
+                "name": "assessment-objective",
+                "prose": "an incident response plan is developed that provides a high-level approach for how the incident response capability fits into the overall organization.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.a.04",
+                "name": "assessment-objective",
+                "prose": "an incident response plan is developed that defines reportable incidents.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.a.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.a.05",
+                "name": "assessment-objective",
+                "prose": "an incident response plan is developed that addresses the sharing of incident information.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.a.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.a.06",
+                "name": "assessment-objective",
+                "prose": "an incident response plan is developed that designates responsibilities to organizational entities, personnel, or roles.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.a.06",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.b.01",
+                "name": "assessment-objective",
+                "prose": "copies of the incident response plan are distributed to designated incident response personnel (identified by name or by role).",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.b.02",
+                "name": "assessment-objective",
+                "prose": "copies of the incident response plan are distributed to organizational elements.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.d",
+                "name": "assessment-objective",
+                "prose": "the incident response plan is protected from unauthorized disclosure.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.06.05.c",
+                "name": "assessment-objective",
+                "prose": "the incident response plan is updated to address system and organizational changes or problems encountered during plan implementation, execution, or testing.",
+                "links": [
+                  {
+                    "href": "#SR-03.06.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.06.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident response policy\n\nprocedures addressing incident response planning\n\nincident response plan\n\nsystem security plan\n\nrecords of incident response plan reviews and approvals\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.06.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with incident response planning responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.06.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "incident response plan and related processes"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.07",
+        "class": "family",
+        "title": "Maintenance",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.07"
+          },
+          {
+            "name": "label",
+            "value": "Maintenance (03.07)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.07.01",
+            "class": "requirement",
+            "title": "03.07.01",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.07.01"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.07.02",
+            "class": "requirement",
+            "title": "03.07.02",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.07.02"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.07.04",
+                "rel": "incorporated_into"
+              },
+              {
+                "href": "03.07.06",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.07.03",
+            "class": "requirement",
+            "title": "03.07.03",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.07.03"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.08.03",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.07.04",
+            "class": "requirement",
+            "title": "Maintenance Tools",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.07.04"
+              },
+              {
+                "name": "label",
+                "value": "Maintenance Tools (03.07.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#97ff2d49-5fe3-4268-8b1f-6f5308c7e705",
+                "rel": "reference"
+              },
+              {
+                "href": "#19b77d31-b8c2-4fba-abba-53c56ad7e490",
+                "rel": "reference"
+              },
+              {
+                "href": "#c5e7e7f0-794e-44ec-814e-a01599bb719d",
+                "rel": "reference"
+              },
+              {
+                "href": "#a873ad87-a316-4204-ae2c-734220738c45",
+                "rel": "reference"
+              },
+              {
+                "href": "#c3256cd6-5ed6-42df-b2f9-0bff7fb8d8c9",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.07.04",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.07.04.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.04.a"
+                      }
+                    ],
+                    "prose": "Approve, control, and monitor the use of system maintenance tools."
+                  },
+                  {
+                    "id": "SR-03.07.04.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.04.b"
+                      }
+                    ],
+                    "prose": "Check media with diagnostic and test programs for malicious code before it is used in the system."
+                  },
+                  {
+                    "id": "SR-03.07.04.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.04.c"
+                      }
+                    ],
+                    "prose": "Prevent the removal of system maintenance equipment containing CUI by verifying that there is no CUI on the equipment, sanitizing or destroying the equipment, or retaining the equipment within the facility."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.07.04",
+                "name": "guidance",
+                "prose": "Approving, controlling, monitoring, and reviewing maintenance tools address security-related issues associated with the tools that are used for diagnostic and repair actions on the system. Maintenance tools can include hardware and software diagnostic and test equipment as well as packet sniffers. The tools may be pre-installed, brought in with maintenance personnel on media, cloud-based, or downloaded from a website. Diagnostic and test programs are potential vehicles for transporting malicious code into the system, either intentionally or unintentionally. Examples of media inspection include checking the cryptographic hash or digital signatures of diagnostic and test programs and media. If organizations inspect media that contain diagnostic and test programs and determine that the media also contain malicious code, the incident is handled consistent with incident handling policies and procedures. A periodic review of system maintenance tools can result in the withdrawal of approval for outdated, unsupported, irrelevant, or no-longer-used tools. Maintenance tools do not address the hardware and software components that support maintenance and are considered a part of the system."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.04.a.01",
+                "name": "assessment-objective",
+                "prose": "the use of system maintenance tools is approved.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.04.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.04.a.02",
+                "name": "assessment-objective",
+                "prose": "the use of system maintenance tools is controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.04.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.04.a.03",
+                "name": "assessment-objective",
+                "prose": "the use of system maintenance tools is monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.04.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.04.b",
+                "name": "assessment-objective",
+                "prose": "media with diagnostic and test programs are checked for malicious code before the media are used in the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.04.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.04.c",
+                "name": "assessment-objective",
+                "prose": "the removal of system maintenance equipment containing CUI is prevented by verifying that there is no CUI on the equipment, sanitizing or destroying the equipment, or retaining the equipment within the facility.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.04.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.07.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "maintenance policy and procedures\n\nprocedures for system maintenance tools\n\nsystem maintenance tools\n\nmaintenance tool inspection records\n\nequipment sanitization records\n\nmedia sanitization records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.07.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system maintenance responsibilities\n\npersonnel responsible for media sanitization\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.07.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for approving, controlling, and monitoring maintenance tools\n\nmechanisms for supporting or implementing the approval, control, or monitoring of maintenance tools\n\nprocesses for preventing the unauthorized removal of information\n\nprocesses for inspecting media for malicious code\n\nmechanisms for supporting media sanitization or the destruction of equipment\n\nmechanisms for supporting the verification of media sanitization\n\nprocesses for inspecting maintenance tools\n\nmechanisms for supporting or implementing the inspection of maintenance tools\n\nmechanisms for supporting or implementing the inspection of media used for maintenance"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.07.05",
+            "class": "requirement",
+            "title": "Nonlocal Maintenance",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.07.05"
+              },
+              {
+                "name": "label",
+                "value": "Nonlocal Maintenance (03.07.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#2ea5b97c-3beb-406d-85ce-7942f262ee8d",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              },
+              {
+                "href": "#c3256cd6-5ed6-42df-b2f9-0bff7fb8d8c9",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.07.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.07.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.05.a"
+                      }
+                    ],
+                    "prose": "Approve and monitor nonlocal maintenance and diagnostic activities."
+                  },
+                  {
+                    "id": "SR-03.07.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.05.b"
+                      }
+                    ],
+                    "prose": "Implement multi-factor authentication and replay resistance in the establishment of nonlocal maintenance and diagnostic sessions."
+                  },
+                  {
+                    "id": "SR-03.07.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.05.c"
+                      }
+                    ],
+                    "prose": "Terminate session and network connections when nonlocal maintenance is completed."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.07.05",
+                "name": "guidance",
+                "prose": "Nonlocal maintenance and diagnostic activities are conducted by individuals who communicate through an external or internal network. Local maintenance and diagnostic activities are carried out by individuals who are physically present at the location of the system and not communicating across a network connection. Authentication techniques used to establish nonlocal maintenance and diagnostic sessions reflect the requirements in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.05.01) 03.05.01."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.05.a.01",
+                "name": "assessment-objective",
+                "prose": "nonlocal maintenance and diagnostic activities are approved.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.05.a.02",
+                "name": "assessment-objective",
+                "prose": "nonlocal maintenance and diagnostic activities are monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.05.c.01",
+                "name": "assessment-objective",
+                "prose": "session connections are terminated when nonlocal maintenance is completed.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.05.c.02",
+                "name": "assessment-objective",
+                "prose": "network connections are terminated when nonlocal maintenance is completed.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.05.b.01",
+                "name": "assessment-objective",
+                "prose": "multi-factor authentication is implemented in the establishment of nonlocal maintenance and diagnostic sessions.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.05.b.02",
+                "name": "assessment-objective",
+                "prose": "replay resistance is implemented in the establishment of nonlocal maintenance and diagnostic sessions.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.07.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "maintenance policy and procedures\n\nremote access policy and procedures\n\nprocedures for nonlocal system maintenance\n\nrecords of remote access\n\nmaintenance records\n\ndiagnostic records\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.07.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system maintenance responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.07.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for managing nonlocal maintenance\n\nmechanisms for implementing, supporting, or managing nonlocal maintenance\n\nmechanisms for implementing multi-factor authentication and replay resistance\n\nmechanisms for terminating nonlocal maintenance sessions and network connections"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.07.06",
+            "class": "requirement",
+            "title": "Maintenance Personnel",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.07.06"
+              },
+              {
+                "name": "label",
+                "value": "Maintenance Personnel (03.07.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#8683e2cc-7184-4407-8774-e45f85a7e85e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.07.06",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.07.06.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.06.a"
+                      }
+                    ],
+                    "prose": "Establish a process for maintenance personnel authorization."
+                  },
+                  {
+                    "id": "SR-03.07.06.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.06.b"
+                      }
+                    ],
+                    "prose": "Maintain a list of authorized maintenance organizations or personnel."
+                  },
+                  {
+                    "id": "SR-03.07.06.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.06.c"
+                      }
+                    ],
+                    "prose": "Verify that non-escorted personnel who perform maintenance on the system possess the required access authorizations."
+                  },
+                  {
+                    "id": "SR-03.07.06.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.07.06.d"
+                      }
+                    ],
+                    "prose": "Designate organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.07.06",
+                "name": "guidance",
+                "prose": "Maintenance personnel refers to individuals who perform hardware or software maintenance on the system, while [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.10.01)03.10.01 addresses physical access for individuals whose maintenance duties place them within the physical protection perimeter of the system. The technical competence of supervising individuals relates to the maintenance performed on the system, while having required access authorizations refers to maintenance on and near the system. Individuals who have not been previously identified as authorized maintenance personnel (e.g., manufacturers, consultants, systems integrators, and vendors) may require privileged access to the system, such as when they are required to conduct maintenance with little or no notice. Organizations may choose to issue temporary credentials to these individuals based on their risk assessments. Temporary credentials may be for one-time use or for very limited time periods."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.06.a",
+                "name": "assessment-objective",
+                "prose": "a process for maintenance personnel authorization is established.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.06.b",
+                "name": "assessment-objective",
+                "prose": "a list of authorized maintenance organizations or personnel is maintained.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.06.d.01",
+                "name": "assessment-objective",
+                "prose": "organizational personnel with required access authorizations are designated to supervise the maintenance activities of personnel who do not possess the required access authorizations.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.06.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.06.d.02",
+                "name": "assessment-objective",
+                "prose": "organizational personnel with required technical competence are designated to supervise the maintenance activities of personnel who do not possess the required access authorizations.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.06.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.07.06.c",
+                "name": "assessment-objective",
+                "prose": "non-escorted personnel who perform maintenance on the system possess the required access authorizations.",
+                "links": [
+                  {
+                    "href": "#SR-03.07.06.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.07.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "maintenance policy and procedures\n\nservice provider contracts\n\nservice-level agreements\n\nlist of authorized personnel\n\nmaintenance records\n\naccess control records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.07.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system maintenance responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.07.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for authorizing and managing maintenance personnel\n\nmechanisms for supporting or implementing the authorization of maintenance personnel"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.08",
+        "class": "family",
+        "title": "Media Protection",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.08"
+          },
+          {
+            "name": "label",
+            "value": "Media Protection (03.08)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.08.01",
+            "class": "requirement",
+            "title": "Media Storage",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.01"
+              },
+              {
+                "name": "label",
+                "value": "Media Storage (03.08.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#6cefb03a-c051-45bd-bd34-8d819e38c1d5",
+                "rel": "reference"
+              },
+              {
+                "href": "#226b6921-eab4-4662-b0df-f2f6049eb782",
+                "rel": "reference"
+              },
+              {
+                "href": "#c3256cd6-5ed6-42df-b2f9-0bff7fb8d8c9",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.01",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.08.01",
+                "name": "guidance",
+                "prose": "System media include digital and non-digital media. Digital media include diskettes, flash drives, magnetic tapes, external or removable solid state or magnetic drives, compact discs, and digital versatile discs. Non-digital media include paper and microfilm. Physically controlling stored media includes conducting inventories, establishing procedures to allow individuals to check out and return media to libraries, and maintaining accountability for stored media. Secure storage includes a locked drawer, desk, or cabinet or a controlled media library. Controlled areas provide physical and procedural controls to meet the requirements established for protecting information and systems. Sanitization techniques (e.g., destroying, cryptographically erasing, clearing, and purging) prevent the disclosure of CUI to unauthorized individuals. The sanitization process removes CUI from media such that the information cannot be retrieved or reconstructed."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.01.01",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are physically controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.01.02",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are securely stored.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nmedia protection policy and procedures\n\nprocedures for media storage\n\naccess control policy and procedures\n\nsystem media\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system media protection and storage responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for storing information media\n\nmechanisms for supporting or implementing secure media storage/media protection"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.02",
+            "class": "requirement",
+            "title": "Media Access",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.02"
+              },
+              {
+                "name": "label",
+                "value": "Media Access (03.08.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#db611cd9-b2d3-4885-b016-31ed93f78598",
+                "rel": "reference"
+              },
+              {
+                "href": "#226b6921-eab4-4662-b0df-f2f6049eb782",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.02",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.08.02",
+                "name": "guidance",
+                "prose": "System media include digital and non-digital media. Access to CUI on system media can be restricted by physically controlling such media. This includes conducting inventories, ensuring that procedures are in place to allow individuals to check out and return media to the media library, and maintaining accountability for stored media. For digital media, access to CUI can be restricted by using cryptographic means. Encrypting data in storage or at rest is addressed in [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.08) 03.13.08."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.02",
+                "name": "assessment-objective",
+                "prose": "access to CUI on system media is restricted to authorized personnel or roles.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nmedia protection policy and procedures\n\nprocedures for media access restrictions\n\naccess control policy and procedures\n\nmedia storage facilities\n\naccess control records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system media protection responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for restricting information on media\n\nmechanisms for supporting or implementing media access restrictions"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.03",
+            "class": "requirement",
+            "title": "Media Sanitization",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.03"
+              },
+              {
+                "name": "label",
+                "value": "Media Sanitization (03.08.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b76b4068-efbd-4c42-9aee-d93844c963d8",
+                "rel": "reference"
+              },
+              {
+                "href": "#c3256cd6-5ed6-42df-b2f9-0bff7fb8d8c9",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.03",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.08.03",
+                "name": "guidance",
+                "prose": "Media sanitization applies to digital and non-digital media that are subject to disposal or reuse, whether or not the media are considered removable. Examples include digital media in scanners, copiers, printers, notebook computers, mobile devices, workstations, network components, and non-digital media. The sanitization process removes CUI from media such that the information cannot be retrieved or reconstructed. Sanitization techniques (e.g., cryptographically erasing, clearing, purging, and destroying) prevent the disclosure of CUI to unauthorized individuals when such media are reused or released for disposal. NARA policies control the sanitization process for media that contain CUI and may require destruction when other methods cannot be applied to the media."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.03",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are sanitized prior to disposal, release out of organizational control, or release for reuse.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "media protection policy and procedures\n\nprocedures for media sanitization and disposal\n\napplicable standards and policies that address media sanitization policy\n\nsystem audit records\n\nmedia sanitization records\n\nsystem design documentation\n\nsystem configuration settings\n\nrecords retention and disposition policy\n\nrecords retention and disposition procedures\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with media sanitization responsibilities\n\npersonnel with records retention and disposition responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for media sanitization\n\nmechanisms for supporting or implementing media sanitization"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.04",
+            "class": "requirement",
+            "title": "Media Marking",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.04"
+              },
+              {
+                "name": "label",
+                "value": "Media Marking (03.08.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#7b44c40d-973a-4fa0-a477-e400e64b98e3",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.04",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.08.04",
+                "name": "guidance",
+                "prose": "System media include digital and non-digital media. Marking refers to the use or application of human-readable security attributes. Labeling refers to the use of security attributes for internal system data structures. Digital media include diskettes, magnetic tapes, external or removable solid state or magnetic drives, flash drives, compact discs, and digital versatile discs. Non-digital media include paper and microfilm. CUI is defined by NARA along with marking, safeguarding, and dissemination requirements for such information."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.04.01",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are marked to indicate distribution limitations.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.04.02",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are marked to indicate handling caveats.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.04.03",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are marked to indicate applicable CUI markings.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nmedia protection policy and procedures\n\nprocedures for media marking\n\nlist of system media marking security attributes\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system media protection and marking responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for marking information media\n\nmechanisms for supporting or implementing media marking"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.05",
+            "class": "requirement",
+            "title": "Media Transport",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.05"
+              },
+              {
+                "name": "label",
+                "value": "Media Transport (03.08.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#df285ec9-d424-4ad6-b71e-43a67fde9b6f",
+                "rel": "reference"
+              },
+              {
+                "href": "#1a3eaa86-0aed-4af8-9be8-0477122cae56",
+                "rel": "reference"
+              },
+              {
+                "href": "#226b6921-eab4-4662-b0df-f2f6049eb782",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.08.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.05.a"
+                      }
+                    ],
+                    "prose": "Protect and control system media that contain CUI during transport outside of controlled areas."
+                  },
+                  {
+                    "id": "SR-03.08.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.05.b"
+                      }
+                    ],
+                    "prose": "Maintain accountability of system media that contain CUI during transport outside of controlled areas."
+                  },
+                  {
+                    "id": "SR-03.08.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.05.c"
+                      }
+                    ],
+                    "prose": "Document activities associated with the transport of system media that contain CUI."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.08.05",
+                "name": "guidance",
+                "prose": "System media include digital and non-digital media. Digital media include flash drives, diskettes, magnetic tapes, external or removable solid state or magnetic drives, compact discs, and digital versatile discs. Non-digital media include microfilm and paper. Controlled areas are spaces for which organizations provide physical or procedural measures to meet the requirements established for protecting CUI and systems. Media protection during transport can include cryptography and/or locked containers. Activities associated with media transport include releasing media for transport, ensuring that media enter the appropriate transport processes, and the actual transport. Authorized transport and courier personnel may include individuals external to the organization. Maintaining accountability of media during transport includes restricting transport activities to authorized personnel and tracking or obtaining the records of transport activities as the media move through the transportation system to prevent and detect loss, destruction, or tampering. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.08)03.13.08 and [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.11) 03.13.11."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.05.a.01",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are protected during transport outside of controlled areas.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.05.a.02",
+                "name": "assessment-objective",
+                "prose": "system media that contain CUI are controlled during transport outside of controlled areas.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.05.c",
+                "name": "assessment-objective",
+                "prose": "activities associated with the transport of system media that contain CUI are documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.05.b",
+                "name": "assessment-objective",
+                "prose": "accountability for system media that contain CUI is maintained during transport outside of controlled areas.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nmedia protection policy and procedures\n\nprocedures for media storage\n\naccess control policy and procedures\n\nauthorized personnel list\n\nsystem media\n\ndesignated controlled areas\n\nsystem and communications protection policy and procedures\n\ncryptographic mechanisms and configuration documentation\n\nprocedures for the protection of information at rest\n\nsystem design documentation\n\nsystem configuration settings\n\nlist of information at rest requiring confidentiality protections\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system media protection and storage responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.05_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for storing information media\n\nmechanisms for supporting or implementing media storage/media protection\n\nmechanisms for supporting or implementing confidentiality protections for information at rest"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.06",
+            "class": "requirement",
+            "title": "03.08.06",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.06"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.13.08",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.07",
+            "class": "requirement",
+            "title": "Media Use",
+            "params": [
+              {
+                "id": "A.03.08.07.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.08.07.ODP[01]"
+                  }
+                ],
+                "label": "types of system media",
+                "usage": "organization-defined types of system media",
+                "guidelines": [
+                  {
+                    "prose": "types of system media with usage restrictions or that are prohibited from use are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.07"
+              },
+              {
+                "name": "label",
+                "value": "Media Use (03.08.07)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#f757e913-9a1f-4a73-b992-397d4a0438f5",
+                "rel": "reference"
+              },
+              {
+                "href": "#226b6921-eab4-4662-b0df-f2f6049eb782",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.07",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.08.07.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.07.a"
+                      }
+                    ],
+                    "prose": "Restrict or prohibit the use of {{ insert: param, A.03.08.07.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.08.07.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.07.b"
+                      }
+                    ],
+                    "prose": "Prohibit the use of removable system media without an identifiable owner."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.08.07",
+                "name": "guidance",
+                "prose": "In contrast to requirement [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.08.01)03.08.01, which restricts user access to media, this requirement restricts or prohibits the use of certain types of media, such as external hard drives, flash drives, or smart displays. Organizations can use technical and non-technical measures (e.g., policies, procedures, and rules of behavior) to control the use of system media. For example, organizations may control the use of portable storage devices by using physical cages on workstations to prohibit access to external ports or disabling or removing the ability to insert, read, or write to devices. Organizations may limit the use of portable storage devices to only approved devices, including devices provided by the organization, devices provided by other approved organizations, and devices that are not personally owned. Organizations may also control the use of portable storage devices based on the type of device — prohibiting the use of writeable, portable devices — and implement this restriction by disabling or removing the capability to write to such devices. Limits on the use of organization-controlled system media in external systems include restrictions on how the media may be used and under what conditions. Requiring identifiable owners (e.g., individuals, organizations, or projects) for removable system media reduces the risk of using such technologies by allowing organizations to assign responsibility and accountability for addressing known vulnerabilities in the media (e.g., insertion of malicious code)."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.07.a",
+                "name": "assessment-objective",
+                "prose": "the use of the following types of system media is restricted or prohibited: {{ insert: param, A.03.08.07.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.07.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.07.b",
+                "name": "assessment-objective",
+                "prose": "the use of removable system media without an identifiable owner is prohibited.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.07.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.07_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system media protection policy and procedures\n\nsystem use policy\n\nprocedures for media usage restrictions\n\nrules of behavior\n\nsystem audit records\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.07_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system media use responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.07_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for media use\n\nmechanisms for restricting or prohibiting the use of system media on systems or system components"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.08",
+            "class": "requirement",
+            "title": "03.08.08",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.08"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.08.07",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.08.09",
+            "class": "requirement",
+            "title": "System Backup – Cryptographic Protection",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.08.09"
+              },
+              {
+                "name": "label",
+                "value": "System Backup – Cryptographic Protection (03.08.09)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#29cd3753-76bb-4b97-a484-f10c10d093ed",
+                "rel": "reference"
+              },
+              {
+                "href": "#d820b996-2a6e-4c4d-9aa8-88118b0664b1",
+                "rel": "reference"
+              },
+              {
+                "href": "#fefb62cb-b252-4071-a540-fa193db38895",
+                "rel": "reference"
+              },
+              {
+                "href": "#cd930fe4-ad2c-4d44-954e-2755be2c8673",
+                "rel": "reference"
+              },
+              {
+                "href": "#e7712341-d9f9-4f8b-9f32-516ddd1960e0",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.08.09",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.08.09.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.09.a"
+                      }
+                    ],
+                    "prose": "Protect the confidentiality of backup information."
+                  },
+                  {
+                    "id": "SR-03.08.09.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.08.09.b"
+                      }
+                    ],
+                    "prose": "Implement cryptographic mechanisms to prevent the unauthorized disclosure of CUI at backup storage locations."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.08.09",
+                "name": "guidance",
+                "prose": "The selection of cryptographic mechanisms is based on the need to protect the confidentiality of backup information. Hardware security module (HSM) devices safeguard and manage cryptographic keys and provide cryptographic processing. Cryptographic operations (e.g., encryption, decryption, and signature generation and verification) are typically hosted on the HSM device, and many implementations provide hardware-accelerated mechanisms for cryptographic operations. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.11) 03.13.11."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.09.b",
+                "name": "assessment-objective",
+                "prose": "cryptographic mechanisms are implemented to prevent the unauthorized disclosure of CUI at backup storage locations.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.09.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.08.09.a",
+                "name": "assessment-objective",
+                "prose": "the confidentiality of backup information is protected.",
+                "links": [
+                  {
+                    "href": "#SR-03.08.09.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.08.09_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "contingency planning policy and procedures\n\nprocedures for system backup\n\ncontingency plan\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.08.09_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system backup responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.08.09_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing the cryptographic protection of backup information"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.09",
+        "class": "family",
+        "title": "Personnel Security",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.09"
+          },
+          {
+            "name": "label",
+            "value": "Personnel Security (03.09)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.09.01",
+            "class": "requirement",
+            "title": "Personnel Screening",
+            "params": [
+              {
+                "id": "A.03.09.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.09.01.ODP[01]"
+                  }
+                ],
+                "label": "conditions",
+                "usage": "organization-defined conditions requiring rescreening",
+                "guidelines": [
+                  {
+                    "prose": "conditions that require the rescreening of individuals are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.09.01"
+              },
+              {
+                "name": "label",
+                "value": "Personnel Screening (03.09.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#8ebdf692-6004-46ff-8ffa-044383bf214b",
+                "rel": "reference"
+              },
+              {
+                "href": "#2932aa8a-9447-435b-9fc8-98b82b6e617c",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.09.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.09.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.09.01.a"
+                      }
+                    ],
+                    "prose": "Screen individuals prior to authorizing access to the system."
+                  },
+                  {
+                    "id": "SR-03.09.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.09.01.b"
+                      }
+                    ],
+                    "prose": "Rescreen individuals in accordance with {{ insert: param, A.03.09.01.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.09.01",
+                "name": "guidance",
+                "prose": "Personnel security screening activities involve the assessment of the conduct, integrity, judgment, loyalty, reliability, and stability of an individual (i.e., the individual’s trustworthiness) prior to authorizing access to the system or when elevating system access. The screening and rescreening activities reflect applicable federal laws, Executive Orders, directives, policies, regulations, and criteria established for the level of access required for the assigned position."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.01.a",
+                "name": "assessment-objective",
+                "prose": "individuals are screened prior to authorizing access to the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.01.b",
+                "name": "assessment-objective",
+                "prose": "individuals are rescreened in accordance with the following conditions: {{ insert: param, A.03.09.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.09.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel security policy and procedures\n\nprocedures for personnel screening and rescreening\n\nrecords of screened personnel\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.09.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with personnel security responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.09.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for personnel screening and rescreening"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.09.02",
+            "class": "requirement",
+            "title": "Personnel Termination and Transfer",
+            "params": [
+              {
+                "id": "A.03.09.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.09.02.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which to disable system access is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.09.02"
+              },
+              {
+                "name": "label",
+                "value": "Personnel Termination and Transfer (03.09.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#29262f3c-2ac6-4cff-9315-4feee3ef51ba",
+                "rel": "reference"
+              },
+              {
+                "href": "#8ef1bc1d-cac5-46e5-b57e-2acee8c6a1a1",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.09.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.09.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.09.02.a"
+                      }
+                    ],
+                    "prose": "When individual employment is terminated:",
+                    "parts": [
+                      {
+                        "id": "SR-03.09.02.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.09.02.a.01"
+                          }
+                        ],
+                        "prose": "Disable system access within {{ insert: param, A.03.09.02.ODP.01 }},"
+                      },
+                      {
+                        "id": "SR-03.09.02.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.09.02.a.02"
+                          }
+                        ],
+                        "prose": "Terminate or revoke authenticators and credentials associated with the individual, and"
+                      },
+                      {
+                        "id": "SR-03.09.02.a.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.09.02.a.03"
+                          }
+                        ],
+                        "prose": "Retrieve security-related system property."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.09.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.09.02.b"
+                      }
+                    ],
+                    "prose": "When individuals are reassigned or transferred to other positions in the organization:",
+                    "parts": [
+                      {
+                        "id": "SR-03.09.02.b.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.09.02.b.01"
+                          }
+                        ],
+                        "prose": "Review and confirm the ongoing operational need for current logical and physical access authorizations to the system and facility, and"
+                      },
+                      {
+                        "id": "SR-03.09.02.b.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.09.02.b.02"
+                          }
+                        ],
+                        "prose": "Modify access authorization to correspond with any changes in operational need."
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.09.02",
+                "name": "guidance",
+                "prose": "Security-related system property includes hardware authentication tokens, system administration technical manuals, keys, identification cards, and building passes. Exit interviews ensure that terminated individuals understand the security constraints imposed by being former employees and that accountability is achieved for the organizational property. Security topics at exit interviews include reminding individuals of potential limitations on future employment and non-disclosure agreements. Exit interviews may not always be possible for some individuals, including in cases related to the unavailability of supervisors, illnesses, or job abandonment. The timely execution of termination actions is essential for individuals who have been terminated for cause. Organizations may consider disabling the accounts of individuals who are being terminated prior to the individuals being notified. This requirement applies to the reassignment or transfer of individuals when the personnel action is permanent or of such extended duration as to require protection. Protections that may be required for transfers or reassignments to other positions within organizations include returning old and issuing new identification cards, keys, and building passes; changing system access authorizations (i.e., privileges); closing system accounts and establishing new accounts; and providing access to official records to which individuals had access at previous work locations in previous system accounts."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.a.01",
+                "name": "assessment-objective",
+                "prose": "upon termination of individual employment, system access is disabled within {{ insert: param, A.03.09.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.a.02.01",
+                "name": "assessment-objective",
+                "prose": "upon termination of individual employment, authenticators associated with the individual are terminated or revoked.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.a.02.02",
+                "name": "assessment-objective",
+                "prose": "upon termination of individual employment, credentials associated with the individual are terminated or revoked.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.a.03",
+                "name": "assessment-objective",
+                "prose": "upon termination of individual employment, security-related system property is retrieved.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.b.02",
+                "name": "assessment-objective",
+                "prose": "upon individual reassignment or transfer to other positions in the organization, access authorization is modified to correspond with any changes in operational need.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.b.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.b.01.01",
+                "name": "assessment-objective",
+                "prose": "upon individual reassignment or transfer to other positions in the organization, the ongoing operational need for current logical and physical access authorizations to the system and facility is reviewed.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.b.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.09.02.b.01.02",
+                "name": "assessment-objective",
+                "prose": "upon individual reassignment or transfer to other positions in the organization, the ongoing operational need for current logical and physical access authorizations to the system and facility is confirmed.",
+                "links": [
+                  {
+                    "href": "#SR-03.09.02.b.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.09.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel security policy and procedures\n\nprocedures for personnel termination\n\nrecords of personnel transfer actions\n\nprocedures for personnel transfer\n\nlist of system and facility access authorizations\n\nrecords of personnel termination actions\n\nrecords of terminated or revoked authenticators or credentials\n\nlist of system accounts\n\nrecords of exit interviews\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.09.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with personnel security responsibilities\n\npersonnel with account management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.09.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for personnel termination\n\nprocesses for personnel transfer\n\nmechanisms for supporting or implementing personnel transfer notifications\n\nmechanisms for supporting or implementing personnel termination notifications\n\nmechanisms for disabling system access and revoking authenticators"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.10",
+        "class": "family",
+        "title": "Physical Protection",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.10"
+          },
+          {
+            "name": "label",
+            "value": "Physical Protection (03.10)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.10.01",
+            "class": "requirement",
+            "title": "Physical Access Authorizations",
+            "params": [
+              {
+                "id": "A.03.10.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.10.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review the access list detailing authorized facility access by individuals is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.01"
+              },
+              {
+                "name": "label",
+                "value": "Physical Access Authorizations (03.10.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#6c38324a-0bfa-428e-a188-be61a8d990d4",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.10.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.10.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.01.a"
+                      }
+                    ],
+                    "prose": "Develop, approve, and maintain a list of individuals with authorized access to the facility where the system resides."
+                  },
+                  {
+                    "id": "SR-03.10.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.01.b"
+                      }
+                    ],
+                    "prose": "Issue authorization credentials for facility access."
+                  },
+                  {
+                    "id": "SR-03.10.01.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.01.c"
+                      }
+                    ],
+                    "prose": "Review the facility access list {{ insert: param, A.03.10.01.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.10.01.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.01.d"
+                      }
+                    ],
+                    "prose": "Remove individuals from the facility access list when access is no longer required."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.10.01",
+                "name": "guidance",
+                "prose": "A facility can include one or more physical locations containing systems or system components that process, store, or transmit CUI. Physical access authorizations apply to employees and visitors. Individuals with permanent physical access authorization credentials are not considered visitors. Authorization credentials include identification badges, identification cards, and smart cards. Organizations determine the strength of the authorization credentials consistent with applicable laws, Executive Orders, directives, regulations, policies, standards, and guidelines. Physical access authorizations may not be necessary to access certain areas within facilities that are designated as publicly accessible."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.01.a.01",
+                "name": "assessment-objective",
+                "prose": "a list of individuals with authorized access to the facility where the system resides is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.01.a.02",
+                "name": "assessment-objective",
+                "prose": "a list of individuals with authorized access to the facility where the system resides is approved.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.01.a.03",
+                "name": "assessment-objective",
+                "prose": "a list of individuals with authorized access to the facility where the system resides is maintained.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.01.c",
+                "name": "assessment-objective",
+                "prose": "the facility access list is reviewed {{ insert: param, A.03.10.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.01.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.01.d",
+                "name": "assessment-objective",
+                "prose": "individuals from the facility access list are removed when access is no longer required.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.01.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.01.b",
+                "name": "assessment-objective",
+                "prose": "authorization credentials for facility access are issued.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.10.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nprocedures for physical access authorizations\n\nauthorized personnel access list\n\nphysical access list reviews\n\nphysical access termination records\n\nauthorization credentials\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.10.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with physical access authorization responsibilities\n\npersonnel with physical access to the facility where the system resides\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.10.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for physical access authorizations\n\nmechanisms for supporting or implementing physical access authorizations"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.02",
+            "class": "requirement",
+            "title": "Monitoring Physical Access",
+            "params": [
+              {
+                "id": "A.03.10.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.10.02.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review physical access logs is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.10.02.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.10.02.ODP[02]"
+                  }
+                ],
+                "label": "events or potential indicators of events",
+                "usage": "organization-defined events or potential indications of events",
+                "guidelines": [
+                  {
+                    "prose": "events or potential indications of events requiring physical access logs to be reviewed are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.02"
+              },
+              {
+                "name": "label",
+                "value": "Monitoring Physical Access (03.10.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#ff59a583-9733-4f57-90ee-652beb17b64b",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.10.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.10.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.02.a"
+                      }
+                    ],
+                    "prose": "Monitor physical access to the facility where the system resides to detect and respond to physical security incidents."
+                  },
+                  {
+                    "id": "SR-03.10.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.02.b"
+                      }
+                    ],
+                    "prose": "Review physical access logs {{ insert: param, A.03.10.02.ODP.01 }} and upon occurrence of {{ insert: param, A.03.10.02.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.10.02",
+                "name": "guidance",
+                "prose": "A facility can include one or more physical locations containing systems or system components that process, store, or transmit CUI. Physical access monitoring includes publicly accessible areas within organizational facilities. Examples of physical access monitoring include guards, video surveillance equipment (i.e., cameras), and sensor devices. Reviewing physical access logs can help to identify suspicious activities, anomalous events, or potential threats. The reviews can be supported by audit logging controls if the access logs are part of an automated system. Incident response capabilities include investigations of physical security incidents and responses to those incidents. Incidents include security violations or suspicious physical access activities, such as access outside of normal work hours, repeated access to areas not normally accessed, access for unusual lengths of time, and out-of-sequence access."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.02.a.01",
+                "name": "assessment-objective",
+                "prose": "physical access to the facility where the system resides is monitored to detect physical security incidents.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.02.a.02",
+                "name": "assessment-objective",
+                "prose": "physical security incidents are responded to.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.02.b.01",
+                "name": "assessment-objective",
+                "prose": "physical access logs are reviewed {{ insert: param, A.03.10.02.ODP.01 }} .",
+                "links": [
+                  {
+                    "href": "#SR-03.10.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.02.b.02",
+                "name": "assessment-objective",
+                "prose": "physical access logs are reviewed upon occurrence of {{ insert: param, A.03.10.02.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.10.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nprocedures for physical access monitoring\n\nphysical access logs or records\n\nphysical access monitoring records\n\nphysical access log reviews\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.10.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with physical access monitoring responsibilities\n\npersonnel with incident response responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.10.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for monitoring physical access\n\nmechanisms for supporting or implementing physical access monitoring\n\nmechanisms for supporting or implementing the review of physical access logs"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.03",
+            "class": "requirement",
+            "title": "03.10.03",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.03"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.10.07",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.04",
+            "class": "requirement",
+            "title": "03.10.04",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.04"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.10.07",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.05",
+            "class": "requirement",
+            "title": "03.10.05",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.05"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.10.07",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.06",
+            "class": "requirement",
+            "title": "Alternate Work Site",
+            "params": [
+              {
+                "id": "A.03.10.06.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.10.06.ODP[01]"
+                  }
+                ],
+                "label": "security requirements",
+                "usage": "organization-defined security requirements",
+                "guidelines": [
+                  {
+                    "prose": "security requirements to be employed at alternate work sites are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.06"
+              },
+              {
+                "name": "label",
+                "value": "Alternate Work Site (03.10.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#d9fe2bca-43e7-40af-85f4-a3758363dc95",
+                "rel": "reference"
+              },
+              {
+                "href": "#68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+                "rel": "reference"
+              },
+              {
+                "href": "#b684972f-48eb-4a6e-b581-b5e697b3bc19",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.10.06",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.10.06.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.06.a"
+                      }
+                    ],
+                    "prose": "Determine alternate work sites allowed for use by employees."
+                  },
+                  {
+                    "id": "SR-03.10.06.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.06.b"
+                      }
+                    ],
+                    "prose": "Employ the following security requirements at alternate work sites: {{ insert: param, A.03.10.06.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.10.06",
+                "name": "guidance",
+                "prose": "Alternate work sites include the private residences of employees or other facilities designated by the organization. Alternate work sites can provide readily available alternate locations during contingency operations. Organizations can define different security requirements for specific alternate work sites or types of sites, depending on the work-related activities conducted at the sites. Assessing the effectiveness of the requirements and providing a means to communicate incidents at alternate work sites supports the contingency planning activities of organizations."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.06.a",
+                "name": "assessment-objective",
+                "prose": "alternate work sites allowed for use by employees are determined.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.06.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.06.b",
+                "name": "assessment-objective",
+                "prose": "the following security requirements are employed at alternate work sites: {{ insert: param, A.03.10.06.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.10.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nprocedures for alternate work sites for personnel\n\nlist of security requirements for alternate work sites\n\nassessments of security requirements at alternate work sites\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.10.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel approving the use of alternate work sites\n\npersonnel using alternate work sites\n\npersonnel assessing security requirements at alternate work sites\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.10.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for security at alternate work sites\n\nmechanisms for supporting alternate work sites\n\nsecurity requirements employed at alternate work sites\n\nmeans of communication between personnel at alternate work sites and security personnel"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.07",
+            "class": "requirement",
+            "title": "Physical Access Control",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.07"
+              },
+              {
+                "name": "label",
+                "value": "Physical Access Control (03.10.07)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#06ed46ad-12ae-47f1-8a6f-2840d9aa6d18",
+                "rel": "reference"
+              },
+              {
+                "href": "#c2d1d66c-a5da-4c16-9d5f-8f5bb0b2efeb",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.10.07",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.10.07.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.07.a"
+                      }
+                    ],
+                    "prose": "Enforce physical access authorizations at entry and exit points to the facility where the system resides by:",
+                    "parts": [
+                      {
+                        "id": "SR-03.10.07.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.10.07.a.01"
+                          }
+                        ],
+                        "prose": "Verifying individual physical access authorizations before granting access to the facility and"
+                      },
+                      {
+                        "id": "SR-03.10.07.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.10.07.a.02"
+                          }
+                        ],
+                        "prose": "Controlling ingress and egress with physical access control systems, devices, or guards."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.10.07.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.07.b"
+                      }
+                    ],
+                    "prose": "Maintain physical access audit logs for entry or exit points."
+                  },
+                  {
+                    "id": "SR-03.10.07.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.07.c"
+                      }
+                    ],
+                    "prose": "Escort visitors, and control visitor activity."
+                  },
+                  {
+                    "id": "SR-03.10.07.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.07.d"
+                      }
+                    ],
+                    "prose": "Secure keys, combinations, and other physical access devices."
+                  },
+                  {
+                    "id": "SR-03.10.07.e",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.10.07.e"
+                      }
+                    ],
+                    "prose": "Control physical access to output devices to prevent unauthorized individuals from obtaining access to CUI."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.10.07",
+                "name": "guidance",
+                "prose": "This requirement addresses physical locations containing systems or system components that process, store, or transmit CUI. Organizations determine the types of guards needed, including professional security staff or administrative staff. Physical access devices include keys, locks, combinations, biometric readers, and card readers. Physical access control systems comply with applicable laws, Executive Orders, directives, policies, regulations, standards, and guidelines. Organizations have flexibility in the types of audit logs employed. Audit logs can be procedural, automated, or some combination thereof. Physical access points can include exterior access points, interior access points to systems that require supplemental access controls, or both. Physical access control applies to employees and visitors. Individuals with permanent physical access authorizations are not considered visitors. Controlling physical access to output devices includes placing output devices in locked rooms or other secured areas with keypad or card reader access controls and only allowing access to authorized individuals, placing output devices in locations that can be monitored by personnel, installing monitor or screen filters, and using headphones. Examples of output devices include monitors, printers, scanners, facsimile machines, audio devices, and copiers."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.a.01",
+                "name": "assessment-objective",
+                "prose": "physical access authorizations are enforced at entry and exit points to the facility where the system resides by verifying individual physical access authorizations before granting access.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.a.02",
+                "name": "assessment-objective",
+                "prose": "physical access authorizations are enforced at entry and exit points to the facility where the system resides by controlling ingress and egress with physical access control systems, devices, or guards.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.b",
+                "name": "assessment-objective",
+                "prose": "physical access audit logs for entry or exit points are maintained.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.c.01",
+                "name": "assessment-objective",
+                "prose": "visitors are escorted.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.c.02",
+                "name": "assessment-objective",
+                "prose": "visitor activity is controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.e",
+                "name": "assessment-objective",
+                "prose": "physical access to output devices is controlled to prevent unauthorized individuals from obtaining access to CUI.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.e",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.07.d",
+                "name": "assessment-objective",
+                "prose": "keys, combinations, and other physical access devices are secured.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.07.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.10.07_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nprocedures for physical access control\n\nphysical access control logs or records\n\ninventory records of physical access control devices\n\nsystem entry and exit points\n\nrecords of key and lock combination changes\n\nstorage locations for physical access control devices\n\nphysical access control devices\n\nlist of security safeguards controlling access to designated publicly accessible areas within facility\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.10.07_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with physical access control responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.10.07_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for physical access control\n\nmechanisms for supporting or implementing physical access control\n\nphysical access control devices"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.10.08",
+            "class": "requirement",
+            "title": "Access Control for Transmission",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.10.08"
+              },
+              {
+                "name": "label",
+                "value": "Access Control for Transmission (03.10.08)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#faf017f0-641d-44ca-ae6d-34dcdcf0184b",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.10.08",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.10.08",
+                "name": "guidance",
+                "prose": "Safeguarding measures applied to system distribution and transmission lines prevent accidental damage, disruption, and physical tampering. Such measures may also be necessary to prevent eavesdropping or the modification of unencrypted transmissions. Safeguarding measures used to control physical access to system distribution and transmission lines include disconnected or locked spare jacks, locked wiring closets, cabling protection with conduit or cable trays, and wiretapping sensors."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.10.08",
+                "name": "assessment-objective",
+                "prose": "physical access to system distribution and transmission lines within organizational facilities is controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.10.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.10.08_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "physical protection policy and procedures\n\nprocedures for access control for transmission mediums\n\nsystem design documentation\n\nfacility communications and wiring diagrams\n\nlist of physical security safeguards applied to system distribution and transmission lines\n\nprocedures for access control for display medium\n\nfacility layout of system components\n\nlist of output devices and associated outputs that require physical access controls\n\nactual displays from system components\n\nphysical access control logs or records for areas containing output devices and related outputs\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.10.08_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with physical access control responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.10.08_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for access control for distribution and transmission lines\n\nmechanisms for supporting or implementing access control for distribution and transmission lines\n\nprocesses for access control to output devices\n\nmechanisms for supporting or implementing access control for output devices"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.11",
+        "class": "family",
+        "title": "Risk Assessment",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.11"
+          },
+          {
+            "name": "label",
+            "value": "Risk Assessment (03.11)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.11.01",
+            "class": "requirement",
+            "title": "Risk Assessment",
+            "params": [
+              {
+                "id": "A.03.11.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.11.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to update the risk assessment is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.11.01"
+              },
+              {
+                "name": "label",
+                "value": "Risk Assessment (03.11.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#e44bad03-7296-4d3a-91b1-d1679985188f",
+                "rel": "reference"
+              },
+              {
+                "href": "#0ce472eb-e23b-41ce-85b7-5feff832f386",
+                "rel": "reference"
+              },
+              {
+                "href": "#eeffa926-bb28-462b-a65a-79e605236291",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              },
+              {
+                "href": "#d7469545-b483-4820-b7a1-b64841239a93",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.11.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.11.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.11.01.a"
+                      }
+                    ],
+                    "prose": "Assess the risk (including supply chain risk) of unauthorized disclosure resulting from the processing, storage, or transmission of CUI."
+                  },
+                  {
+                    "id": "SR-03.11.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.11.01.b"
+                      }
+                    ],
+                    "prose": "Update risk assessments {{ insert: param, A.03.11.01.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.11.01",
+                "name": "guidance",
+                "prose": "Establishing the system boundary is a prerequisite to assessing the risk of the unauthorized disclosure of CUI. Risk assessments consider threats, vulnerabilities, likelihood, and adverse impacts to organizational operations and assets based on the operation and use of the system and the unauthorized disclosure of CUI. Risk assessments also consider risks from external parties (e.g., contractors operating systems on behalf of the organization, service providers, individuals accessing systems, and outsourcing entities). Risk assessments can be conducted at the organization level, the mission or business process level, or the system level and at any phase in the system development life cycle. Risk assessments include supply chain-related risks associated with suppliers or contractors and the system, system component, or system service that they provide."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.01.a",
+                "name": "assessment-objective",
+                "prose": "the risk (including supply chain risk) of unauthorized disclosure resulting from the processing, storage, or transmission of CUI is assessed.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.01.b",
+                "name": "assessment-objective",
+                "prose": "risk assessments are updated {{ insert: param, A.03.11.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.11.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "risk assessment policy and procedures\n\nsecurity planning policy and procedures\n\nprocedures for organizational assessments of risk\n\nrisk assessment\n\nrisk assessment results\n\nrisk assessment reviews\n\nrisk assessment updates\n\nSCRM policy and procedures\n\ninventory of critical systems, system components, and system services\n\nprocedures for organizational assessments of supply chain risk\n\nacquisition policy\n\nSCRM plan\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.11.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with risk assessment responsibilities\n\npersonnel with SCRM responsibilities\n\npersonnel with security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.11.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for organizational risk assessments\n\nmechanisms for supporting or conducting, documenting, reviewing, disseminating, and updating risk assessments\n\nmechanisms for supporting or conducting, documenting, reviewing, disseminating, and updating supply chain risk assessments"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.11.02",
+            "class": "requirement",
+            "title": "Vulnerability Monitoring and Scanning",
+            "params": [
+              {
+                "id": "A.03.11.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.11.02.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which the system is monitored for vulnerabilities is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.11.02.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.11.02.ODP[02]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which the system is scanned for vulnerabilities is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.11.02.ODP.03",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.11.02.ODP[03]"
+                  }
+                ],
+                "label": "response times",
+                "usage": "organization-defined response times",
+                "guidelines": [
+                  {
+                    "prose": "response times to remediate system vulnerabilities are defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.11.02.ODP.04",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.11.02.ODP[04]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to update system vulnerabilities to be scanned is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.11.02"
+              },
+              {
+                "name": "label",
+                "value": "Vulnerability Monitoring and Scanning (03.11.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#7e817cf4-c844-4c44-bcf2-b5b53b18a9a8",
+                "rel": "reference"
+              },
+              {
+                "href": "#5b9fcaef-085b-4c1d-b291-8810bbc5b88e",
+                "rel": "reference"
+              },
+              {
+                "href": "#c1809cdb-face-4fae-9476-4c97ebf0ad0c",
+                "rel": "reference"
+              },
+              {
+                "href": "#7d1055bb-574a-4487-b0c7-5791a0509fc8",
+                "rel": "reference"
+              },
+              {
+                "href": "#a5981dd2-7c12-469b-8ca9-648d1bb49326",
+                "rel": "reference"
+              },
+              {
+                "href": "#60b7ef54-4422-4a73-99ab-854410a7e716",
+                "rel": "reference"
+              },
+              {
+                "href": "#bb27dd66-aa0b-42d9-952a-7bab2fe8047e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.11.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.11.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.11.02.a"
+                      }
+                    ],
+                    "prose": "Monitor and scan the system for vulnerabilities {{ insert: param, A.03.11.02.ODP.01 }} and when new vulnerabilities affecting the system are identified."
+                  },
+                  {
+                    "id": "SR-03.11.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.11.02.b"
+                      }
+                    ],
+                    "prose": "Remediate system vulnerabilities within {{ insert: param, A.03.11.02.ODP.03 }}."
+                  },
+                  {
+                    "id": "SR-03.11.02.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.11.02.c"
+                      }
+                    ],
+                    "prose": "Update system vulnerabilities to be scanned {{ insert: param, A.03.11.02.ODP.04 }} and when new vulnerabilities are identified and reported."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.11.02",
+                "name": "guidance",
+                "prose": "Organizations determine the required vulnerability scanning for system components and ensure that potential sources of vulnerabilities (e.g., networked printers, scanners, and copiers) are not overlooked. Vulnerability analyses for custom software may require additional approaches, such as static analysis, dynamic analysis, or binary analysis. Organizations can use these approaches in source code reviews and tools (e.g., static analysis tools, web-based application scanners, binary analyzers). Vulnerability scanning includes scanning for patch levels; scanning for functions, ports, protocols, and services that should not be accessible to users or devices; and scanning for improperly configured or incorrectly operating flow control mechanisms. To facilitate interoperability, organizations consider using scanning tools that express vulnerabilities in the Common Vulnerabilities and Exposures (CVE) naming convention. Sources for vulnerability information also include the Common Weakness Enumeration (CWE) listing, the National Vulnerability Database (NVD), and the Common Vulnerability Scoring System (CVSS)."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.a.01",
+                "name": "assessment-objective",
+                "prose": "the system is monitored for vulnerabilities {{ insert: param, A.03.11.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.a.02",
+                "name": "assessment-objective",
+                "prose": "the system is scanned for vulnerabilities {{ insert: param, A.03.11.02.ODP.02 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.b",
+                "name": "assessment-objective",
+                "prose": "system vulnerabilities are remediated within {{ insert: param, A.03.11.02.ODP.03 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.a.03",
+                "name": "assessment-objective",
+                "prose": "the system is monitored for vulnerabilities when new vulnerabilities that affect the system are identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.a.04",
+                "name": "assessment-objective",
+                "prose": "the system is scanned for vulnerabilities when new vulnerabilities that affect the system are identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.c.01",
+                "name": "assessment-objective",
+                "prose": "system vulnerabilities to be scanned are updated {{ insert: param, A.03.11.02.ODP.04 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.02.c.02",
+                "name": "assessment-objective",
+                "prose": "system vulnerabilities to be scanned are updated when new vulnerabilities are identified and reported.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.02.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.11.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "risk assessment policy and procedures\n\nprocedures for vulnerability scanning\n\npatch and vulnerability management records\n\nvulnerability scanning tools and configuration documentation\n\nvulnerability scanning results\n\nrisk assessment\n\nrisk assessment report\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.11.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with risk assessment and vulnerability scanning responsibilities\n\npersonnel with vulnerability scan analysis responsibilities\n\npersonnel with vulnerability remediation responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.11.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for vulnerability monitoring, scanning, analysis, and remediation\n\nmechanisms for supporting or implementing vulnerability monitoring, scanning, analysis, and remediation"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.11.03",
+            "class": "requirement",
+            "title": "03.11.03",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.11.03"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.11.02",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.11.04",
+            "class": "requirement",
+            "title": "Risk Response",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.11.04"
+              },
+              {
+                "name": "label",
+                "value": "Risk Response (03.11.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#cef1d874-0a3f-4b49-96d1-3630d480bac1",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#d7469545-b483-4820-b7a1-b64841239a93",
+                "rel": "reference"
+              },
+              {
+                "href": "#8d1fb520-63c6-441b-a4ba-974c8d98ef71",
+                "rel": "reference"
+              },
+              {
+                "href": "#4cd3f53c-8e18-43d2-8fb5-82c1eeb45582",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.11.04",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.11.04",
+                "name": "guidance",
+                "prose": "This requirement addresses the need to determine an appropriate response to risk before generating a plan of action and milestones (POAM) entry. It may be possible to mitigate the risk immediately so that a POAM entry is not needed. However, a POAM entry is generated if the risk response is to mitigate the identified risk and the mitigation cannot be completed immediately."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.04.01",
+                "name": "assessment-objective",
+                "prose": "findings from security assessments are responded to.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.04.02",
+                "name": "assessment-objective",
+                "prose": "findings from security monitoring are responded to.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.11.04.03",
+                "name": "assessment-objective",
+                "prose": "findings from security audits are responded to.",
+                "links": [
+                  {
+                    "href": "#SR-03.11.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.11.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "risk assessment policy\n\nassessment reports\n\nsystem audit records\n\nevent logs\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.11.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with assessment and auditing responsibilities\n\nsystem administrators\n\npersonnel with security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.11.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for assessments and audits\n\nmechanisms and tools supporting or implementing assessments and auditing"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.12",
+        "class": "family",
+        "title": "Security Assessment and Monitoring",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.12"
+          },
+          {
+            "name": "label",
+            "value": "Security Assessment and Monitoring (03.12)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.12.01",
+            "class": "requirement",
+            "title": "Security Assessment",
+            "params": [
+              {
+                "id": "A.03.12.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.12.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to assess the security requirements for the system and its environment of operation is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.12.01"
+              },
+              {
+                "name": "label",
+                "value": "Security Assessment (03.12.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#5d5edea2-31e3-4a91-b39e-d581f059c985",
+                "rel": "reference"
+              },
+              {
+                "href": "#c1809cdb-face-4fae-9476-4c97ebf0ad0c",
+                "rel": "reference"
+              },
+              {
+                "href": "#8d1fb520-63c6-441b-a4ba-974c8d98ef71",
+                "rel": "reference"
+              },
+              {
+                "href": "#7af9ad3c-594d-43b8-a527-de9f622421e0",
+                "rel": "reference"
+              },
+              {
+                "href": "#60b7ef54-4422-4a73-99ab-854410a7e716",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.12.01",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.12.01",
+                "name": "guidance",
+                "prose": "By assessing the security requirements, organizations determine whether the necessary safeguards and countermeasures are implemented correctly, operating as intended, and producing the desired outcome. Security assessments identify weaknesses in the system and provide the essential information needed to make risk-based decisions. Security assessment reports document assessment results in sufficient detail as deemed necessary by the organization to determine the accuracy and completeness of the reports. Security assessment results are provided to the individuals or roles appropriate for the types of assessments being conducted."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.01",
+                "name": "assessment-objective",
+                "prose": "the security requirements for the system and its environment of operation are assessed {{ insert: param, A.03.12.01.ODP.01 }} to determine if the requirements have been satisfied.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.12.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security assessment and monitoring policy and procedures\n\nprocedures for security assessment planning\n\nsecurity assessment plan\n\nsecurity assessment report\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.12.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with security assessment responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.12.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting security assessments, processes for security assessment plan development, or security assessment reporting"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.12.02",
+            "class": "requirement",
+            "title": "Plan of Action and Milestones",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.12.02"
+              },
+              {
+                "name": "label",
+                "value": "Plan of Action and Milestones (03.12.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#1fc4b465-1569-40de-94ec-a8d17534c5fa",
+                "rel": "reference"
+              },
+              {
+                "href": "#8d1fb520-63c6-441b-a4ba-974c8d98ef71",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.12.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.12.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.12.02.a"
+                      }
+                    ],
+                    "prose": "Develop a plan of action and milestones for the system:",
+                    "parts": [
+                      {
+                        "id": "SR-03.12.02.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.12.02.a.01"
+                          }
+                        ],
+                        "prose": "To document the planned remediation actions to correct weaknesses or deficiencies noted during security assessments and"
+                      },
+                      {
+                        "id": "SR-03.12.02.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.12.02.a.02"
+                          }
+                        ],
+                        "prose": "To reduce or eliminate known system vulnerabilities."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.12.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.12.02.b"
+                      }
+                    ],
+                    "prose": "Update the existing plan of action and milestones based on the findings from:",
+                    "parts": [
+                      {
+                        "id": "SR-03.12.02.b.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.12.02.b.01"
+                          }
+                        ],
+                        "prose": "Security assessments,"
+                      },
+                      {
+                        "id": "SR-03.12.02.b.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.12.02.b.02"
+                          }
+                        ],
+                        "prose": "Audits or reviews, and"
+                      },
+                      {
+                        "id": "SR-03.12.02.b.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.12.02.b.03"
+                          }
+                        ],
+                        "prose": "Continuous monitoring activities."
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.12.02",
+                "name": "guidance",
+                "prose": "Plans of action and milestones (POAMs) are important documents in organizational security programs. Organizations use POAMs to describe how unsatisfied security requirements will be met and how planned mitigations will be implemented. Organizations can document system security plans and POAMs as separate or combined documents in any format. Federal agencies may consider system security plans and POAMs as inputs to risk-based decisions on whether to process, store, or transmit CUI on a system hosted by a nonfederal organization."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.02.a.01",
+                "name": "assessment-objective",
+                "prose": "a plan of action and milestones for the system is developed to document the planned remediation actions for correcting weaknesses or deficiencies noted during security assessments.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.02.a.02",
+                "name": "assessment-objective",
+                "prose": "a plan of action and milestones for the system is developed to reduce or eliminate known system vulnerabilities.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.02.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.02.b.01",
+                "name": "assessment-objective",
+                "prose": "the existing plan of action and milestones is updated based on the findings from security assessments.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.02.b.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.02.b.03",
+                "name": "assessment-objective",
+                "prose": "the existing plan of action and milestones is updated based on the findings from continuous monitoring activities.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.02.b.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.02.b.02",
+                "name": "assessment-objective",
+                "prose": "the existing plan of action and milestones is updated based on the findings from audits or reviews.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.02.b.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.12.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security assessment and monitoring policy and procedures\n\nprocedures for plans of action and milestones\n\nsecurity assessment plan\n\nsecurity assessment report\n\nsecurity assessment evidence\n\nplan of action and milestones\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.12.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with plans of action and milestones development and implementation responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.12.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for developing, implementing, and maintaining plans of action and milestones"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.12.03",
+            "class": "requirement",
+            "title": "Continuous Monitoring",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.12.03"
+              },
+              {
+                "name": "label",
+                "value": "Continuous Monitoring (03.12.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#43d68e46-1c1b-4796-ad7f-696700231d3a",
+                "rel": "reference"
+              },
+              {
+                "href": "#c1809cdb-face-4fae-9476-4c97ebf0ad0c",
+                "rel": "reference"
+              },
+              {
+                "href": "#a07d3a28-bdd3-4161-b724-485cb436eba0",
+                "rel": "reference"
+              },
+              {
+                "href": "#8d1fb520-63c6-441b-a4ba-974c8d98ef71",
+                "rel": "reference"
+              },
+              {
+                "href": "#4cd3f53c-8e18-43d2-8fb5-82c1eeb45582",
+                "rel": "reference"
+              },
+              {
+                "href": "#60b7ef54-4422-4a73-99ab-854410a7e716",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.12.03",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.12.03",
+                "name": "guidance",
+                "prose": "Continuous monitoring at the system level facilitates ongoing awareness of the system security posture to support risk management decisions. The terms continuous and ongoing imply that organizations assess and monitor their systems at a frequency that is sufficient to support risk-based decisions. Different types of security requirements may require different monitoring frequencies."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.03.01",
+                "name": "assessment-objective",
+                "prose": "a system-level continuous monitoring strategy is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.03.02",
+                "name": "assessment-objective",
+                "prose": "a system-level continuous monitoring strategy is implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.03.03",
+                "name": "assessment-objective",
+                "prose": "ongoing monitoring is included in the continuous monitoring strategy.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.03.04",
+                "name": "assessment-objective",
+                "prose": "security assessments are included in the continuous monitoring strategy.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.12.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security assessment and monitoring policy and procedures\n\norganizational continuous monitoring strategy\n\nsystem-level continuous monitoring strategy\n\nprocedures for continuous monitoring of the system\n\nprocedures for configuration management\n\nsecurity assessment report\n\nplan of action and milestones\n\nsystem monitoring records\n\nconfiguration management records\n\nimpact analyses\n\nstatus reports\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.12.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with continuous monitoring responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.12.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing continuous monitoring\n\nmechanisms for supporting response actions for assessment and monitoring results\n\nmechanisms for supporting security status reporting"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.12.04",
+            "class": "requirement",
+            "title": "03.12.04",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.12.04"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.15.02",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.12.05",
+            "class": "requirement",
+            "title": "Information Exchange",
+            "params": [
+              {
+                "id": "A.03.12.05.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.12.05.ODP[01]"
+                  }
+                ],
+                "label": "SELECTED PARAMETER VALUES",
+                "select": {
+                  "how-many": "one-or-more",
+                  "choice": [
+                    "interconnection security agreements",
+                    "information exchange security agreements",
+                    "memoranda of understanding or agreement",
+                    "service-level agreements",
+                    "user agreements",
+                    "non-disclosure agreements",
+                    "other types of agreements"
+                  ]
+                }
+              },
+              {
+                "id": "A.03.12.05.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.12.05.ODP[02]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review and update agreements is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.12.05"
+              },
+              {
+                "name": "label",
+                "value": "Information Exchange (03.12.05)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#e40475b0-0ae0-4a8e-8d10-36e13d943946",
+                "rel": "reference"
+              },
+              {
+                "href": "#30e1c8c9-2673-4139-a581-400bb26ce159",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.12.05",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.12.05.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.12.05.a"
+                      }
+                    ],
+                    "prose": "Approve and manage the exchange of CUI between the system and other systems using {{ insert: param, A.03.12.05.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.12.05.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.12.05.b"
+                      }
+                    ],
+                    "prose": "Document interface characteristics, security requirements, and responsibilities for each system as part of the exchange agreements."
+                  },
+                  {
+                    "id": "SR-03.12.05.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.12.05.c"
+                      }
+                    ],
+                    "prose": "Review and update the exchange agreements {{ insert: param, A.03.12.05.ODP.02 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.12.05",
+                "name": "guidance",
+                "prose": "Information exchange applies to information exchanges between two or more systems, both internal and external to the organization. Organizations consider the risks related to new or increased threats that may be introduced when systems exchange information with other systems that may have different security requirements or policies. The types of agreements selected are based on factors such as the relationship between the organizations exchanging information (e.g., government to government, business to business, government to business, government or business, or government or business to individual) and the level of access to the organizational system by users of the other system. The types of agreements can include information exchange security agreements, interconnection security agreements, memoranda of understanding or agreement, service-level agreements, or other types of agreements. Organizations may incorporate agreement information into formal contracts, especially for information exchanges established between federal agencies and nonfederal organizations (e.g., service providers, contractors, system developers, and system integrators). The types of information contained in exchange agreements include the interface characteristics, security requirements, controls, and responsibilities for each system."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.a.01",
+                "name": "assessment-objective",
+                "prose": "the exchange of CUI between the system and other systems is approved using {{ insert: param, A.03.12.05.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.a.02",
+                "name": "assessment-objective",
+                "prose": "the exchange of CUI between the system and other systems is managed using {{ insert: param, A.03.12.05.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.b.01",
+                "name": "assessment-objective",
+                "prose": "interface characteristics for each system are documented as part of the exchange agreements.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.b.02",
+                "name": "assessment-objective",
+                "prose": "security requirements for each system are documented as part of the exchange agreements.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.b.03",
+                "name": "assessment-objective",
+                "prose": "responsibilities for each system are documented as part of the exchange agreements.",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.c.01",
+                "name": "assessment-objective",
+                "prose": "exchange agreements are reviewed {{ insert: param, A.03.12.05.ODP.02 }} .",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.12.05.c.02",
+                "name": "assessment-objective",
+                "prose": "exchange agreements are updated {{ insert: param, A.03.12.05.ODP.02 }} .",
+                "links": [
+                  {
+                    "href": "#SR-03.12.05.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.12.05_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "access control policy and procedures\n\nprocedures for system connections\n\nsystem and communications protection policy and procedures\n\nsystem interconnection security agreements\n\ninformation exchange security agreements\n\nservice-level agreements\n\nmemoranda of understanding or agreements\n\nnon-disclosure agreements\n\nsystem design documentation\n\nenterprise architecture\n\nsecurity architecture\n\nsystem configuration settings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.12.05_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with development, implementation, and approval responsibilities for system interconnection agreements\n\npersonnel who manage systems to which the exchange agreements apply\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.13",
+        "class": "family",
+        "title": "System and Communications Protection",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.13"
+          },
+          {
+            "name": "label",
+            "value": "System and Communications Protection (03.13)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.13.01",
+            "class": "requirement",
+            "title": "Boundary Protection",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.01"
+              },
+              {
+                "name": "label",
+                "value": "Boundary Protection (03.13.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#a0545240-de4e-416d-8764-11c4ae62468a",
+                "rel": "reference"
+              },
+              {
+                "href": "#2cf4ace8-d71c-4e8f-a472-f2502de8a550",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#905fc293-cebb-4cc6-90d6-c95ed047090b",
+                "rel": "reference"
+              },
+              {
+                "href": "#2e702ac1-d107-4251-b12e-6816b9f20747",
+                "rel": "reference"
+              },
+              {
+                "href": "#0bb2b4eb-d888-4ef1-b612-5ad3ac27a41a",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.13.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.01.a"
+                      }
+                    ],
+                    "prose": "Monitor and control communications at external managed interfaces to the system and key internal managed interfaces within the system."
+                  },
+                  {
+                    "id": "SR-03.13.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.01.b"
+                      }
+                    ],
+                    "prose": "Implement subnetworks for publicly accessible system components that are physically or logically separated from internal networks."
+                  },
+                  {
+                    "id": "SR-03.13.01.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.01.c"
+                      }
+                    ],
+                    "prose": "Connect to external systems only through managed interfaces that consist of boundary protection devices arranged in accordance with an organizational security architecture."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.13.01",
+                "name": "guidance",
+                "prose": "Managed interfaces include gateways, routers, firewalls, network-based malicious code analysis, virtualization systems, and encrypted tunnels implemented within a security architecture. Subnetworks that are either physically or logically separated from internal networks are referred to as demilitarized zones or DMZs. Restricting or prohibiting interfaces within organizational systems includes restricting external web traffic to designated web servers within managed interfaces, prohibiting external traffic that appears to be spoofing internal addresses, and prohibiting internal traffic that appears to be spoofing external addresses."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.01.a.01",
+                "name": "assessment-objective",
+                "prose": "communications at external managed interfaces to the system are monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.01.a.02",
+                "name": "assessment-objective",
+                "prose": "communications at external managed interfaces to the system are controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.01.a.03",
+                "name": "assessment-objective",
+                "prose": "communications at key internal managed interfaces within the system are monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.01.a.04",
+                "name": "assessment-objective",
+                "prose": "communications at key internal managed interfaces within the system are controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.01.b",
+                "name": "assessment-objective",
+                "prose": "subnetworks are implemented for publicly accessible system components that are physically or logically separated from internal networks.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.01.c",
+                "name": "assessment-objective",
+                "prose": "external system connections are only made through managed interfaces that consist of boundary protection devices arranged in accordance with an organizational security architecture.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.01.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for boundary protection\n\nlist of key internal boundaries within the system\n\nboundary protection hardware and software\n\nsystem configuration settings\n\nsecurity architecture\n\nsystem audit records\n\nsystem design documentation\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with boundary protection responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing boundary protection capabilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.02",
+            "class": "requirement",
+            "title": "03.13.02",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.02"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.03",
+            "class": "requirement",
+            "title": "03.13.03",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.03"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.01",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.02",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.03",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.04",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.05",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.06",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.01.07",
+                "rel": "addressed_by"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.04",
+            "class": "requirement",
+            "title": "Information in Shared System Resources",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.04"
+              },
+              {
+                "name": "label",
+                "value": "Information in Shared System Resources (03.13.04)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#1f34e010-fb4a-42e2-ae2f-2d5a611a8581",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.04",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.04",
+                "name": "guidance",
+                "prose": "Preventing unauthorized and unintended information transfer via shared system resources stops information produced by the actions of prior users or roles (or actions of processes acting on behalf of prior users or roles) from being available to current users or roles (or current processes acting on behalf of current users or roles) that obtain access to shared system resources after those resources have been released back to the system. Information in shared system resources also applies to encrypted representations of information. In other contexts, the control of information in shared system resources is referred to as object reuse and residual information protection. Information in shared system resources does not address information remanence, which refers to the residual representation of data that has been nominally deleted, covert channels (including storage and timing channels) in which shared system resources are manipulated to violate information flow restrictions, or components within systems for which there are only single users or roles."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.04.01",
+                "name": "assessment-objective",
+                "prose": "unauthorized information transfer via shared system resources is prevented.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.04.02",
+                "name": "assessment-objective",
+                "prose": "unintended information transfer via shared system resources is prevented.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.04_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for information protection in shared system resources\n\nsystem configuration settings\n\nsystem audit records\n\nsystem design documentation\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.04_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.04_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for preventing the unauthorized and unintended transfer of information via shared system resources"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.05",
+            "class": "requirement",
+            "title": "03.13.05",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.05"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.13.01",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.06",
+            "class": "requirement",
+            "title": "Network Communications – Deny by Default – Allow by Exception",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.06"
+              },
+              {
+                "name": "label",
+                "value": "Network Communications – Deny by Default – Allow by Exception (03.13.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#ad6bde1d-4352-430d-95f6-a1f9cbace84d",
+                "rel": "reference"
+              },
+              {
+                "href": "#905fc293-cebb-4cc6-90d6-c95ed047090b",
+                "rel": "reference"
+              },
+              {
+                "href": "#0bb2b4eb-d888-4ef1-b612-5ad3ac27a41a",
+                "rel": "reference"
+              },
+              {
+                "href": "#a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.06",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.06",
+                "name": "guidance",
+                "prose": "This requirement applies to inbound and outbound network communications traffic at the system boundary and at identified points within the system. A deny-all, allow-by-exception network communications traffic policy ensures that only essential and approved connections are allowed."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.06.01",
+                "name": "assessment-objective",
+                "prose": "network communications traffic is denied by default.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.06",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.06.02",
+                "name": "assessment-objective",
+                "prose": "network communications traffic is allowed by exception.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.06",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for boundary protection\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with boundary protection responsibilities\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for implementing traffic management at managed interfaces"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.07",
+            "class": "requirement",
+            "title": "03.13.07",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.07"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.01.12",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.04.02",
+                "rel": "addressed_by"
+              },
+              {
+                "href": "03.04.06",
+                "rel": "addressed_by"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.08",
+            "class": "requirement",
+            "title": "Transmission and Storage Confidentiality",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.08"
+              },
+              {
+                "name": "label",
+                "value": "Transmission and Storage Confidentiality (03.13.08)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#523267df-021c-4e2d-ad9f-bbc05f915764",
+                "rel": "reference"
+              },
+              {
+                "href": "#b8d0af05-79fa-4a8f-98f1-f595285d8e81",
+                "rel": "reference"
+              },
+              {
+                "href": "#1a3eaa86-0aed-4af8-9be8-0477122cae56",
+                "rel": "reference"
+              },
+              {
+                "href": "#7f931c0d-e575-4392-aa68-3cdb755a6ea4",
+                "rel": "reference"
+              },
+              {
+                "href": "#ee7a6c0f-4d87-4bef-a353-ca0e7ee09073",
+                "rel": "reference"
+              },
+              {
+                "href": "#9b69bf22-8406-48cb-845c-bcc84aac8bf5",
+                "rel": "reference"
+              },
+              {
+                "href": "#226b6921-eab4-4662-b0df-f2f6049eb782",
+                "rel": "reference"
+              },
+              {
+                "href": "#be88bb5c-d994-40f4-b273-3df87369c0ab",
+                "rel": "reference"
+              },
+              {
+                "href": "#68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+                "rel": "reference"
+              },
+              {
+                "href": "#da00e9f9-6829-46d6-bcec-a08ef5556e7f",
+                "rel": "reference"
+              },
+              {
+                "href": "#2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+                "rel": "reference"
+              },
+              {
+                "href": "#7a27adf3-4c7f-4207-8782-d7bbd8791806",
+                "rel": "reference"
+              },
+              {
+                "href": "#b684972f-48eb-4a6e-b581-b5e697b3bc19",
+                "rel": "reference"
+              },
+              {
+                "href": "#2afcb88d-1586-4f5a-8438-2f84c98eff27",
+                "rel": "reference"
+              },
+              {
+                "href": "#1b330b12-130c-4a91-b0c8-231ab77ff053",
+                "rel": "reference"
+              },
+              {
+                "href": "#fce8ddf8-ff73-497e-b372-ec6c7bc06b2b",
+                "rel": "reference"
+              },
+              {
+                "href": "#784d88ea-68d3-45f0-ab58-cbe9e8695988",
+                "rel": "reference"
+              },
+              {
+                "href": "#13290408-22ce-4afa-a0f0-ca438c1e932b",
+                "rel": "reference"
+              },
+              {
+                "href": "#e0aa4a13-03cc-4b86-be6c-80225af5c3af",
+                "rel": "reference"
+              },
+              {
+                "href": "#6aba579a-f262-4bf9-a8e7-6820ea63de34",
+                "rel": "reference"
+              },
+              {
+                "href": "#a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.08",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.08",
+                "name": "guidance",
+                "prose": "This requirement applies to internal and external networks and any system components that can transmit CUI, including servers, notebook computers, desktop computers, mobile devices, printers, copiers, scanners, facsimile machines, and radios. Unprotected communication paths are susceptible to interception and modification. Encryption protects CUI from unauthorized disclosure during transmission and while in storage. Cryptographic mechanisms that protect the confidentiality of CUI during transmission include TLS and IPsec. Information in storage (i.e., information at rest) refers to the state of CUI when it is not in process or in transit and resides on internal or external storage devices, storage area network devices, and databases. Protecting CUI in storage does not focus on the type of storage device or the frequency of access to that device but rather on the state of the information. This requirement relates to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.11) 03.13.11."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.08.01",
+                "name": "assessment-objective",
+                "prose": "cryptographic mechanisms are implemented to prevent the unauthorized disclosure of CUI during transmission.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.08.02",
+                "name": "assessment-objective",
+                "prose": "cryptographic mechanisms are implemented to prevent the unauthorized disclosure of CUI while in storage.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.08_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for transmission confidentiality\n\nprocedures for the protection of information at rest\n\nsystem design documentation\n\nsystem configuration settings\n\ncryptographic mechanisms and associated configuration documentation\n\ninformation in storage requiring confidentiality protection\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.08_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.08_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing transmission confidentiality\n\ncryptographic mechanisms for supporting or implementing transmission confidentiality\n\nmechanisms for supporting or implementing confidentiality protection for information in storage\n\ncryptographic mechanisms for implementing confidentiality protections for information in storage"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.09",
+            "class": "requirement",
+            "title": "Network Disconnect",
+            "params": [
+              {
+                "id": "A.03.13.09.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.13.09.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period of inactivity after which the system terminates a network connection associated with a communications session is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.09"
+              },
+              {
+                "name": "label",
+                "value": "Network Disconnect (03.13.09)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#f70cb413-b2ce-416a-a89d-cd27549d01b4",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.09",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.09",
+                "name": "guidance",
+                "prose": "This requirement applies to internal and external networks. Terminating network connections associated with communications sessions includes deallocating TCP/IP addresses or port pairs at the operating system level or deallocating networking assignments at the application level if multiple application sessions are using a single network connection. Time periods of inactivity may be established by organizations and include time periods by type of network access or for specific network accesses."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.09",
+                "name": "assessment-objective",
+                "prose": "the network connection associated with a communications session is terminated at the end of the session or after {{ insert: param, A.03.13.09.ODP.01 }} of inactivity.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.09",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.09_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for network disconnect\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.09_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.09_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing a network disconnect capability"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.10",
+            "class": "requirement",
+            "title": "Cryptographic Key Establishment and Management",
+            "params": [
+              {
+                "id": "A.03.13.10.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.13.10.ODP[01]"
+                  }
+                ],
+                "label": "requirements",
+                "usage": "organization-defined requirements for key generation, distribution, storage, access, and destruction",
+                "guidelines": [
+                  {
+                    "prose": "requirements for key generation, distribution, storage, access, and destruction are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.10"
+              },
+              {
+                "name": "label",
+                "value": "Cryptographic Key Establishment and Management (03.13.10)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#8e5443e8-137c-48bf-95d3-297142328d64",
+                "rel": "reference"
+              },
+              {
+                "href": "#ee7a6c0f-4d87-4bef-a353-ca0e7ee09073",
+                "rel": "reference"
+              },
+              {
+                "href": "#1b330b12-130c-4a91-b0c8-231ab77ff053",
+                "rel": "reference"
+              },
+              {
+                "href": "#fce8ddf8-ff73-497e-b372-ec6c7bc06b2b",
+                "rel": "reference"
+              },
+              {
+                "href": "#784d88ea-68d3-45f0-ab58-cbe9e8695988",
+                "rel": "reference"
+              },
+              {
+                "href": "#13290408-22ce-4afa-a0f0-ca438c1e932b",
+                "rel": "reference"
+              },
+              {
+                "href": "#e0aa4a13-03cc-4b86-be6c-80225af5c3af",
+                "rel": "reference"
+              },
+              {
+                "href": "#6aba579a-f262-4bf9-a8e7-6820ea63de34",
+                "rel": "reference"
+              },
+              {
+                "href": "#900b7a48-6d75-4177-aaa6-137d817232c7",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.10",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.10",
+                "name": "guidance",
+                "prose": "Cryptographic keys can be established and managed using either manual procedures or automated mechanisms supported by manual procedures. Organizations satisfy key establishment and management requirements in accordance with applicable federal laws, Executive Orders, policies, directives, regulations, and standards that specify appropriate options, levels, and parameters. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.13.11) 03.13.11."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.10.01",
+                "name": "assessment-objective",
+                "prose": "cryptographic keys are established in the system in accordance with the following key management requirements: {{ insert: param, A.03.13.10.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.10",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.10.02",
+                "name": "assessment-objective",
+                "prose": "cryptographic keys are managed in the system in accordance with the following key management requirements: {{ insert: param, A.03.13.10.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.10",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.10_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for cryptographic key establishment and management\n\nsystem design documentation\n\nsystem configuration settings\n\ncryptographic mechanisms\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.10_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for cryptographic key establishment or management\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.10_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing cryptographic key establishment and management"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.11",
+            "class": "requirement",
+            "title": "Cryptographic Protection",
+            "params": [
+              {
+                "id": "A.03.13.11.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.13.11.ODP[01]"
+                  }
+                ],
+                "label": "types of cryptography",
+                "usage": "organization-defined types of cryptography",
+                "guidelines": [
+                  {
+                    "prose": "the types of cryptography for protecting the confidentiality of CUI are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.11"
+              },
+              {
+                "name": "label",
+                "value": "Cryptographic Protection (03.13.11)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#2d31b72b-97a1-497f-b99d-79f01dce0dc5",
+                "rel": "reference"
+              },
+              {
+                "href": "#ee7a6c0f-4d87-4bef-a353-ca0e7ee09073",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.11",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.11",
+                "name": "guidance",
+                "prose": "Cryptography is implemented in accordance with applicable laws, Executive Orders, directives, regulations, policies, standards, and guidelines. FIPS-validated cryptography is recommended for the protection of CUI."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.11",
+                "name": "assessment-objective",
+                "prose": "the following types of cryptography are implemented to protect the confidentiality of CUI: {{ insert: param, A.03.13.11.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.11",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.11_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for cryptographic protection\n\nsystem design documentation\n\nsystem configuration settings\n\ncryptographic module validation certificates\n\nlist of FIPS-validated cryptographic modules\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.11_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for cryptographic protection\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.11_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing cryptographic protection"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.12",
+            "class": "requirement",
+            "title": "Collaborative Computing Devices and Applications",
+            "params": [
+              {
+                "id": "A.03.13.12.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.13.12.ODP[01]"
+                  }
+                ],
+                "label": "exceptions",
+                "usage": "organization-defined exceptions where remote activation is to be allowed",
+                "guidelines": [
+                  {
+                    "prose": "exceptions where remote activation is to be allowed are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.12"
+              },
+              {
+                "name": "label",
+                "value": "Collaborative Computing Devices and Applications (03.13.12)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#1fc5134c-7c9e-4cc7-a894-f4d088d291b6",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.12",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.13.12.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.12.a"
+                      }
+                    ],
+                    "prose": "Prohibit the remote activation of collaborative computing devices and applications with the following exceptions: {{ insert: param, A.03.13.12.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.13.12.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.12.b"
+                      }
+                    ],
+                    "prose": "Provide an explicit indication of use to users physically present at the devices."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.13.12",
+                "name": "guidance",
+                "prose": "Collaborative computing devices include white boards, microphones, and cameras. Notebook computers, smartphones, display monitors, and tablets containing cameras and microphones are considered part of collaborative computing devices when conferencing software is in use. Indication of use includes notifying users (e.g., a pop-up menu stating that recording is in progress or that the microphone has been turned on) when collaborative computing devices are activated. Dedicated video conferencing systems, which typically rely on one of the participants calling or connecting to the other party to activate the video conference, are excluded. Solutions to prevent device usage include webcam covers and buttons to disable microphones."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.12.a",
+                "name": "assessment-objective",
+                "prose": "the remote activation of collaborative computing devices and applications is prohibited with the following exceptions: {{ insert: param, A.03.13.12.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.12.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.12.b",
+                "name": "assessment-objective",
+                "prose": "an explicit indication of use is provided to users who are physically present at the devices.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.12.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.12_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for collaborative computing\n\naccess control policy and procedures\n\nsystem configuration settings\n\nsystem design documentation\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.12_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for managing collaborative computing devices\n\npersonnel with information security responsibilities\n\nsystem developers\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.12_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing the management of remote activation of collaborative computing devices\n\nmechanisms for providing an indication of use of collaborative computing devices"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.13",
+            "class": "requirement",
+            "title": "Mobile Code",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.13"
+              },
+              {
+                "name": "label",
+                "value": "Mobile Code (03.13.13)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#5fdb115e-695d-4a5e-963f-3693835c8fd1",
+                "rel": "reference"
+              },
+              {
+                "href": "#fd0344a1-4138-4908-8329-aeabbd3e2dd4",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.13",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.13.13.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.13.a"
+                      }
+                    ],
+                    "prose": "Define acceptable mobile code and mobile code technologies."
+                  },
+                  {
+                    "id": "SR-03.13.13.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.13.13.b"
+                      }
+                    ],
+                    "prose": "Authorize, monitor, and control the use of mobile code."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.13.13",
+                "name": "guidance",
+                "prose": "Mobile code includes software programs or parts of programs that are obtained from remote systems, transmitted across a network, and executed on a local system without explicit installation or execution by the recipient. Decisions regarding the use of mobile code are based on the potential for the code to cause damage to the system if used maliciously. Mobile code technologies include Java applets, JavaScript, HTML5, VBScript, and WebGL. Usage restrictions and implementation guidelines apply to the selection and use of mobile code installed on servers and downloaded and executed on individual workstations and devices, including notebook computers, smart phones, and smart devices. Mobile code policies and procedures address the actions taken to prevent the development, acquisition, and use of unacceptable mobile code within the system, including requiring mobile code to be digitally signed by a trusted source."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.13.b.01",
+                "name": "assessment-objective",
+                "prose": "the use of mobile code is authorized.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.13.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.13.b.02",
+                "name": "assessment-objective",
+                "prose": "the use of mobile code is monitored.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.13.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.13.b.03",
+                "name": "assessment-objective",
+                "prose": "the use of mobile code is controlled.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.13.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.13.a.01",
+                "name": "assessment-objective",
+                "prose": "acceptable mobile code is defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.13.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.13.a.02",
+                "name": "assessment-objective",
+                "prose": "acceptable mobile code technologies are defined.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.13.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.13_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for mobile code\n\nmobile code implementation policy and procedures\n\nlist of acceptable mobile code and mobile code technologies\n\nauthorization records\n\nsystem monitoring records\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.13_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for managing mobile code\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.13_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for authorizing, monitoring, and controlling mobile code\n\nmechanisms for supporting or implementing the management of mobile code\n\nmechanisms for supporting or implementing mobile code monitoring"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.14",
+            "class": "requirement",
+            "title": "03.13.14",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.14"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.15",
+            "class": "requirement",
+            "title": "Session Authenticity",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.15"
+              },
+              {
+                "name": "label",
+                "value": "Session Authenticity (03.13.15)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#247bb5d5-5121-4330-9f32-7cd8e0bf505a",
+                "rel": "reference"
+              },
+              {
+                "href": "#be88bb5c-d994-40f4-b273-3df87369c0ab",
+                "rel": "reference"
+              },
+              {
+                "href": "#2afcb88d-1586-4f5a-8438-2f84c98eff27",
+                "rel": "reference"
+              },
+              {
+                "href": "#a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+                "rel": "reference"
+              },
+              {
+                "href": "#53577f0d-fdba-4e18-a195-a04ea7c68e2e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.13.15",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.13.15",
+                "name": "guidance",
+                "prose": "Protecting session authenticity addresses communications protection at the session level, not at the packet level. Such protection establishes grounds for confidence at both ends of the communications sessions in the ongoing identities of other parties and the validity of the transmitted information. Authenticity protection includes protecting against adversary-in-the-middle attacks, session hijacking, and the insertion of false information into sessions."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.13.15",
+                "name": "assessment-objective",
+                "prose": "the authenticity of communications sessions is protected.",
+                "links": [
+                  {
+                    "href": "#SR-03.13.15",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.13.15_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and communications protection policy and procedures\n\nprocedures for session authenticity\n\nsystem design documentation\n\nsystem configuration settings\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.13.15_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.13.15_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "mechanisms for supporting or implementing session authenticity"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.13.16",
+            "class": "requirement",
+            "title": "03.13.16",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.13.16"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.13.08",
+                "rel": "incorporated_into"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.14",
+        "class": "family",
+        "title": "System and Information Integrity",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.14"
+          },
+          {
+            "name": "label",
+            "value": "System and Information Integrity (03.14)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.14.01",
+            "class": "requirement",
+            "title": "Flaw Remediation",
+            "params": [
+              {
+                "id": "A.03.14.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.14.01.ODP[01]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which to install security-relevant software updates after the release of the updates is defined."
+                  }
+                ]
+              },
+              {
+                "id": "A.03.14.01.ODP.02",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.14.01.ODP[02]"
+                  }
+                ],
+                "label": "time period",
+                "usage": "organization-defined time period",
+                "guidelines": [
+                  {
+                    "prose": "the time period within which to install security-relevant firmware updates after the release of the updates is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.01"
+              },
+              {
+                "name": "label",
+                "value": "Flaw Remediation (03.14.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b1c2fc95-3868-4b70-8596-ccbc8768fbe6",
+                "rel": "reference"
+              },
+              {
+                "href": "#73d621e1-ab3d-4958-b4d0-2ab05338b934",
+                "rel": "reference"
+              },
+              {
+                "href": "#4cd3f53c-8e18-43d2-8fb5-82c1eeb45582",
+                "rel": "reference"
+              },
+              {
+                "href": "#a5981dd2-7c12-469b-8ca9-648d1bb49326",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.14.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.14.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.01.a"
+                      }
+                    ],
+                    "prose": "Identify, report, and correct system flaws."
+                  },
+                  {
+                    "id": "SR-03.14.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.01.b"
+                      }
+                    ],
+                    "prose": "Install security-relevant software and firmware updates within {{ insert: param, A.03.14.01.ODP.01 }} of the release of the updates."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.14.01",
+                "name": "guidance",
+                "prose": "Organizations identify systems that are affected by announced software and firmware flaws, including potential vulnerabilities that result from those flaws, and report this information to designated personnel with information security responsibilities. Security-relevant updates include patches, service packs, hot fixes, and anti-virus signatures. Organizations address the flaws discovered during security assessments, continuous monitoring, incident response activities, and system error handling. Organizations can take advantage of available resources (e.g., CWE or CVE databases) when remediating system flaws. Organization-defined time periods for updating security-relevant software and firmware may vary based on a variety of factors, including the criticality of the update (i.e., severity of the vulnerability related to the discovered flaw). Some types of flaw remediation may require more testing than other types."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.01.a.01",
+                "name": "assessment-objective",
+                "prose": "system flaws are identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.01.a.02",
+                "name": "assessment-objective",
+                "prose": "system flaws are reported.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.01.a.03",
+                "name": "assessment-objective",
+                "prose": "system flaws are corrected.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.01.b.01",
+                "name": "assessment-objective",
+                "prose": "security-relevant software updates are installed within {{ insert: param, A.03.14.01.ODP.01 }} of the release of the updates.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.01.b.02",
+                "name": "assessment-objective",
+                "prose": "security-relevant firmware updates are installed within {{ insert: param, A.03.14.01.ODP.02 }} of the release of the updates.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.14.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and information integrity policy and procedures\n\nprocedures for flaw remediation\n\nprocedures for configuration management\n\nlist of recent security flaw remediation actions performed on the system\n\nlist of flaws and vulnerabilities that may potentially affect the system\n\ntest results from the installation of software and firmware updates to correct system flaws\n\ninstallation and change control records for security-relevant software and firmware updates\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.14.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel responsible for installing, configuring, or maintaining the system\n\npersonnel responsible for flaw remediation\n\npersonnel with configuration management responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.14.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for identifying, reporting, and correcting system flaws\n\nprocesses for installing software and firmware updates\n\nmechanisms for supporting or implementing the reporting and correction of system flaws\n\nmechanisms for supporting or implementing the testing software and firmware updates"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.02",
+            "class": "requirement",
+            "title": "Malicious Code Protection",
+            "params": [
+              {
+                "id": "A.03.14.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.14.02.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which malicious code protection mechanisms perform scans is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.02"
+              },
+              {
+                "name": "label",
+                "value": "Malicious Code Protection (03.14.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#7210b5f7-7e09-4ab8-b7ba-f5258eb602e9",
+                "rel": "reference"
+              },
+              {
+                "href": "#2cf4ace8-d71c-4e8f-a472-f2502de8a550",
+                "rel": "reference"
+              },
+              {
+                "href": "#7a27adf3-4c7f-4207-8782-d7bbd8791806",
+                "rel": "reference"
+              },
+              {
+                "href": "#b335d513-7986-46b1-9a1d-234a90c42e4a",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.14.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.14.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.02.a"
+                      }
+                    ],
+                    "prose": "Implement malicious code protection mechanisms at system entry and exit points to detect and eradicate malicious code."
+                  },
+                  {
+                    "id": "SR-03.14.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.02.b"
+                      }
+                    ],
+                    "prose": "Update malicious code protection mechanisms as new releases are available in accordance with configuration management policies and procedures."
+                  },
+                  {
+                    "id": "SR-03.14.02.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.02.c"
+                      }
+                    ],
+                    "prose": "Configure malicious code protection mechanisms to:",
+                    "parts": [
+                      {
+                        "id": "SR-03.14.02.c.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.14.02.c.01"
+                          }
+                        ],
+                        "prose": "Perform scans of the system {{ insert: param, A.03.14.02.ODP.01 }} and real-time scans of files from external sources at endpoints or system entry and exit points as the files are downloaded, opened, or executed; and"
+                      },
+                      {
+                        "id": "SR-03.14.02.c.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.14.02.c.02"
+                          }
+                        ],
+                        "prose": "Block malicious code, quarantine malicious code, or take other mitigation actions in response to malicious code detection."
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.14.02",
+                "name": "guidance",
+                "prose": "Malicious code insertions occur through the exploitation of system vulnerabilities. Malicious code can be inserted into the system in a variety of ways, including email, the internet, and portable storage devices. Malicious code includes viruses, worms, Trojan horses, and spyware. Malicious code can be encoded in various formats, contained in compressed or hidden files, or hidden in files using techniques such as steganography. Malicious code may be present in commercial off-the-shelf software and custom-built software and could include logic bombs, backdoors, and other types of attacks that could affect organizational mission and business functions. Periodic scans of the system and real-time scans of files from external sources as files are downloaded, opened, or executed can detect malicious code. Malicious code protection mechanisms can also monitor systems for anomalous or unexpected behaviors and take appropriate actions. Malicious code protection mechanisms include signature- and non-signature-based technologies. Non-signature-based detection mechanisms include artificial intelligence techniques that use heuristics to detect, analyze, and describe the characteristics or behavior of malicious code and to provide controls against such code for which signatures do not yet exist or for which existing signatures may not be effective. Malicious code for which active signatures do not yet exist or may be ineffective includes polymorphic malicious code (i.e., code that changes signatures when it replicates). Non-signature-based mechanisms include reputation-based technologies. Pervasive configuration management, anti-exploitation software, and software integrity controls may also be effective in preventing unauthorized code execution. If malicious code cannot be detected by detection methods or technologies, organizations can rely on secure coding practices, configuration management and control, trusted procurement processes, and monitoring practices to help ensure that the software only performs intended functions. Organizations may determine that different actions are warranted in response to the detection of malicious code. For example, organizations can define actions to be taken in response to the detection of malicious code during scans, malicious downloads, or malicious activity when attempting to open or execute files."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.02.a.01",
+                "name": "assessment-objective",
+                "prose": "malicious code protection mechanisms are implemented at system entry and exit points to detect malicious code.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.02.a.02",
+                "name": "assessment-objective",
+                "prose": "malicious code protection mechanisms are implemented at system entry and exit points to eradicate malicious code.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.02.b",
+                "name": "assessment-objective",
+                "prose": "malicious code protection mechanisms are updated as new releases are available in accordance with configuration management policy and procedures.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.02.c.01.01",
+                "name": "assessment-objective",
+                "prose": "malicious code protection mechanisms are configured to perform scans of the system {{ insert: param, A.03.14.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.02.c.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.02.c.02",
+                "name": "assessment-objective",
+                "prose": "malicious code protection mechanisms are configured to block malicious code, quarantine malicious code, or take other actions in response to malicious code detection.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.02.c.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.02.c.01.02",
+                "name": "assessment-objective",
+                "prose": "malicious code protection mechanisms are configured to perform real-time scans of files from external sources at endpoints or system entry and exit points as the files are downloaded, opened, or executed.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.02.c.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.14.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and information integrity policy and procedures\n\nconfiguration management policy and procedures\n\nprocedures for malicious code protection\n\nrecords of malicious code protection updates\n\nsystem design documentation\n\nsystem configuration settings\n\nscan results from malicious code protection mechanisms\n\nrecord of actions initiated by malicious code protection mechanisms in response to malicious code detection\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.14.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel responsible for malicious code protection\n\npersonnel with system installation, configuration, or maintenance responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.14.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for employing, updating, and configuring malicious code protection mechanisms\n\nprocesses for addressing the detection of false positives and resulting potential impacts\n\nmechanisms for supporting or implementing, employing, updating, and configuring malicious code protection mechanisms\n\nmechanisms for supporting or implementing malicious code scanning and the execution of subsequent actions"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.03",
+            "class": "requirement",
+            "title": "Security Alerts, Advisories, and Directives",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.03"
+              },
+              {
+                "name": "label",
+                "value": "Security Alerts, Advisories, and Directives (03.14.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#e522acff-a07b-48a7-ad5c-e4a7faa1b84f",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.14.03",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.14.03.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.03.a"
+                      }
+                    ],
+                    "prose": "Receive system security alerts, advisories, and directives from external organizations on an ongoing basis."
+                  },
+                  {
+                    "id": "SR-03.14.03.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.03.b"
+                      }
+                    ],
+                    "prose": "Generate and disseminate internal system security alerts, advisories, and directives, as necessary."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.14.03",
+                "name": "guidance",
+                "prose": "There are many publicly available sources of system security alerts and advisories. The Department of Homeland Security’s Cybersecurity and Infrastructure Security Agency (CISA), the National Security Agency (NSA), and the Federal Bureau of Investigation (FBI) generate security alerts and advisories to maintain situational awareness across the Federal Government and in nonfederal organizations. Software vendors, subscription services, and industry Information Sharing and Analysis Centers (ISACs) may also provide security alerts and advisories. Compliance with security directives is essential due to the critical nature of many of these directives and the potential immediate adverse effects on organizational operations and assets, individuals, other organizations, and the Nation should the directives not be implemented in a timely manner."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.03.a",
+                "name": "assessment-objective",
+                "prose": "system security alerts, advisories, and directives from external organizations are received on an ongoing basis.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.03.b.01",
+                "name": "assessment-objective",
+                "prose": "internal security alerts, advisories, and directives are generated, as necessary.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.03.b.02",
+                "name": "assessment-objective",
+                "prose": "internal security alerts, advisories, and directives are disseminated, as necessary.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.04",
+            "class": "requirement",
+            "title": "03.14.04",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.04"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.14.02",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.05",
+            "class": "requirement",
+            "title": "03.14.05",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.05"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.14.02",
+                "rel": "addressed_by"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.06",
+            "class": "requirement",
+            "title": "System Monitoring",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.06"
+              },
+              {
+                "name": "label",
+                "value": "System Monitoring (03.14.06)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#3cf2c4c9-9454-4204-8af1-269d900e9fab",
+                "rel": "reference"
+              },
+              {
+                "href": "#c827ca1c-d73d-414d-9434-1d3bda394ce9",
+                "rel": "reference"
+              },
+              {
+                "href": "#a07d3a28-bdd3-4161-b724-485cb436eba0",
+                "rel": "reference"
+              },
+              {
+                "href": "#7a27adf3-4c7f-4207-8782-d7bbd8791806",
+                "rel": "reference"
+              },
+              {
+                "href": "#46da9c8c-ae0f-4088-85a8-aa218b7f4de0",
+                "rel": "reference"
+              },
+              {
+                "href": "#b335d513-7986-46b1-9a1d-234a90c42e4a",
+                "rel": "reference"
+              },
+              {
+                "href": "#96810306-d115-4307-ab9a-baf41aebfc18",
+                "rel": "reference"
+              },
+              {
+                "href": "#ad479a27-d988-4830-b855-5acf7c5a9efa",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.14.06",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.14.06.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.06.a"
+                      }
+                    ],
+                    "prose": "Monitor the system to detect:",
+                    "parts": [
+                      {
+                        "id": "SR-03.14.06.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.14.06.a.01"
+                          }
+                        ],
+                        "prose": "Attacks and indicators of potential attacks and"
+                      },
+                      {
+                        "id": "SR-03.14.06.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.14.06.a.02"
+                          }
+                        ],
+                        "prose": "Unauthorized connections."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.14.06.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.06.b"
+                      }
+                    ],
+                    "prose": "Identify unauthorized use of the system."
+                  },
+                  {
+                    "id": "SR-03.14.06.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.14.06.c"
+                      }
+                    ],
+                    "prose": "Monitor inbound and outbound communications traffic to detect unusual or unauthorized activities or conditions."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.14.06",
+                "name": "guidance",
+                "prose": "System monitoring involves external and internal monitoring. Internal monitoring includes the observation of events that occur within the system. External monitoring includes the observation of events that occur at the system boundary. Organizations can monitor the system by observing audit record activities in real time or by observing other system aspects, such as access patterns, characteristics of access, and other actions. The monitoring objectives may guide determination of the events. A system monitoring capability is achieved through a variety of tools and techniques (e.g., audit record monitoring software, intrusion detection systems, intrusion prevention systems, malicious code protection software, scanning tools, network monitoring software). Strategic locations for monitoring devices include selected perimeter locations and near server farms that support critical applications with such devices being employed at managed system interfaces. The granularity of monitoring the information collected is based on organizational monitoring objectives and the capability of the system to support such objectives. Systems connections can be network, remote, or local. A network connection is any connection with a device that communicates through a network (e.g., local area network, the internet). A remote connection is any connection with a device that communicates through an external network (e.g., the internet). Network, remote, and local connections can be either wired or wireless. Unusual or unauthorized activities or conditions related to inbound and outbound communications traffic include internal traffic that indicates the presence of malicious code in the system or propagating among system components, the unauthorized export of information, or signaling to external systems. Evidence of malicious code is used to identify a potentially compromised system. System monitoring requirements, including the need for types of system monitoring, may be referenced in other requirements."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.06.a.01.01",
+                "name": "assessment-objective",
+                "prose": "the system is monitored to detect attacks.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.06.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.06.a.01.02",
+                "name": "assessment-objective",
+                "prose": "the system is monitored to detect indicators of potential attacks.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.06.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.06.a.02",
+                "name": "assessment-objective",
+                "prose": "the system is monitored to detect unauthorized connections.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.06.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.06.b",
+                "name": "assessment-objective",
+                "prose": "unauthorized use of the system is identified.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.06.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.06.c.01",
+                "name": "assessment-objective",
+                "prose": "inbound communications traffic is monitored to detect unusual or unauthorized activities or conditions.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.06.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.06.c.02",
+                "name": "assessment-objective",
+                "prose": "outbound communications traffic is monitored to detect unusual or unauthorized activities or conditions.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.06.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.14.06_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and information integrity policy and procedures\n\nprocedures for system monitoring tools and techniques\n\ncontinuous monitoring strategy\n\nfacility diagram or layout\n\nsystem design documentation\n\nlocations within the system where monitoring devices are deployed\n\nsystem configuration settings\n\nsystem protocols\n\nsystem audit records\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.14.06_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with responsibilities for installing, configuring, or maintaining the system\n\npersonnel with system monitoring responsibilities\n\npersonnel with intrusion detection responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.14.06_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for intrusion detection and system monitoring\n\nmechanisms for supporting or implementing system monitoring capabilities\n\nmechanisms for supporting or implementing intrusion detection and system monitoring capabilities\n\nmechanisms for supporting or implementing the monitoring of inbound and outbound communications traffic"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.07",
+            "class": "requirement",
+            "title": "03.14.07",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.07"
+              },
+              {
+                "name": "status",
+                "value": "withdrawn"
+              }
+            ],
+            "links": [
+              {
+                "href": "03.14.06",
+                "rel": "incorporated_into"
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.14.08",
+            "class": "requirement",
+            "title": "Information Management and Retention",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.14.08"
+              },
+              {
+                "name": "label",
+                "value": "Information Management and Retention (03.14.08)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b885e0fc-d253-46df-831f-47198e312eb3",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.14.08",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.14.08",
+                "name": "guidance",
+                "prose": "Federal agencies consider data retention requirements for nonfederal organizations. Retaining CUI on nonfederal systems after contracts or agreements have concluded increases the attack surface for those systems and the risk of the information being compromised. NARA provides federal policy and guidance on records retention and schedules."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.08.01",
+                "name": "assessment-objective",
+                "prose": "CUI within the system is managed in accordance with applicable laws, Executive Orders, directives, regulations, policies, standards, guidelines, and operational requirements.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.08.02",
+                "name": "assessment-objective",
+                "prose": "CUI within the system is retained in accordance with applicable laws, Executive Orders, directives, regulations, policies, standards, guidelines, and operational requirements.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.08.03",
+                "name": "assessment-objective",
+                "prose": "CUI output from the system is managed in accordance with applicable laws, Executive Orders, directives, regulations, policies, standards, guidelines, and operational requirements.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.14.08.04",
+                "name": "assessment-objective",
+                "prose": "CUI output from the system is retained in accordance with applicable laws, Executive Orders, directives, regulations, policies, standards, guidelines, and operational requirements.",
+                "links": [
+                  {
+                    "href": "#SR-03.14.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.14.08_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and information integrity policy and procedures\n\nlaws, Executive Orders, directives, policies, regulations, standards, and operational requirements applicable to information management and retention\n\nrecords retention and disposition policy\n\nrecords retention and disposition procedures\n\nmedia protection policy\n\nmedia protection procedures\n\naudit findings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.14.08_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information and records management, retention, and disposition responsibilities\n\npersonnel with information security responsibilities\n\nsystem administrators"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.14.08_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for information management, retention, and disposition\n\nmechanisms for supporting or implementing information management, retention, and disposition"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.15",
+        "class": "family",
+        "title": "Planning",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.15"
+          },
+          {
+            "name": "label",
+            "value": "Planning (03.15)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.15.01",
+            "class": "requirement",
+            "title": "Policy and Procedures",
+            "params": [
+              {
+                "id": "A.03.15.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.15.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which the policies and procedures for satisfying security requirements are reviewed and updated is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.15.01"
+              },
+              {
+                "name": "label",
+                "value": "Policy and Procedures (03.15.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#1dd03f05-e3c1-481c-9590-13dd588807e6",
+                "rel": "reference"
+              },
+              {
+                "href": "#f213e469-4196-4f82-8931-440856d65848",
+                "rel": "reference"
+              },
+              {
+                "href": "#eb6b8287-f201-41a9-a0b5-23155d9f016f",
+                "rel": "reference"
+              },
+              {
+                "href": "#606da864-95d0-4f13-bd54-0889935fb4a5",
+                "rel": "reference"
+              },
+              {
+                "href": "#617c26b8-5215-4bea-9833-e2ec7089e007",
+                "rel": "reference"
+              },
+              {
+                "href": "#4fb939a1-86c8-44e2-b243-3b8500942f61",
+                "rel": "reference"
+              },
+              {
+                "href": "#5eb31bc4-5237-4743-9840-16d9786f1f2b",
+                "rel": "reference"
+              },
+              {
+                "href": "#b20148d4-995c-4adf-9ff3-149e3fcf46b9",
+                "rel": "reference"
+              },
+              {
+                "href": "#60de36fe-e8d8-4450-b910-d19d7ed88b49",
+                "rel": "reference"
+              },
+              {
+                "href": "#e9ec4438-5be3-4cc7-8e0a-20b9b1e62a6c",
+                "rel": "reference"
+              },
+              {
+                "href": "#e32dcf8a-c6b1-481f-8d18-a824d58ad02e",
+                "rel": "reference"
+              },
+              {
+                "href": "#8cd6eded-fe36-4221-afbf-0d0397d7673a",
+                "rel": "reference"
+              },
+              {
+                "href": "#83231b22-97e6-45d4-8635-e4fc85a8c504",
+                "rel": "reference"
+              },
+              {
+                "href": "#26c70e72-c6ff-418c-830f-621d6b7dabb2",
+                "rel": "reference"
+              },
+              {
+                "href": "#f565dc28-9b86-4d0c-9ca0-dbb1b7aa6b3c",
+                "rel": "reference"
+              },
+              {
+                "href": "#d88ad43f-460d-4f84-858c-0b43199f8d4c",
+                "rel": "reference"
+              },
+              {
+                "href": "#53f5bfd7-6558-43e6-9da5-f97618d244f0",
+                "rel": "reference"
+              },
+              {
+                "href": "#0ab034d8-e9ad-4132-9ffe-83bc0bcfaba0",
+                "rel": "reference"
+              },
+              {
+                "href": "#abf53127-c0a1-4e39-b27e-78b7e4010489",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.15.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.15.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.01.a"
+                      }
+                    ],
+                    "prose": "Develop, document, and disseminate to organizational personnel or roles the policies and procedures needed to satisfy the security requirements for the protection of CUI."
+                  },
+                  {
+                    "id": "SR-03.15.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.01.b"
+                      }
+                    ],
+                    "prose": "Review and update policies and procedures {{ insert: param, A.03.15.01.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.15.01",
+                "name": "guidance",
+                "prose": "This requirement addresses policies and procedures for the protection of CUI. Policies and procedures contribute to security assurance and should address each family of the CUI security requirements. Policies can be included as part of the organizational security policy or be represented by separate policies that address each family of security requirements. Procedures describe how policies are implemented and can be directed at the individual or role that is the object of the procedure. Procedures can be documented in system security plans or in one or more separate documents."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.01.a.01",
+                "name": "assessment-objective",
+                "prose": "policies needed to satisfy the security requirements for the protection of CUI are developed and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.01.a.02",
+                "name": "assessment-objective",
+                "prose": "policies needed to satisfy the security requirements for the protection of CUI are disseminated to organizational personnel or roles.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.01.a.03",
+                "name": "assessment-objective",
+                "prose": "procedures needed to satisfy the security requirements for the protection of CUI are developed and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.01.a.04",
+                "name": "assessment-objective",
+                "prose": "procedures needed to satisfy the security requirements for the protection of CUI are disseminated to organizational personnel or roles.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.01.b.01",
+                "name": "assessment-objective",
+                "prose": "policies and procedures are reviewed {{ insert: param, A.03.15.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.01.b.02",
+                "name": "assessment-objective",
+                "prose": "policies and procedures are updated {{ insert: param, A.03.15.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.15.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security policies and procedures associated with the protection of CUI\n\naudit findings\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.15.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with information security responsibilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.15.02",
+            "class": "requirement",
+            "title": "System Security Plan",
+            "params": [
+              {
+                "id": "A.03.15.02.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.15.02.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which the system security plan is reviewed and updated is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.15.02"
+              },
+              {
+                "name": "label",
+                "value": "System Security Plan (03.15.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#6cf24eac-432c-4450-838d-19d7bc6f2278",
+                "rel": "reference"
+              },
+              {
+                "href": "#bfced6a4-225e-4c21-b7c6-bece622bfb0e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.15.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.15.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.02.a"
+                      }
+                    ],
+                    "prose": "Develop a system security plan that:",
+                    "parts": [
+                      {
+                        "id": "SR-03.15.02.a.01",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.01"
+                          }
+                        ],
+                        "prose": "Defines the constituent system components;"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.02",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.02"
+                          }
+                        ],
+                        "prose": "Identifies the information types processed, stored, and transmitted by the system;"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.03",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.03"
+                          }
+                        ],
+                        "prose": "Describes specific threats to the system that are of concern to the organization;"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.04",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.04"
+                          }
+                        ],
+                        "prose": "Describes the operational environment for the system and any dependencies on or connections to other systems or system components;"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.05",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.05"
+                          }
+                        ],
+                        "prose": "Provides an overview of the security requirements for the system;"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.06",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.06"
+                          }
+                        ],
+                        "prose": "Describes the safeguards in place or planned for meeting the security requirements;"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.07",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.07"
+                          }
+                        ],
+                        "prose": "Identifies individuals that fulfill system roles and responsibilities; and"
+                      },
+                      {
+                        "id": "SR-03.15.02.a.08",
+                        "name": "item",
+                        "props": [
+                          {
+                            "name": "label",
+                            "value": "SR-03.15.02.a.08"
+                          }
+                        ],
+                        "prose": "Includes other relevant information necessary for the protection of CUI."
+                      }
+                    ]
+                  },
+                  {
+                    "id": "SR-03.15.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.02.b"
+                      }
+                    ],
+                    "prose": "Review and update the system security plan {{ insert: param, A.03.15.02.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.15.02.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.02.c"
+                      }
+                    ],
+                    "prose": "Protect the system security plan from unauthorized disclosure."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.15.02",
+                "name": "guidance",
+                "prose": "System security plans provide key characteristics of the system that is processing, storing, and transmitting CUI and how the system and information are protected. System security plans contain sufficient information to enable a design and implementation that are unambiguously compliant with the intent of the plans and the subsequent determinations of risk if the plan is implemented as intended. System security plans can be a collection of documents, including documents that already exist. Effective system security plans reference policies, procedures, and documents (e.g., design specifications) that provide additional detailed information. This reduces the documentation requirements associated with security programs and maintains security information in other established management or operational areas related to enterprise architecture, the system development life cycle, systems engineering, and acquisition."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.01",
+                "name": "assessment-objective",
+                "prose": "a system security plan that defines the constituent system components is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.02",
+                "name": "assessment-objective",
+                "prose": "a system security plan that identifies the information types processed, stored, and transmitted by the system is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.03",
+                "name": "assessment-objective",
+                "prose": "a system security plan that describes specific threats to the system that are of concern to the organization is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.03",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.04",
+                "name": "assessment-objective",
+                "prose": "a system security plan that describes the operational environment for the system and any dependencies on or connections to other systems or system components is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.04",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.05",
+                "name": "assessment-objective",
+                "prose": "a system security plan that provides an overview of the security requirements for the system is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.05",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.06",
+                "name": "assessment-objective",
+                "prose": "a system security plan that describes the safeguards in place or planned for meeting the security requirements is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.06",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.07",
+                "name": "assessment-objective",
+                "prose": "a system security plan that identifies individuals that fulfill system roles and responsibilities is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.07",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.a.08",
+                "name": "assessment-objective",
+                "prose": "a system security plan that includes other relevant information necessary for the protection of CUI is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.a.08",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.b.01",
+                "name": "assessment-objective",
+                "prose": "the system security plan is reviewed {{ insert: param, A.03.15.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.b.02",
+                "name": "assessment-objective",
+                "prose": "the system security plan is updated {{ insert: param, A.03.15.02.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.02.c",
+                "name": "assessment-objective",
+                "prose": "the system security plan is protected from unauthorized disclosure.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.02.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.15.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security planning policy and procedures\n\nprocedures for system security plan development and implementation\n\nprocedures for system security plan reviews and updates\n\nenterprise architecture\n\nsystem security plan\n\nrecords of system security plan reviews and updates\n\nrisk assessments\n\nrisk assessment results\n\nsecurity architecture and design documentation\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.15.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system security planning and plan implementation responsibilities\n\nsystem developers\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.15.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for system security plan development, review, update, and approval"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.15.03",
+            "class": "requirement",
+            "title": "Rules of Behavior",
+            "params": [
+              {
+                "id": "A.03.15.03.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.15.03.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which the rules of behavior are reviewed and updated is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.15.03"
+              },
+              {
+                "name": "label",
+                "value": "Rules of Behavior (03.15.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#0f441928-41d8-4ab0-9c5a-6a903bb1a58e",
+                "rel": "reference"
+              },
+              {
+                "href": "#bfced6a4-225e-4c21-b7c6-bece622bfb0e",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.15.03",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.15.03.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.03.a"
+                      }
+                    ],
+                    "prose": "Establish rules that describe the responsibilities and expected behavior for system usage and protecting CUI."
+                  },
+                  {
+                    "id": "SR-03.15.03.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.03.b"
+                      }
+                    ],
+                    "prose": "Provide rules to individuals who require access to the system."
+                  },
+                  {
+                    "id": "SR-03.15.03.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.03.c"
+                      }
+                    ],
+                    "prose": "Receive a documented acknowledgement from individuals indicating that they have read, understand, and agree to abide by the rules of behavior before authorizing access to CUI and the system."
+                  },
+                  {
+                    "id": "SR-03.15.03.d",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.15.03.d"
+                      }
+                    ],
+                    "prose": "Review and update the rules of behavior {{ insert: param, A.03.15.03.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.15.03",
+                "name": "guidance",
+                "prose": "Rules of behavior represent a type of access agreement for system users. Organizations consider rules of behavior for the handling of CUI based on individual user roles and responsibilities and differentiate between rules that apply to privileged users and rules that apply to general users."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.03.a",
+                "name": "assessment-objective",
+                "prose": "rules that describe responsibilities and expected behavior for system usage and protecting CUI are established.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.03.b",
+                "name": "assessment-objective",
+                "prose": "rules are provided to individuals who require access to the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.03.c",
+                "name": "assessment-objective",
+                "prose": "a documented acknowledgement from individuals indicating that they have read, understand, and agree to abide by the rules of behavior is received before authorizing access to CUI and the system.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.03.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.03.d.02",
+                "name": "assessment-objective",
+                "prose": "the rules of behavior are updated {{ insert: param, A.03.15.03.ODP.01 }} .",
+                "links": [
+                  {
+                    "href": "#SR-03.15.03.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.15.03.d.01",
+                "name": "assessment-objective",
+                "prose": "the rules of behavior are reviewed {{ insert: param, A.03.15.03.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.15.03.d",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.15.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "security planning policy and procedures\n\nrules of behavior for system users\n\nsigned acknowledgements of rules of behavior\n\nrecords for rules of behavior reviews and updates\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.15.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with rules of behavior establishment, review, and update responsibilities\n\npersonnel with literacy training and awareness responsibilities\n\npersonnel with role-based training responsibilities\n\nauthorized users of the system who have signed rules of behavior\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.15.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for establishing, reviewing, disseminating, and updating rules of behavior\n\nmechanisms for supporting or implementing the establishment, dissemination, review, and update of rules of behavior"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.16",
+        "class": "family",
+        "title": "System and Services Acquisition",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.16"
+          },
+          {
+            "name": "label",
+            "value": "System and Services Acquisition (03.16)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.16.01",
+            "class": "requirement",
+            "title": "Security Engineering Principles",
+            "params": [
+              {
+                "id": "A.03.16.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.16.01.ODP[01]"
+                  }
+                ],
+                "label": "systems security engineering principles",
+                "usage": "organization-defined systems security engineering principles",
+                "guidelines": [
+                  {
+                    "prose": "systems security engineering principles to be applied to the development or modification of the system and system components are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.16.01"
+              },
+              {
+                "name": "label",
+                "value": "Security Engineering Principles (03.16.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#9498ecc0-c39c-43f4-8d7d-91c0298ea808",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#fa117c16-587d-4163-a421-e35553768633",
+                "rel": "reference"
+              },
+              {
+                "href": "#2e702ac1-d107-4251-b12e-6816b9f20747",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.16.01",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.16.01",
+                "name": "guidance",
+                "prose": "Organizations apply systems security engineering principles to new development systems. For legacy systems, organizations apply systems security engineering principles to system modifications to the extent feasible, given the current state of hardware, software, and firmware components. The application of systems security engineering principles helps to develop trustworthy, secure, and resilient systems and reduce the susceptibility of organizations to disruptions, hazards, and threats. Examples include developing layered protections; establishing security policies, architectures, and controls as the foundation for system design; incorporating security requirements into the system development life cycle; delineating physical and logical security boundaries; ensuring that developers are trained on how to build trustworthy secure software; and performing threat modeling to identify use cases, threat agents, attack vectors and patterns, design patterns, and compensating controls needed to mitigate risk. Organizations that apply security engineering principles can facilitate the development of trustworthy, secure systems, system components, and system services; reduce risks to acceptable levels; and make informed risk-management decisions."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.16.01",
+                "name": "assessment-objective",
+                "prose": "{{ insert: param, A.03.16.01.ODP.01 }} are applied to the development or modification of the system and system components.",
+                "links": [
+                  {
+                    "href": "#SR-03.16.01",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.16.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and services acquisition policy\n\nsystem and services acquisition procedures\n\nprocedures addressing security engineering principles used in the development and modification of the system\n\nsystem design documentation\n\nsecurity requirements and specifications for the system\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.16.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with acquisition/contracting responsibilities\n\npersonnel with information security responsibilities\n\npersonnel with system development and modification responsibilities\n\nsystem developers"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.16.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for applying security engineering principles in system development and modification\n\nmechanisms supporting the application of security engineering principles in system development and modification"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.16.02",
+            "class": "requirement",
+            "title": "Unsupported System Components",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.16.02"
+              },
+              {
+                "name": "label",
+                "value": "Unsupported System Components (03.16.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#f271ee7e-4dce-4846-bbd7-f9da0faf71dd",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.16.02",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.16.02.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.16.02.a"
+                      }
+                    ],
+                    "prose": "Replace system components when support for the components is no longer available from the developer, vendor, or manufacturer."
+                  },
+                  {
+                    "id": "SR-03.16.02.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.16.02.b"
+                      }
+                    ],
+                    "prose": "Provide options for risk mitigation or alternative sources for continued support for unsupported components that cannot be replaced."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.16.02",
+                "name": "guidance",
+                "prose": "Support for system components includes software patches, firmware updates, replacement parts, and maintenance contracts. An example of unsupported components includes when vendors no longer provide critical software patches or product updates, which can result in opportunities for adversaries to exploit weaknesses or deficiencies in the installed components. Exceptions to replacing unsupported system components include systems that provide critical mission or business capabilities when newer technologies are unavailable or when the systems are so isolated that installing replacement components is not an option. Alternative sources of support address the need to provide continued support for system components that are no longer supported by the original manufacturers, developers, or vendors when such components remain essential to organizational missions and business functions. If necessary, organizations can establish in-house support by developing customized patches for critical software components or obtain the services of external service providers who provide ongoing support for unsupported components through contractual relationships. Such contractual relationships can include open-source software value-added vendors. The increased risk of using unsupported system components can be mitigated by prohibiting the connection of such components to public or uncontrolled networks or implementing other forms of isolation."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.16.02.b",
+                "name": "assessment-objective",
+                "prose": "options for risk mitigation or alternative sources for continued support for unsupported components that cannot be replaced are provided.",
+                "links": [
+                  {
+                    "href": "#SR-03.16.02.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.16.02.a",
+                "name": "assessment-objective",
+                "prose": "system components are replaced when support for the components is no longer available from the developer, vendor, or manufacturer.",
+                "links": [
+                  {
+                    "href": "#SR-03.16.02.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.16.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and services acquisition policy and procedures\n\nprocedures for the replacement or continued use of unsupported system components\n\ndocumented evidence of replacing unsupported system components\n\ndocumented approvals (including justification) for the continued use of unsupported system components\n\nSCRM plan\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.16.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with system and service acquisition responsibilities\n\npersonnel responsible for component replacement\n\npersonnel with system development life cycle responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.16.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for replacing unsupported system components\n\nmechanisms for supporting or implementing the replacement of unsupported system components"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.16.03",
+            "class": "requirement",
+            "title": "External System Services",
+            "params": [
+              {
+                "id": "A.03.16.03.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.16.03.ODP[01]"
+                  }
+                ],
+                "label": "security requirements",
+                "usage": "organization-defined security requirements",
+                "guidelines": [
+                  {
+                    "prose": "security requirements to be satisfied by external system service providers are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.16.03"
+              },
+              {
+                "name": "label",
+                "value": "External System Services (03.16.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#02e3d499-9faa-46d6-bbb9-120f6eeba77f",
+                "rel": "reference"
+              },
+              {
+                "href": "#a10063e9-0afe-4e96-9bb0-f308c8179077",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.16.03",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.16.03.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.16.03.a"
+                      }
+                    ],
+                    "prose": "Require the providers of external system services used for the processing, storage, or transmission of CUI to comply with the following security requirements: {{ insert: param, A.03.16.03.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.16.03.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.16.03.b"
+                      }
+                    ],
+                    "prose": "Define and document user roles and responsibilities with regard to external system services, including shared responsibilities with external service providers."
+                  },
+                  {
+                    "id": "SR-03.16.03.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.16.03.c"
+                      }
+                    ],
+                    "prose": "Implement processes, methods, and techniques to monitor security requirement compliance by external service providers on an ongoing basis."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.16.03",
+                "name": "guidance",
+                "prose": "External system services are provided by external service providers. Organizations establish relationships with external service providers in a variety of ways, including through business partnerships, contracts, interagency agreements, lines of business arrangements, licensing agreements, joint ventures, and supply chain exchanges. The responsibility for managing risks from the use of external system services remains with the organization charged with protecting CUI. Service-level agreements define expectations of performance, describe measurable outcomes, and identify remedies, mitigations, and response requirements for instances of noncompliance. Information from external service providers regarding the specific functions, ports, protocols, and services used in the provision of such services can be useful when there is a need to understand the trade-offs involved in restricting certain functions and services or blocking certain ports and protocols. This requirement is related to [](#/cprt/framework/version/SP_800_171_3_0_0/home?element=03.01.20) 03.01.20."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.16.03.a",
+                "name": "assessment-objective",
+                "prose": "the providers of external system services used for the processing, storage, or transmission of CUI comply with the following security requirements: {{ insert: param, A.03.16.03.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.16.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.16.03.c",
+                "name": "assessment-objective",
+                "prose": "processes, methods, and techniques to monitor security requirement compliance by external service providers on an ongoing basis are implemented.",
+                "links": [
+                  {
+                    "href": "#SR-03.16.03.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.16.03.b",
+                "name": "assessment-objective",
+                "prose": "user roles and responsibilities with regard to external system services, including shared responsibilities with external service providers, are defined and documented.",
+                "links": [
+                  {
+                    "href": "#SR-03.16.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.16.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "system and services acquisition policy and procedures\n\nprocedures for monitoring security requirement compliance by external service providers\n\nacquisition documentation\n\ncontracts\n\nservice-level agreements\n\ninteragency agreements\n\nlicensing agreements\n\nlist of security requirements for external provider services\n\nassessment results or reports from external service providers\n\nSCRM plan\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.16.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with acquisition responsibilities\n\nexternal providers of system services\n\npersonnel with SCRM responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.16.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "organizational processes for monitoring security and privacy control compliance by external service providers on an ongoing basis\n\nmechanisms for monitoring security and privacy control compliance by external service providers on an ongoing basis"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "SP_800_171_03.17",
+        "class": "family",
+        "title": "Supply Chain Risk Management",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "03.17"
+          },
+          {
+            "name": "label",
+            "value": "Supply Chain Risk Management (03.17)"
+          }
+        ],
+        "controls": [
+          {
+            "id": "SP_800_171_03.17.01",
+            "class": "requirement",
+            "title": "Supply Chain Risk Management Plan",
+            "params": [
+              {
+                "id": "A.03.17.01.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.17.01.ODP[01]"
+                  }
+                ],
+                "label": "frequency",
+                "usage": "organization-defined frequency",
+                "guidelines": [
+                  {
+                    "prose": "the frequency at which to review and update the supply chain risk management plan is defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.17.01"
+              },
+              {
+                "name": "label",
+                "value": "Supply Chain Risk Management Plan (03.17.01)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b2025cb2-29b9-48b4-aedb-853288194feb",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              },
+              {
+                "href": "#2932aa8a-9447-435b-9fc8-98b82b6e617c",
+                "rel": "reference"
+              },
+              {
+                "href": "#d7469545-b483-4820-b7a1-b64841239a93",
+                "rel": "reference"
+              },
+              {
+                "href": "#4cd3f53c-8e18-43d2-8fb5-82c1eeb45582",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.17.01",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.17.01.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.17.01.a"
+                      }
+                    ],
+                    "prose": "Develop a plan for managing supply chain risks associated with the research and development, design, manufacturing, acquisition, delivery, integration, operations, maintenance, and disposal of the system, system components, or system services."
+                  },
+                  {
+                    "id": "SR-03.17.01.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.17.01.b"
+                      }
+                    ],
+                    "prose": "Review and update the supply chain risk management plan {{ insert: param, A.03.17.01.ODP.01 }}."
+                  },
+                  {
+                    "id": "SR-03.17.01.c",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.17.01.c"
+                      }
+                    ],
+                    "prose": "Protect the supply chain risk management plan from unauthorized disclosure."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.17.01",
+                "name": "guidance",
+                "prose": "Dependence on the products, systems, and services of external providers and the nature of the relationships with those providers present an increasing level of risk to an organization. Threat actions that may increase security risks include unauthorized production, the insertion or use of counterfeits, tampering, poor manufacturing and development practices in the supply chain, theft, and the insertion of malicious software, firmware, and hardware. Supply chain risks can be endemic or systemic within a system, component, or service. Managing supply chain risks is a complex, multifaceted undertaking that requires a coordinated effort across an organization to build trust relationships and communicate with internal and external stakeholders. Supply chain risk management (SCRM) activities include identifying and assessing risks, determining appropriate risk response actions, developing SCRM plans to document response actions, and monitoring performance against the plans. The system-level SCRM plan is implementation-specific and provides constraints, policy implementation, requirements, and implications. It can either be stand-alone or incorporated into system security plans. The SCRM plan addresses the management, implementation, and monitoring of SCRM requirements and the development or sustainment of systems across the system development life cycle to support mission and business functions. Because supply chains can differ significantly across and within organizations, SCRM plans are tailored to individual program, organizational, and operational contexts."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.01",
+                "name": "assessment-objective",
+                "prose": "a plan for managing supply chain risks is developed.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.02",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the research and development of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.03",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the design of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.04",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the manufacturing of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.05",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the acquisition of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.06",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the delivery of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.07",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the integration of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.08",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the operation of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.09",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the maintenance of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.a.10",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan addresses risks associated with the disposal of the system, system components, or system services.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.b.01",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan is reviewed {{ insert: param, A.03.17.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.b.02",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan is updated {{ insert: param, A.03.17.01.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.01.c",
+                "name": "assessment-objective",
+                "prose": "the SCRM plan is protected from unauthorized disclosure.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.01.c",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.17.01_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "SCRM policy and procedures\n\nSCRM plan\n\nsystem and services acquisition policy and procedures\n\nsystem and services acquisition procedures\n\nprocedures for supply chain protection\n\nprocedures for protecting the SCRM plan from unauthorized disclosure\n\nsystem development life cycle procedures\n\nprocedures for the integration of information security requirements into the acquisition process\n\nacquisition documentation\n\nservice-level agreements\n\nacquisition contracts for the system, system components, or system services\n\nlist of supply chain threats\n\nlist of safeguards for supply chain threats\n\nsystem life cycle documentation, including research and development, design, manufacturing, acquisition, delivery, integration, operations, maintenance, and disposal\n\ninter-organizational agreements and procedures\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.17.01_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with acquisition responsibilities\n\npersonnel with SCRM responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.17.01_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "organizational processes for defining and documenting the system development life cycle (SDLC)\n\norganizational processes for identifying SDLC roles and responsibilities\n\norganizational processes for integrating SCRM into the SDLC\n\nmechanisms for supporting or implementing the SDLC"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.17.02",
+            "class": "requirement",
+            "title": "Acquisition Strategies, Tools, and Methods",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.17.02"
+              },
+              {
+                "name": "label",
+                "value": "Acquisition Strategies, Tools, and Methods (03.17.02)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#b7e352b7-6344-4b4e-8a78-090010eb4d36",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              },
+              {
+                "href": "#d7469545-b483-4820-b7a1-b64841239a93",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.17.02",
+                "name": "statement",
+                "class": "security_requirement"
+              },
+              {
+                "id": "guidance_D-03.17.02",
+                "name": "guidance",
+                "prose": "The acquisition process provides an important vehicle for protecting the supply chain. There are many useful tools and techniques available, including obscuring the end use of a system or system component, using blind purchases, requiring tamperevident packaging, or using trusted or controlled distribution. The results from a supply chain risk assessment can inform the strategies, tools, and methods that are most applicable to the situation. Tools and techniques may provide protections against unauthorized production, theft, tampering, the insertion of counterfeits, the insertion of malicious software or backdoors, and poor development practices throughout the system life cycle. Organizations also consider providing incentives for suppliers to implement safeguards, promote transparency in their processes and security practices, provide contract language that addresses the prohibition of tainted or counterfeit components, and restrict purchases from untrustworthy suppliers. Organizations consider providing training, education, and awareness programs for personnel regarding supply chain risks, available mitigation strategies, and when the programs should be employed. Methods for reviewing and protecting development plans, documentation, and evidence are commensurate with the security requirements of the organization. Contracts may specify documentation protection requirements."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.02.01",
+                "name": "assessment-objective",
+                "prose": "acquisition strategies, contract tools, and procurement methods are developed to identify supply chain risks.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.02.02",
+                "name": "assessment-objective",
+                "prose": "acquisition strategies, contract tools, and procurement methods are developed to protect against supply chain risks.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.02.03",
+                "name": "assessment-objective",
+                "prose": "acquisition strategies, contract tools, and procurement methods are developed to mitigate supply chain risks.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.02.04",
+                "name": "assessment-objective",
+                "prose": "acquisition strategies, contract tools, and procurement methods are implemented to identify supply chain risks.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.02.05",
+                "name": "assessment-objective",
+                "prose": "acquisition strategies, contract tools, and procurement methods are implemented to protect against supply chain risks.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.02.06",
+                "name": "assessment-objective",
+                "prose": "acquisition strategies, contract tools, and procurement methods are implemented to mitigate supply chain risks.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.02",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.17.02_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "SCRM policy and procedures\n\nSCRM plan\n\nsystem and services acquisition policy and procedures\n\nprocedures for supply chain protection\n\nprocedures for the integration of information security requirements into the acquisition process\n\nsolicitation documentation\n\nacquisition documentation (including purchase orders)\n\nservice-level agreements\n\nacquisition contracts for the system, system components, or services\n\ndocumentation of identified supply chain risks\n\nmitigation plans for supply chain risks\n\ndocumentation of training, education, and awareness programs for personnel regarding supply chain risk\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.17.02_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with acquisition responsibilities\n\npersonnel with SCRM responsibilities\n\npersonnel with information security responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.17.02_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for defining and employing tailored acquisition strategies, contract tools, and procurement methods\n\nmechanisms for implementing tailored acquisition strategies, contract tools, and procurement methods"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "SP_800_171_03.17.03",
+            "class": "requirement",
+            "title": "Supply Chain Requirements and Processes",
+            "params": [
+              {
+                "id": "A.03.17.03.ODP.01",
+                "props": [
+                  {
+                    "name": "label",
+                    "value": "A.03.17.03.ODP[01]"
+                  }
+                ],
+                "label": "security requirements",
+                "usage": "organization-defined security requirements",
+                "guidelines": [
+                  {
+                    "prose": "security requirements to protect against supply chain risks to the system, system components, or system services and to limit the harm or consequences from supply chain-related events are defined."
+                  }
+                ]
+              }
+            ],
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "03.17.03"
+              },
+              {
+                "name": "label",
+                "value": "Supply Chain Requirements and Processes (03.17.03)"
+              }
+            ],
+            "links": [
+              {
+                "href": "#3fea095b-2378-4c35-bcea-873d68703b0b",
+                "rel": "reference"
+              },
+              {
+                "href": "#a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+                "rel": "reference"
+              },
+              {
+                "href": "#d7469545-b483-4820-b7a1-b64841239a93",
+                "rel": "reference"
+              }
+            ],
+            "parts": [
+              {
+                "id": "statement_03.17.03",
+                "name": "statement",
+                "class": "security_requirement",
+                "parts": [
+                  {
+                    "id": "SR-03.17.03.a",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.17.03.a"
+                      }
+                    ],
+                    "prose": "Establish a process for identifying and addressing weaknesses or deficiencies in the supply chain elements and processes."
+                  },
+                  {
+                    "id": "SR-03.17.03.b",
+                    "name": "item",
+                    "props": [
+                      {
+                        "name": "label",
+                        "value": "SR-03.17.03.b"
+                      }
+                    ],
+                    "prose": "Enforce the following security requirements to protect against supply chain risks to the system, system components, or system services and to limit the harm or consequences from supply chain-related events: {{ insert: param, A.03.17.03.ODP.01 }}."
+                  }
+                ]
+              },
+              {
+                "id": "guidance_D-03.17.03",
+                "name": "guidance",
+                "prose": "Supply chain elements include organizations, entities, or tools that are employed for the research, development, design, manufacturing, acquisition, delivery, integration, operations, maintenance, and disposal of systems and system components. Supply chain processes include hardware, software, firmware, and systems development processes; shipping and handling procedures; physical security programs; personnel security programs; configuration management tools, techniques, and measures to maintain provenance; or other programs, processes, or procedures associated with the development, acquisition, maintenance, and disposal of systems and system components. Supply chain elements and processes are provided by organizations, system integrators, or external service providers. Weaknesses or deficiencies in supply chain elements or processes represent potential vulnerabilities that can be exploited by adversaries to harm the organization and affect its ability to carry out its core missions or business functions."
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.03.a.01",
+                "name": "assessment-objective",
+                "prose": "a process for identifying weaknesses or deficiencies in the supply chain elements and processes is established.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.03.a.02",
+                "name": "assessment-objective",
+                "prose": "a process for addressing weaknesses or deficiencies in the supply chain elements and processes is established.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.03.a",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "assessment-objective_DS-A.03.17.03.b",
+                "name": "assessment-objective",
+                "prose": "the following security requirements are enforced to protect against supply chain risks to the system, system components, or system services and to limit the harm or consequences of supply chain-related events: {{ insert: param, A.03.17.03.ODP.01 }}.",
+                "links": [
+                  {
+                    "href": "#SR-03.17.03.b",
+                    "rel": "assessment-for"
+                  }
+                ]
+              },
+              {
+                "id": "E-03.17.03_assessment-method_examine",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "EXAMINE"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "SCRM policy and procedures\n\nSCRM strategy\n\nSCRM plan\n\nsystems and critical system components inventory documentation\n\nsystem and services acquisition policy and procedures\n\nprocedures for the integration of security requirements into the acquisition process\n\nsolicitation documentation\n\nacquisition documentation (including purchase orders)\n\nshipping and handling procedures\n\nconfiguration management documentation and records\n\nacquisition contracts for systems or services\n\nservice-level agreements\n\nrisk register documentation\n\nsystem security plan\n\nother relevant documents or records"
+                  }
+                ]
+              },
+              {
+                "id": "I-03.17.03_assessment-method_interview",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "INTERVIEW"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "personnel with acquisition responsibilities\n\npersonnel with information security responsibilities\n\npersonnel with SCRM responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "T-03.17.03_assessment-method_test",
+                "name": "assessment-method",
+                "props": [
+                  {
+                    "name": "method",
+                    "ns": "http://csrc.nist.gov/ns/rmf",
+                    "value": "TEST"
+                  }
+                ],
+                "parts": [
+                  {
+                    "name": "assessment-objects",
+                    "prose": "processes for identifying and addressing supply chain element and process deficiencies"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "back-matter": {
+      "resources": [
+        {
+          "uuid": "6845eb53-a392-4552-83f4-04b129b40d3f",
+          "title": "Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/publications/detail/sp/800-171/rev-2/final",
+              "media-type": "application/html"
+            }
+          ]
+        },
+        {
+          "uuid": "6957f4cd-7e2e-43a9-9f76-720c861efb45",
+          "title": "Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/pubs/sp/800/171/r3/final",
+              "media-type": "application/html"
+            }
+          ]
+        },
+        {
+          "uuid": "e59e6d39-499f-4235-aa9f-8463b3bba156",
+          "title": "Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt",
+              "media-type": "application/html"
+            }
+          ]
+        },
+        {
+          "uuid": "8ebdf692-6004-46ff-8ffa-044383bf214b",
+          "title": "PS-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PS-03"
+            }
+          ]
+        },
+        {
+          "uuid": "2932aa8a-9447-435b-9fc8-98b82b6e617c",
+          "title": "SP 800-181",
+          "citation": {
+            "text": "Petersen R, Santos D, Smith MC, Wetzel KA, Witte G (2020) Workforce Framework for Cybersecurity (NICE Framework). (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-181, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-181r1"
+            }
+          ]
+        },
+        {
+          "uuid": "29262f3c-2ac6-4cff-9315-4feee3ef51ba",
+          "title": "PS-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PS-04"
+            }
+          ]
+        },
+        {
+          "uuid": "8ef1bc1d-cac5-46e5-b57e-2acee8c6a1a1",
+          "title": "PS-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PS-05"
+            }
+          ]
+        },
+        {
+          "uuid": "b2025cb2-29b9-48b4-aedb-853288194feb",
+          "title": "SR-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SR-02"
+            }
+          ]
+        },
+        {
+          "uuid": "a249da1e-0a36-4942-ae4e-e84bb7b78b51",
+          "title": "SP 800-161",
+          "citation": {
+            "text": "Boyens JM, Smith A, Bartol N, Winkler K, Holbrook A, Fallon M (2022) Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-161, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-161r1"
+            }
+          ]
+        },
+        {
+          "uuid": "d7469545-b483-4820-b7a1-b64841239a93",
+          "title": "SP 800-30",
+          "citation": {
+            "text": "Joint Task Force Transformation Initiative (2012) Guide for Conducting Risk Assessments. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-30, Rev."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-30r1"
+            }
+          ]
+        },
+        {
+          "uuid": "4cd3f53c-8e18-43d2-8fb5-82c1eeb45582",
+          "title": "SP 800-39",
+          "citation": {
+            "text": "Joint Task Force Transformation Initiative (2011) Managing Information Security Risk: Organization, Mission, and Information System View. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-39."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-39"
+            }
+          ]
+        },
+        {
+          "uuid": "b7e352b7-6344-4b4e-8a78-090010eb4d36",
+          "title": "SR-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SR-05"
+            }
+          ]
+        },
+        {
+          "uuid": "3fea095b-2378-4c35-bcea-873d68703b0b",
+          "title": "SR-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SR-03"
+            }
+          ]
+        },
+        {
+          "uuid": "13c67bb0-9c04-442b-8c7f-0e4f55f995a5",
+          "title": "AC-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-02"
+            }
+          ]
+        },
+        {
+          "uuid": "78a467a2-9b1b-4d5f-a7e5-b2661a4374a0",
+          "title": "AC-02(03)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-02(03)"
+            }
+          ]
+        },
+        {
+          "uuid": "9197204c-0af8-4a31-9495-ae2ba8995fb9",
+          "title": "AC-02(05)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-02(05)"
+            }
+          ]
+        },
+        {
+          "uuid": "a21c08b1-1984-4b6a-b8eb-fa667b8fc7e8",
+          "title": "AC-02(13)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-02(13)"
+            }
+          ]
+        },
+        {
+          "uuid": "56cd2f5a-abf8-4810-b449-55de6ee5dbb1",
+          "title": "IR 7874",
+          "citation": {
+            "text": "Hu VC, Scarfone KA (2012) Guidelines for Access Control System Evaluation Metrics. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Interagency or Internal Report (IR) 7874."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.IR.7874"
+            }
+          ]
+        },
+        {
+          "uuid": "f509b76c-728e-4afa-9db3-ed09265f4723",
+          "title": "IR 7966",
+          "citation": {
+            "text": "Ylonen T, Turner P, Scarfone KA, Souppaya MP (2015) Security of Interactive and Automated Access Management Using Secure Shell (SSH). (National Institute of Standards and Technology, Gaithersburg, MD), NIST Interagency or Internal Report (IR) 7966."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.IR.7966"
+            }
+          ]
+        },
+        {
+          "uuid": "be88bb5c-d994-40f4-b273-3df87369c0ab",
+          "title": "SP 800-113",
+          "citation": {
+            "text": "Frankel SE, Hoffman P, Orebaugh AD, Park R (2008) Guide to SSL VPNs. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-113."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-113"
+            }
+          ]
+        },
+        {
+          "uuid": "68ef9454-30ff-4bb7-bbe5-a631d353a6cb",
+          "title": "SP 800-114",
+          "citation": {
+            "text": "Souppaya MP, Scarfone KA (2016) User’s Guide to Telework and Bring Your Own Device (BYOD) Security. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-114, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-114r1"
+            }
+          ]
+        },
+        {
+          "uuid": "da00e9f9-6829-46d6-bcec-a08ef5556e7f",
+          "title": "SP 800-121",
+          "citation": {
+            "text": "Padgette J, Bahr J, Holtmann M, Batra M, Chen L, Smithbey R, Scarfone KA (2017) Guide to Bluetooth Security. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-121, Rev. 2, Includes updates as of January 19, 2022."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-121r2-upd1"
+            }
+          ]
+        },
+        {
+          "uuid": "276c6996-e72e-409e-a5dc-f9a53435028b",
+          "title": "SP 800-162",
+          "citation": {
+            "text": "Hu VC, Ferraiolo DF, Kuhn R, Schnitzer A, Sandlin K, Miller R, Scarfone KA (2014) Guide to Attribute Based Access Control (ABAC) Definition and Considerations. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-162, Includes updates as of August 2, 2019."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-162"
+            }
+          ]
+        },
+        {
+          "uuid": "3d61b0ab-28ea-40e4-b231-ba750516968b",
+          "title": "SP 800-178",
+          "citation": {
+            "text": "Ferraiolo DF, Hu VC, Kuhn R, Chandramouli R (2016) A Comparison of Attribute Based Access Control (ABAC) Standards for Data Service Applications: Extensible Access Control Markup Language (XACML) and"
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-178"
+            }
+          ]
+        },
+        {
+          "uuid": "72a57444-839c-4c52-8f18-3a710d23b5b6",
+          "title": "SP 800-192",
+          "citation": {
+            "text": "Yaga DJ, Kuhn R, Hu VC (2017) Verification and Test Methods for Access Control Policies/Models. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-192."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-192"
+            }
+          ]
+        },
+        {
+          "uuid": "b684972f-48eb-4a6e-b581-b5e697b3bc19",
+          "title": "SP 800-46",
+          "citation": {
+            "text": "Souppaya MP, Scarfone KA (2016) Guide to Enterprise Telework, Remote Access, and Bring Your Own Device (BYOD) Security. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-46, Rev. 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-46r2"
+            }
+          ]
+        },
+        {
+          "uuid": "13290408-22ce-4afa-a0f0-ca438c1e932b",
+          "title": "SP 800-57-1",
+          "citation": {
+            "text": "Barker EB (2020) Recommendation for Key Management: Part 1 – General. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-57 Part 1, Rev. 5."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-57pt1r5"
+            }
+          ]
+        },
+        {
+          "uuid": "e0aa4a13-03cc-4b86-be6c-80225af5c3af",
+          "title": "SP 800-57-2",
+          "citation": {
+            "text": "Barker EB, Barker WC (2019) Recommendation for Key Management: Part 2 – Best Practices for Key Management Organizations. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-57 Part 2, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-57pt2r1"
+            }
+          ]
+        },
+        {
+          "uuid": "6aba579a-f262-4bf9-a8e7-6820ea63de34",
+          "title": "SP 800-57-3",
+          "citation": {
+            "text": "Barker EB, Dang QH (2015) Recommendation for Key Management, Part 3: ApplicationSpecific Key Management Guidance. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-57 Part 3, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-57pt3r1"
+            }
+          ]
+        },
+        {
+          "uuid": "a58bb8d1-1534-4ba0-b86c-11072b59ec98",
+          "title": "SP 800-77",
+          "citation": {
+            "text": "Barker EB, Dang QH, Frankel SE, Scarfone KA, Wouters P (2020) Guide to IPsec VPNs. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-77, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-77r1"
+            }
+          ]
+        },
+        {
+          "uuid": "086c4c08-e24e-4a8d-96e8-d384f36acc62",
+          "title": "AC-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-03"
+            }
+          ]
+        },
+        {
+          "uuid": "a9f06e3c-3130-46ad-b51c-ff67f4d9b338",
+          "title": "AC-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-04"
+            }
+          ]
+        },
+        {
+          "uuid": "a10063e9-0afe-4e96-9bb0-f308c8179077",
+          "title": "SP 800-160-1",
+          "citation": {
+            "text": "Ross R, Winstead M, McEvilley M (2022) Engineering Trustworthy Secure Systems. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-160, Vol. 1, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-160v1r1"
+            }
+          ]
+        },
+        {
+          "uuid": "f15afb9b-7fec-4178-bf5c-ab9b19643998",
+          "title": "AC-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-05"
+            }
+          ]
+        },
+        {
+          "uuid": "1240a1b8-e785-4b78-b89f-929d67e50f8f",
+          "title": "AC-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06"
+            }
+          ]
+        },
+        {
+          "uuid": "b67dc576-0eb9-454f-9f8b-241e11d1e790",
+          "title": "AC-06(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "d62abb9e-b573-4519-a5a0-869448c62c7a",
+          "title": "AC-06(07)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06(07)"
+            }
+          ]
+        },
+        {
+          "uuid": "c3606a57-b8a7-4a26-9ba4-9dc3dbadd08c",
+          "title": "AU-09(04)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-09(04)"
+            }
+          ]
+        },
+        {
+          "uuid": "3c84ba44-6fdd-45da-9176-3a018d3179e5",
+          "title": "AC-06(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "e9163a6a-1231-4195-85ee-d8c7ef9cd552",
+          "title": "AC-06(05)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06(05)"
+            }
+          ]
+        },
+        {
+          "uuid": "b3af0cb9-ee6e-45be-a855-0e28dbceedeb",
+          "title": "AC-06(09)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06(09)"
+            }
+          ]
+        },
+        {
+          "uuid": "404238c1-fc3f-4d3b-9d50-923f5d676888",
+          "title": "AC-06(10)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-06(10)"
+            }
+          ]
+        },
+        {
+          "uuid": "2734910e-c595-4116-8ccd-4a85a9c8eda7",
+          "title": "AC-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-07"
+            }
+          ]
+        },
+        {
+          "uuid": "2d1ff7ad-c4f5-4f94-80fd-796164f6f1b4",
+          "title": "SP 800-124",
+          "citation": {
+            "text": "Howell G, Franklin JM, Sritapan V, Souppaya M, Scarfone K (2023) Guidelines for Managing the Security of Mobile Devices in the Enterprise. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-124, Rev. 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-124r2"
+            }
+          ]
+        },
+        {
+          "uuid": "900b7a48-6d75-4177-aaa6-137d817232c7",
+          "title": "SP 800-63-3",
+          "citation": {
+            "text": "Grassi PA, Garcia ME, Fenton JL (2017) Digital Identity Guidelines. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-63-3, Includes updates as of March 2, 2020."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-63-3"
+            }
+          ]
+        },
+        {
+          "uuid": "e8e9d62c-b3ca-4285-b88f-3db08a1509fa",
+          "title": "AC-08",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-08"
+            }
+          ]
+        },
+        {
+          "uuid": "b3dcf788-1166-44ff-9abe-1c140f2975da",
+          "title": "AC-11",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-11"
+            }
+          ]
+        },
+        {
+          "uuid": "3b4eda46-abb8-4dc0-8983-cb43c22e72ef",
+          "title": "AC-11(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-11(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "fe6e872e-39da-4949-a8e4-63670f03386e",
+          "title": "AC-12",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-12"
+            }
+          ]
+        },
+        {
+          "uuid": "4108e300-3475-4ccc-8e09-7a5bfdd282cf",
+          "title": "AC-17",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-17"
+            }
+          ]
+        },
+        {
+          "uuid": "6a901397-ab79-4174-9af3-96040731a7e3",
+          "title": "AC-17(03)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-17(03)"
+            }
+          ]
+        },
+        {
+          "uuid": "002ac0fe-a790-4a93-be63-571ecb414e89",
+          "title": "AC-17(04)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-17(04)"
+            }
+          ]
+        },
+        {
+          "uuid": "b22943e2-fcb6-43b7-8895-eeff60a3a222",
+          "title": "AC-18",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-18"
+            }
+          ]
+        },
+        {
+          "uuid": "1db363ba-2f6c-43d9-aed7-37c23fd45f9d",
+          "title": "AC-18(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-18(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "799f75c1-3e9a-47a1-994f-a7bf60460550",
+          "title": "AC-18(03)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-18(03)"
+            }
+          ]
+        },
+        {
+          "uuid": "ad479a27-d988-4830-b855-5acf7c5a9efa",
+          "title": "SP 800-94",
+          "citation": {
+            "text": "Scarfone KA, Mell PM (2007) Guide to Intrusion Detection and Prevention Systems (IDPS). (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-94."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-94"
+            }
+          ]
+        },
+        {
+          "uuid": "ff9a9661-8d87-4750-a2c4-d781dd3c98dd",
+          "title": "SP 800-97",
+          "citation": {
+            "text": "Frankel SE, Eydt B, Owens L, Scarfone KA (2007) Establishing Wireless Robust Security Networks: A Guide to IEEE 802.11i. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-97."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-97"
+            }
+          ]
+        },
+        {
+          "uuid": "600d351d-0d99-4789-abcd-3a1dfcce2d52",
+          "title": "AC-19",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-19"
+            }
+          ]
+        },
+        {
+          "uuid": "c436a93b-debb-411e-a0d6-81e2f6cb49d5",
+          "title": "AC-19(05)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-19(05)"
+            }
+          ]
+        },
+        {
+          "uuid": "45969a10-8816-4ae0-abc4-d0c1764bab75",
+          "title": "AC-20",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-20"
+            }
+          ]
+        },
+        {
+          "uuid": "52fd9e23-defd-4647-a7d2-b96416edefc9",
+          "title": "AC-20(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-20(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "50c6d509-5e60-4b57-802c-1c5253946ef4",
+          "title": "AC-20(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-20(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "08316684-be23-473a-abd0-22abe611ad1a",
+          "title": "AC-22",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-22"
+            }
+          ]
+        },
+        {
+          "uuid": "1dd03f05-e3c1-481c-9590-13dd588807e6",
+          "title": "AC-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-01"
+            }
+          ]
+        },
+        {
+          "uuid": "f213e469-4196-4f82-8931-440856d65848",
+          "title": "AT-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AT-01"
+            }
+          ]
+        },
+        {
+          "uuid": "eb6b8287-f201-41a9-a0b5-23155d9f016f",
+          "title": "AU-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-01"
+            }
+          ]
+        },
+        {
+          "uuid": "606da864-95d0-4f13-bd54-0889935fb4a5",
+          "title": "CA-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CA-01"
+            }
+          ]
+        },
+        {
+          "uuid": "617c26b8-5215-4bea-9833-e2ec7089e007",
+          "title": "CM-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-01"
+            }
+          ]
+        },
+        {
+          "uuid": "4fb939a1-86c8-44e2-b243-3b8500942f61",
+          "title": "IA-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-01"
+            }
+          ]
+        },
+        {
+          "uuid": "5eb31bc4-5237-4743-9840-16d9786f1f2b",
+          "title": "IR-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-01"
+            }
+          ]
+        },
+        {
+          "uuid": "b20148d4-995c-4adf-9ff3-149e3fcf46b9",
+          "title": "MA-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-01"
+            }
+          ]
+        },
+        {
+          "uuid": "60de36fe-e8d8-4450-b910-d19d7ed88b49",
+          "title": "MP-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-01"
+            }
+          ]
+        },
+        {
+          "uuid": "e9ec4438-5be3-4cc7-8e0a-20b9b1e62a6c",
+          "title": "PE-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-01"
+            }
+          ]
+        },
+        {
+          "uuid": "e32dcf8a-c6b1-481f-8d18-a824d58ad02e",
+          "title": "PL-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PL-01"
+            }
+          ]
+        },
+        {
+          "uuid": "8cd6eded-fe36-4221-afbf-0d0397d7673a",
+          "title": "PS-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PS-01"
+            }
+          ]
+        },
+        {
+          "uuid": "83231b22-97e6-45d4-8635-e4fc85a8c504",
+          "title": "RA-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-01"
+            }
+          ]
+        },
+        {
+          "uuid": "26c70e72-c6ff-418c-830f-621d6b7dabb2",
+          "title": "SA-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SA-01"
+            }
+          ]
+        },
+        {
+          "uuid": "f565dc28-9b86-4d0c-9ca0-dbb1b7aa6b3c",
+          "title": "SC-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-01"
+            }
+          ]
+        },
+        {
+          "uuid": "d88ad43f-460d-4f84-858c-0b43199f8d4c",
+          "title": "SI-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-01"
+            }
+          ]
+        },
+        {
+          "uuid": "53f5bfd7-6558-43e6-9da5-f97618d244f0",
+          "title": "SR-01",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SR-01"
+            }
+          ]
+        },
+        {
+          "uuid": "0ab034d8-e9ad-4132-9ffe-83bc0bcfaba0",
+          "title": "SP 800-100",
+          "citation": {
+            "text": "Bowen P, Hash J, Wilson M (2006) Information Security Handbook: A Guide for Managers. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-100, Includes updates as of March 7, 2007."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-100"
+            }
+          ]
+        },
+        {
+          "uuid": "abf53127-c0a1-4e39-b27e-78b7e4010489",
+          "title": "SP 800-12",
+          "citation": {
+            "text": "Nieles M, Pillitteri VY, Dempsey KL (2017) An Introduction to Information Security. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-12, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-12r1"
+            }
+          ]
+        },
+        {
+          "uuid": "6cf24eac-432c-4450-838d-19d7bc6f2278",
+          "title": "PL-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PL-02"
+            }
+          ]
+        },
+        {
+          "uuid": "bfced6a4-225e-4c21-b7c6-bece622bfb0e",
+          "title": "SP 800-18",
+          "citation": {
+            "text": "Swanson MA, Hash J, Bowen P (2006) Guide for Developing Security Plans for Federal Information Systems. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-18, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-18r1"
+            }
+          ]
+        },
+        {
+          "uuid": "0f441928-41d8-4ab0-9c5a-6a903bb1a58e",
+          "title": "PL-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PL-04"
+            }
+          ]
+        },
+        {
+          "uuid": "9498ecc0-c39c-43f4-8d7d-91c0298ea808",
+          "title": "SA-08",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SA-08"
+            }
+          ]
+        },
+        {
+          "uuid": "fa117c16-587d-4163-a421-e35553768633",
+          "title": "SP 800-160-2",
+          "citation": {
+            "text": "Ross RS, Pillitteri VY, Graubart R, Bodeau D, McQuaid R (2021) Developing Cyber-Resilient Systems: A Systems Security Engineering Approach. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-160, Vol. 2, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-160v2r1"
+            }
+          ]
+        },
+        {
+          "uuid": "2e702ac1-d107-4251-b12e-6816b9f20747",
+          "title": "SP 800-207",
+          "citation": {
+            "text": "Rose S, Borchert O, Mitchell S, Connelly S (2017) Zero Trust Architecture. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-207."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-207"
+            }
+          ]
+        },
+        {
+          "uuid": "f271ee7e-4dce-4846-bbd7-f9da0faf71dd",
+          "title": "SA-22",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SA-22"
+            }
+          ]
+        },
+        {
+          "uuid": "02e3d499-9faa-46d6-bbb9-120f6eeba77f",
+          "title": "SA-09",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SA-09"
+            }
+          ]
+        },
+        {
+          "uuid": "4e5dd76f-13cb-4cb6-84f8-da66c566b988",
+          "title": "CM-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-02"
+            }
+          ]
+        },
+        {
+          "uuid": "2c17a971-f0a2-47df-9f91-d752a39a4b56",
+          "title": "IR 8011-2",
+          "citation": {
+            "text": "Dempsey KL, Eavy P, Moore G (2017) Automation Support for Security Control Assessments: Volume 2: Hardware Asset Management. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Interagency or Internal Report (IR) 8011, Volume 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.IR.8011-2"
+            }
+          ]
+        },
+        {
+          "uuid": "64230fd9-c88b-4288-82a4-2c1e5e490a4a",
+          "title": "IR 8011-3",
+          "citation": {
+            "text": "Dempsey KL, Eavy P, Goren N, Moore G (2018) Automation Support for Security Control Assessments: Volume 3: Software Asset Management. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Interagency or Internal Report (IR) 8011, Volume 3."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.IR.8011-3"
+            }
+          ]
+        },
+        {
+          "uuid": "73d621e1-ab3d-4958-b4d0-2ab05338b934",
+          "title": "SP 800-128",
+          "citation": {
+            "text": "Johnson LA, Dempsey KL, Ross RS, Gupta S, Bailey D (2011) Guide for Security-Focused Configuration Management of Information Systems. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-128, Includes updates as of October 10, 2019."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-128"
+            }
+          ]
+        },
+        {
+          "uuid": "3c484dac-6220-4f09-9afb-d31fd47269d2",
+          "title": "CM-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-06"
+            }
+          ]
+        },
+        {
+          "uuid": "7d1055bb-574a-4487-b0c7-5791a0509fc8",
+          "title": "SP 800-126",
+          "citation": {
+            "text": "Waltermire DA, Quinn SD, Booth H, III, Scarfone KA, Prisaca D (2018) The Technical Specification for the Security Content Automation Protocol (SCAP): SCAP Version 1.3. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-126, Rev. 3."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-126r3"
+            }
+          ]
+        },
+        {
+          "uuid": "bb27dd66-aa0b-42d9-952a-7bab2fe8047e",
+          "title": "SP 800-70",
+          "citation": {
+            "text": "Quinn SD, Souppaya MP, Cook MR, Scarfone KA (2018) National Checklist Program for IT Products: Guidelines for Checklist Users and Developers. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-70, Rev. 4."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-70r4"
+            }
+          ]
+        },
+        {
+          "uuid": "02cf8bfa-85d5-4738-9dac-e6ac625f05ca",
+          "title": "CM-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-03"
+            }
+          ]
+        },
+        {
+          "uuid": "971156e2-ba52-4418-a4ca-179886d6bc3b",
+          "title": "CM-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-04"
+            }
+          ]
+        },
+        {
+          "uuid": "d8227f66-d7ed-461a-ba6b-e36ef724de9f",
+          "title": "CM-04(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-04(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "55ed1dd1-b4cb-4df9-964a-eae7f44e0be1",
+          "title": "CM-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-05"
+            }
+          ]
+        },
+        {
+          "uuid": "ee7a6c0f-4d87-4bef-a353-ca0e7ee09073",
+          "title": "FIPS 140-3",
+          "citation": {
+            "text": "National Institute of Standards and Technology (2019) Security Requirements for Cryptographic Modules. (U.S. Department of Commerce, Washington, D.C.), Federal Information Processing Standards Publication (FIPS) 140-3."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.FIPS.140-3"
+            }
+          ]
+        },
+        {
+          "uuid": "e95ca7ce-1251-4a4c-ad90-296e3895001b",
+          "title": "FIPS 180-4",
+          "citation": {
+            "text": "National Institute of Standards and Technology (2015) Secure Hash Standard (SHS). (U.S. Department of Commerce, Washington, D.C.), Federal Information Processing Standards Publication (FIPS) 180-4."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.FIPS.180-4"
+            }
+          ]
+        },
+        {
+          "uuid": "925f7cfa-84ca-42f7-98e4-13eaa5ee57d5",
+          "title": "CM-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-07"
+            }
+          ]
+        },
+        {
+          "uuid": "fa702319-e39d-485e-b0bb-d33e9071ca91",
+          "title": "CM-07(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-07(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "3beee199-43e4-4679-91dc-e94270b125f4",
+          "title": "SP 800-167",
+          "citation": {
+            "text": "Sedgewick A, Souppaya MP, Scarfone KA (2015) Guide to Application Whitelisting. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-167."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-167"
+            }
+          ]
+        },
+        {
+          "uuid": "a24d80b7-67d9-4657-8701-987487af6a6a",
+          "title": "CM-07(05)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-07(05)"
+            }
+          ]
+        },
+        {
+          "uuid": "8d0ba78d-a7c0-4141-b24a-8afc5366ef65",
+          "title": "CM-08",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-08"
+            }
+          ]
+        },
+        {
+          "uuid": "9b7a1b97-6c78-4ca6-b053-f421162e63bd",
+          "title": "CM-08(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-08(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "cba05591-32fa-439a-9f3c-c72b11c18b11",
+          "title": "CM-12",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-12"
+            }
+          ]
+        },
+        {
+          "uuid": "a342e082-b4de-44d7-b461-80eed2c111aa",
+          "title": "CM-02(07)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CM-02(07)"
+            }
+          ]
+        },
+        {
+          "uuid": "3437202e-3b72-4cec-83c4-3b03a9e267a8",
+          "title": "IR-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-04"
+            }
+          ]
+        },
+        {
+          "uuid": "6af8bc6f-a2ce-4b74-bc88-507d5bbc0c33",
+          "title": "SP 800-50",
+          "citation": {
+            "text": "Wilson M, Hash J (2003) Building an Information Technology Security Awareness and Training Program. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-50."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-50"
+            }
+          ]
+        },
+        {
+          "uuid": "46da9c8c-ae0f-4088-85a8-aa218b7f4de0",
+          "title": "SP 800-61",
+          "citation": {
+            "text": "Cichonski PR, Millar T, Grance T, Scarfone KA (2012) Computer Security Incident Handling Guide. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-61, Rev. 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-61r2"
+            }
+          ]
+        },
+        {
+          "uuid": "b4c05da9-c9cb-49c0-819b-0076c26f417e",
+          "title": "IR-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-05"
+            }
+          ]
+        },
+        {
+          "uuid": "18730fb2-20c1-4ef7-b271-88a69d2091d6",
+          "title": "IR-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-06"
+            }
+          ]
+        },
+        {
+          "uuid": "96f470cf-a8a3-407b-b531-db686248d67b",
+          "title": "IR-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-07"
+            }
+          ]
+        },
+        {
+          "uuid": "d1d734b3-9384-42b3-968c-5ba2939626ee",
+          "title": "SP 800-86",
+          "citation": {
+            "text": "Kent K, Chevalier S, Grance T, Dang H (2006) Guide to Integrating Forensic Techniques into Incident Response. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-86."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-86"
+            }
+          ]
+        },
+        {
+          "uuid": "5e56bdf5-cedb-42ae-988e-feec7f3ae98b",
+          "title": "IR-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-03"
+            }
+          ]
+        },
+        {
+          "uuid": "49c62ac0-6eb3-4bce-ae3d-4bffd33290fe",
+          "title": "SP 800-84",
+          "citation": {
+            "text": "Grance T, Nolan T, Burke K, Dudley R, White G, Good T (2006) Guide to Test, Training, and Exercise Programs for IT Plans and Capabilities. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-84."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-84"
+            }
+          ]
+        },
+        {
+          "uuid": "478afc24-d6f6-45f6-b020-b55706df5241",
+          "title": "IR-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-02"
+            }
+          ]
+        },
+        {
+          "uuid": "a07d3a28-bdd3-4161-b724-485cb436eba0",
+          "title": "SP 800-137",
+          "citation": {
+            "text": "Dempsey KL, Chawla NS, Johnson LA, Johnston R, Jones AC, Orebaugh AD, Scholl MA, Stine KM (2011) Information Security Continuous Monitoring (ISCM) for Federal Information Systems and Organizations. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-137."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-137"
+            }
+          ]
+        },
+        {
+          "uuid": "0279cdf8-f523-4b59-98ad-25352980e72d",
+          "title": "IR-08",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-08"
+            }
+          ]
+        },
+        {
+          "uuid": "a0545240-de4e-416d-8764-11c4ae62468a",
+          "title": "SC-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-07"
+            }
+          ]
+        },
+        {
+          "uuid": "2cf4ace8-d71c-4e8f-a472-f2502de8a550",
+          "title": "SP 800-125B",
+          "citation": {
+            "text": "Chandramouli R (2016) Secure Virtual Network Configuration for Virtual Machine (VM) Protection. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-125B."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-125B"
+            }
+          ]
+        },
+        {
+          "uuid": "905fc293-cebb-4cc6-90d6-c95ed047090b",
+          "title": "SP 800-189",
+          "citation": {
+            "text": "Sriram K, Montgomery D (2019) Resilient Interdomain Traffic Exchange: BGP Security and DDoS Mitigation. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-189."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-189"
+            }
+          ]
+        },
+        {
+          "uuid": "0bb2b4eb-d888-4ef1-b612-5ad3ac27a41a",
+          "title": "SP 800-41",
+          "citation": {
+            "text": "Scarfone KA, Hoffman P (2009) Guidelines on Firewalls and Firewall Policy. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-41, Rev. 1"
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-41r1"
+            }
+          ]
+        },
+        {
+          "uuid": "1f34e010-fb4a-42e2-ae2f-2d5a611a8581",
+          "title": "SC-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-04"
+            }
+          ]
+        },
+        {
+          "uuid": "ad6bde1d-4352-430d-95f6-a1f9cbace84d",
+          "title": "SC-07(05)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-07(05)"
+            }
+          ]
+        },
+        {
+          "uuid": "523267df-021c-4e2d-ad9f-bbc05f915764",
+          "title": "SC-08",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-08"
+            }
+          ]
+        },
+        {
+          "uuid": "b8d0af05-79fa-4a8f-98f1-f595285d8e81",
+          "title": "SC-08(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-08(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "1a3eaa86-0aed-4af8-9be8-0477122cae56",
+          "title": "SC-28",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-28"
+            }
+          ]
+        },
+        {
+          "uuid": "7f931c0d-e575-4392-aa68-3cdb755a6ea4",
+          "title": "SC-28(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-28(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "9b69bf22-8406-48cb-845c-bcc84aac8bf5",
+          "title": "FIPS 197",
+          "citation": {
+            "text": "National Institute of Standards and Technology (2001) Advanced Encryption Standard (AES). (U.S. Department of Commerce, Washington, D.C.), Federal Information Processing Standards Publication (FIPS) 197, updated May 9, 2023."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.FIPS.197-upd1"
+            }
+          ]
+        },
+        {
+          "uuid": "226b6921-eab4-4662-b0df-f2f6049eb782",
+          "title": "SP 800-111",
+          "citation": {
+            "text": "Scarfone KA, Souppaya MP, Sexton M (2007) Guide to Storage Encryption Technologies for End User Devices. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-111."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-111"
+            }
+          ]
+        },
+        {
+          "uuid": "7a27adf3-4c7f-4207-8782-d7bbd8791806",
+          "title": "SP 800-177",
+          "citation": {
+            "text": "Rose SW, Nightingale S, Garfinkel SL, Chandramouli R (2019) Trustworthy Email. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-177, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-177r1"
+            }
+          ]
+        },
+        {
+          "uuid": "2afcb88d-1586-4f5a-8438-2f84c98eff27",
+          "title": "SP 800-52",
+          "citation": {
+            "text": "McKay KA, Cooper DA (2019) Guidelines for the Selection, Configuration, and Use of Transport Layer Security (TLS) Implementations. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-52, Rev. 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-52r2"
+            }
+          ]
+        },
+        {
+          "uuid": "1b330b12-130c-4a91-b0c8-231ab77ff053",
+          "title": "SP 800-56A",
+          "citation": {
+            "text": "Barker EB, Chen L, Roginsky A, Vassilev A, Davis R (2018) Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-56A, Rev. 3."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-56Ar3"
+            }
+          ]
+        },
+        {
+          "uuid": "fce8ddf8-ff73-497e-b372-ec6c7bc06b2b",
+          "title": "SP 800-56B",
+          "citation": {
+            "text": "Barker EB, Chen L, Roginsky A, Vassilev A, Davis R, Simon S (2019) Recommendation for Pair-Wise Key-Establishment Using Integer Factorization Cryptography. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-56B, Rev. 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-56Br2"
+            }
+          ]
+        },
+        {
+          "uuid": "784d88ea-68d3-45f0-ab58-cbe9e8695988",
+          "title": "SP 800-56C",
+          "citation": {
+            "text": "Barker EB, Chen L, Davis R (2020) Recommendation for Key-Derivation Methods in KeyEstablishment Schemes. (National Institute of Standards and Technology, Gaithersburg, MD)"
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-56Cr2"
+            }
+          ]
+        },
+        {
+          "uuid": "f70cb413-b2ce-416a-a89d-cd27549d01b4",
+          "title": "SC-10",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-10"
+            }
+          ]
+        },
+        {
+          "uuid": "8e5443e8-137c-48bf-95d3-297142328d64",
+          "title": "SC-12",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-12"
+            }
+          ]
+        },
+        {
+          "uuid": "2d31b72b-97a1-497f-b99d-79f01dce0dc5",
+          "title": "SC-13",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-13"
+            }
+          ]
+        },
+        {
+          "uuid": "1fc5134c-7c9e-4cc7-a894-f4d088d291b6",
+          "title": "SC-15",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-15"
+            }
+          ]
+        },
+        {
+          "uuid": "5fdb115e-695d-4a5e-963f-3693835c8fd1",
+          "title": "SC-18",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-18"
+            }
+          ]
+        },
+        {
+          "uuid": "fd0344a1-4138-4908-8329-aeabbd3e2dd4",
+          "title": "SP 800-28",
+          "citation": {
+            "text": "Jansen W, Winograd T, Scarfone KA (2008) Guidelines on Active Content and Mobile Code. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-28, Version 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-28ver2"
+            }
+          ]
+        },
+        {
+          "uuid": "247bb5d5-5121-4330-9f32-7cd8e0bf505a",
+          "title": "SC-23",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-23"
+            }
+          ]
+        },
+        {
+          "uuid": "53577f0d-fdba-4e18-a195-a04ea7c68e2e",
+          "title": "SP 800-95",
+          "citation": {
+            "text": "Singhal A, Winograd T, Scarfone KA (2007) Guide to Secure Web Services. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-95."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-95"
+            }
+          ]
+        },
+        {
+          "uuid": "5d5edea2-31e3-4a91-b39e-d581f059c985",
+          "title": "CA-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CA-02"
+            }
+          ]
+        },
+        {
+          "uuid": "c1809cdb-face-4fae-9476-4c97ebf0ad0c",
+          "title": "SP 800-115",
+          "citation": {
+            "text": "Scarfone KA, Souppaya MP, Cody A, Orebaugh AD (2008) Technical Guide to Information Security Testing and Assessment. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-115."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-115"
+            }
+          ]
+        },
+        {
+          "uuid": "8d1fb520-63c6-441b-a4ba-974c8d98ef71",
+          "title": "SP 800-37",
+          "citation": {
+            "text": "Joint Task Force (2018) Risk Management Framework for Information Systems and Organizations: A System Life Cycle Approach for Security and Privacy. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-37, Rev. 2."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-37r2"
+            }
+          ]
+        },
+        {
+          "uuid": "7af9ad3c-594d-43b8-a527-de9f622421e0",
+          "title": "SP 800-53",
+          "citation": {
+            "text": "Joint Task Force (2020) Security and Privacy Controls for Information Systems and Organizations. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-53, Rev. 5, Includes updates as of December 10, 2020."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-53r5"
+            }
+          ]
+        },
+        {
+          "uuid": "60b7ef54-4422-4a73-99ab-854410a7e716",
+          "title": "SP 800-53A",
+          "citation": {
+            "text": "Joint Task Force Transformation Initiative (2022) Assessing Security and Privacy Controls in Information Systems and Organizations. (National Institute of Standards and Technology, Gaithersburg, MD),"
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-53Ar5"
+            }
+          ]
+        },
+        {
+          "uuid": "1fc4b465-1569-40de-94ec-a8d17534c5fa",
+          "title": "CA-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CA-05"
+            }
+          ]
+        },
+        {
+          "uuid": "43d68e46-1c1b-4796-ad7f-696700231d3a",
+          "title": "CA-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CA-07"
+            }
+          ]
+        },
+        {
+          "uuid": "e40475b0-0ae0-4a8e-8d10-36e13d943946",
+          "title": "CA-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CA-03"
+            }
+          ]
+        },
+        {
+          "uuid": "30e1c8c9-2673-4139-a581-400bb26ce159",
+          "title": "SP 800-47",
+          "citation": {
+            "text": "Dempsey K, Pillitteri V, Regenscheid A (2021) Managing the Security of Information Exchanges. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-47,"
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-47r1"
+            }
+          ]
+        },
+        {
+          "uuid": "97ff2d49-5fe3-4268-8b1f-6f5308c7e705",
+          "title": "MA-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-03"
+            }
+          ]
+        },
+        {
+          "uuid": "19b77d31-b8c2-4fba-abba-53c56ad7e490",
+          "title": "MA-03(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-03(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "c5e7e7f0-794e-44ec-814e-a01599bb719d",
+          "title": "MA-03(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-03(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "a873ad87-a316-4204-ae2c-734220738c45",
+          "title": "MA-03(03)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-03(03)"
+            }
+          ]
+        },
+        {
+          "uuid": "c3256cd6-5ed6-42df-b2f9-0bff7fb8d8c9",
+          "title": "SP 800-88",
+          "citation": {
+            "text": "Kissel RL, Regenscheid AR, Scholl MA, Stine KM (2014) Guidelines for Media Sanitization. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-88, Rev."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-88r1"
+            }
+          ]
+        },
+        {
+          "uuid": "2ea5b97c-3beb-406d-85ce-7942f262ee8d",
+          "title": "MA-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-04"
+            }
+          ]
+        },
+        {
+          "uuid": "8683e2cc-7184-4407-8774-e45f85a7e85e",
+          "title": "MA-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MA-05"
+            }
+          ]
+        },
+        {
+          "uuid": "6c38324a-0bfa-428e-a188-be61a8d990d4",
+          "title": "PE-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-02"
+            }
+          ]
+        },
+        {
+          "uuid": "ff59a583-9733-4f57-90ee-652beb17b64b",
+          "title": "PE-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-06"
+            }
+          ]
+        },
+        {
+          "uuid": "d9fe2bca-43e7-40af-85f4-a3758363dc95",
+          "title": "PE-17",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-17"
+            }
+          ]
+        },
+        {
+          "uuid": "06ed46ad-12ae-47f1-8a6f-2840d9aa6d18",
+          "title": "PE-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-03"
+            }
+          ]
+        },
+        {
+          "uuid": "c2d1d66c-a5da-4c16-9d5f-8f5bb0b2efeb",
+          "title": "PE-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-05"
+            }
+          ]
+        },
+        {
+          "uuid": "faf017f0-641d-44ca-ae6d-34dcdcf0184b",
+          "title": "PE-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=PE-04"
+            }
+          ]
+        },
+        {
+          "uuid": "b6f9285b-ea87-4695-bad2-90b412875f43",
+          "title": "AU-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-02"
+            }
+          ]
+        },
+        {
+          "uuid": "96810306-d115-4307-ab9a-baf41aebfc18",
+          "title": "SP 800-92",
+          "citation": {
+            "text": "Kent K, Souppaya MP (2006) Guide to Computer Security Log Management. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-92."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-92"
+            }
+          ]
+        },
+        {
+          "uuid": "31e8b262-8a1c-4609-871f-6b0edfc18b5d",
+          "title": "AU-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-03"
+            }
+          ]
+        },
+        {
+          "uuid": "d32c0a1b-6b01-4370-906d-c2787796a25a",
+          "title": "AU-03(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-03(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "c6c510a7-6932-4d6d-9d1e-f51196efded7",
+          "title": "AU-11",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-11"
+            }
+          ]
+        },
+        {
+          "uuid": "9389a9df-1134-499e-8d25-c55eb991f169",
+          "title": "AU-12",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-12"
+            }
+          ]
+        },
+        {
+          "uuid": "146e7fde-bdf0-409f-958f-9c7bad66a557",
+          "title": "AU-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-05"
+            }
+          ]
+        },
+        {
+          "uuid": "af41f34c-51be-4909-aa89-fe15ac8a12c9",
+          "title": "AU-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-06"
+            }
+          ]
+        },
+        {
+          "uuid": "8d9b081e-58b2-4178-a69d-5372d29a8e7e",
+          "title": "AU-06(03)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-06(03)"
+            }
+          ]
+        },
+        {
+          "uuid": "390132ba-7532-4fb8-83fc-58b930857b77",
+          "title": "SP 800-101",
+          "citation": {
+            "text": "Ayers RP, Brothers S, Jansen W (2014) Guidelines on Mobile Device Forensics. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-101, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-101r1"
+            }
+          ]
+        },
+        {
+          "uuid": "6ee136ad-bb59-42aa-8f60-7d3a7b6fecdd",
+          "title": "AU-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-07"
+            }
+          ]
+        },
+        {
+          "uuid": "7cbbdd86-07a1-4477-b0ed-d38b6f416a3b",
+          "title": "AU-08",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-08"
+            }
+          ]
+        },
+        {
+          "uuid": "425d5b83-149c-4292-b7f5-14308d80823e",
+          "title": "AU-09",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-09"
+            }
+          ]
+        },
+        {
+          "uuid": "194c51c5-c474-4dd5-ae82-1a37c891a746",
+          "title": "IA-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-02"
+            }
+          ]
+        },
+        {
+          "uuid": "35f942bb-4765-4a2a-9049-d1c4efb56dc9",
+          "title": "IA-11",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-11"
+            }
+          ]
+        },
+        {
+          "uuid": "ecd0479b-72b6-42cd-b678-cebc75d87b1f",
+          "title": "IA-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-03"
+            }
+          ]
+        },
+        {
+          "uuid": "67ce4ecf-5a60-4cfa-8df9-b4eb26bf8e49",
+          "title": "IA-02(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-02(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "47920758-65e0-4635-84ee-cab9044da725",
+          "title": "IA-02(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-02(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "0c5cc89a-d10f-42cf-a8c3-ef84141eef50",
+          "title": "IA-02(08)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-02(08)"
+            }
+          ]
+        },
+        {
+          "uuid": "d98d8156-6f69-462f-bba2-cd1e37bfa460",
+          "title": "IA-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-04"
+            }
+          ]
+        },
+        {
+          "uuid": "0db27841-8671-492d-bbec-b859058550ad",
+          "title": "IA-04(04)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-04(04)"
+            }
+          ]
+        },
+        {
+          "uuid": "d858bece-144b-4fc6-8110-27777b48eebc",
+          "title": "IA-05(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-05(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "2648e6d1-8618-48f6-8847-be83a99e0818",
+          "title": "IA-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-06"
+            }
+          ]
+        },
+        {
+          "uuid": "46b414e1-a9d3-4cd5-a77c-fc146be57299",
+          "title": "IA-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-05"
+            }
+          ]
+        },
+        {
+          "uuid": "6cefb03a-c051-45bd-bd34-8d819e38c1d5",
+          "title": "MP-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-04"
+            }
+          ]
+        },
+        {
+          "uuid": "db611cd9-b2d3-4885-b016-31ed93f78598",
+          "title": "MP-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-02"
+            }
+          ]
+        },
+        {
+          "uuid": "b76b4068-efbd-4c42-9aee-d93844c963d8",
+          "title": "MP-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-06"
+            }
+          ]
+        },
+        {
+          "uuid": "7b44c40d-973a-4fa0-a477-e400e64b98e3",
+          "title": "MP-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-03"
+            }
+          ]
+        },
+        {
+          "uuid": "df285ec9-d424-4ad6-b71e-43a67fde9b6f",
+          "title": "MP-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-05"
+            }
+          ]
+        },
+        {
+          "uuid": "f757e913-9a1f-4a73-b992-397d4a0438f5",
+          "title": "MP-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=MP-07"
+            }
+          ]
+        },
+        {
+          "uuid": "29cd3753-76bb-4b97-a484-f10c10d093ed",
+          "title": "CP-09",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CP-09"
+            }
+          ]
+        },
+        {
+          "uuid": "d820b996-2a6e-4c4d-9aa8-88118b0664b1",
+          "title": "CP-09(08)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=CP-09(08)"
+            }
+          ]
+        },
+        {
+          "uuid": "fefb62cb-b252-4071-a540-fa193db38895",
+          "title": "SP 800-130",
+          "citation": {
+            "text": "Barker EB, Smid ME, Branstad DK, Chokhani S (2013) A Framework for Designing Cryptographic Key Management Systems. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-130."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-130"
+            }
+          ]
+        },
+        {
+          "uuid": "cd930fe4-ad2c-4d44-954e-2755be2c8673",
+          "title": "SP 800-152",
+          "citation": {
+            "text": "Barker EB, Branstad DK, Smid ME (2015) A Profile for U.S. Federal Cryptographic Key Management Systems (CKMS). (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-152."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-152"
+            }
+          ]
+        },
+        {
+          "uuid": "e7712341-d9f9-4f8b-9f32-516ddd1960e0",
+          "title": "SP 800-34",
+          "citation": {
+            "text": "Swanson MA, Bowen P, Phillips AW, Gallup D, Lynes D (2010) Contingency Planning Guide for Federal Information Systems. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special"
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-34r1"
+            }
+          ]
+        },
+        {
+          "uuid": "1e4af45a-f817-429e-a939-be1e7238053a",
+          "title": "AT-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AT-02"
+            }
+          ]
+        },
+        {
+          "uuid": "7caa0224-60eb-4edf-b9ee-b1ac525fad00",
+          "title": "AT-02(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AT-02(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "e3551468-48c6-4be0-990d-6c9a8a23af0d",
+          "title": "AT-02(03)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AT-02(03)"
+            }
+          ]
+        },
+        {
+          "uuid": "8ad19edd-17dd-4b97-af50-1e49d362148e",
+          "title": "AT-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=AT-03"
+            }
+          ]
+        },
+        {
+          "uuid": "e44bad03-7296-4d3a-91b1-d1679985188f",
+          "title": "RA-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-03"
+            }
+          ]
+        },
+        {
+          "uuid": "0ce472eb-e23b-41ce-85b7-5feff832f386",
+          "title": "RA-03(01)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-03(01)"
+            }
+          ]
+        },
+        {
+          "uuid": "eeffa926-bb28-462b-a65a-79e605236291",
+          "title": "SR-06",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SR-06"
+            }
+          ]
+        },
+        {
+          "uuid": "7e817cf4-c844-4c44-bcf2-b5b53b18a9a8",
+          "title": "RA-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-05"
+            }
+          ]
+        },
+        {
+          "uuid": "5b9fcaef-085b-4c1d-b291-8810bbc5b88e",
+          "title": "RA-05(02)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-05(02)"
+            }
+          ]
+        },
+        {
+          "uuid": "a5981dd2-7c12-469b-8ca9-648d1bb49326",
+          "title": "SP 800-40",
+          "citation": {
+            "text": "Souppaya MP, Scarfone KA (2022) Guide to Enterprise Patch Management Planning: Preventive Maintenance for Technology. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-40, Rev. 4."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-40r4"
+            }
+          ]
+        },
+        {
+          "uuid": "cef1d874-0a3f-4b49-96d1-3630d480bac1",
+          "title": "RA-07",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-07"
+            }
+          ]
+        },
+        {
+          "uuid": "b1c2fc95-3868-4b70-8596-ccbc8768fbe6",
+          "title": "SI-02",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-02"
+            }
+          ]
+        },
+        {
+          "uuid": "7210b5f7-7e09-4ab8-b7ba-f5258eb602e9",
+          "title": "SI-03",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-03"
+            }
+          ]
+        },
+        {
+          "uuid": "b335d513-7986-46b1-9a1d-234a90c42e4a",
+          "title": "SP 800-83",
+          "citation": {
+            "text": "Souppaya MP, Scarfone KA (2013) Guide to Malware Incident Prevention and Handling for Desktops and Laptops. (National Institute of Standards and Technology, Gaithersburg, MD), NIST Special Publication (SP) 800-83, Rev. 1."
+          },
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.SP.800-83r1"
+            }
+          ]
+        },
+        {
+          "uuid": "e522acff-a07b-48a7-ad5c-e4a7faa1b84f",
+          "title": "SI-05",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-05"
+            }
+          ]
+        },
+        {
+          "uuid": "3cf2c4c9-9454-4204-8af1-269d900e9fab",
+          "title": "SI-04",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-04"
+            }
+          ]
+        },
+        {
+          "uuid": "c827ca1c-d73d-414d-9434-1d3bda394ce9",
+          "title": "SI-04(04)",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-04(04)"
+            }
+          ]
+        },
+        {
+          "uuid": "b885e0fc-d253-46df-831f-47198e312eb3",
+          "title": "SI-12",
+          "rlinks": [
+            {
+              "href": "https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-12"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/lemma/data/frameworks/nist-csf-2.0.json
+++ b/src/lemma/data/frameworks/nist-csf-2.0.json
@@ -1,0 +1,8114 @@
+{
+  "catalog": {
+    "uuid": "720a010b-253c-4a94-bb65-cb58400966f5",
+    "metadata": {
+      "title": "NIST Cybersecurity Framework 2.0",
+      "published": "2025-05-29T10:16:00-05:00",
+      "last-modified": "2025-05-14T12:08:20.050176-05:00",
+      "version": "1.0.0",
+      "oscal-version": "v1.1.3",
+      "props": [
+        {
+          "name": "framework-identifier",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "CSF"
+        },
+        {
+          "name": "framework-version-identifier",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "CSF_2_0_0"
+        },
+        {
+          "name": "generated-by",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "Cybersecurity And Privacy Open Reference Datasets In OSCAL (CAPORDINO)"
+        },
+        {
+          "name": "publication-status",
+          "ns": "https://csrc.nist.gov/ns/cprt",
+          "value": "Final"
+        },
+        {
+          "name": "keywords",
+          "value": "Critical infrastructure, cybersecurity, information security, information system, OSCAL, Open Security Controls Assessment Language, security functions, security requirements, system, system security"
+        }
+      ],
+      "links": [
+        {
+          "href": "#3ab41d8a-66e3-4732-ae28-07405dad5127",
+          "rel": "alternate"
+        },
+        {
+          "href": "#a7f54afa-16cf-4200-a043-85aa554b93e4",
+          "rel": "alternate"
+        },
+        {
+          "href": "#0451580b-8ef9-4f52-9182-bc887d6cf369",
+          "rel": "canonical"
+        }
+      ],
+      "roles": [
+        {
+          "id": "publisher",
+          "title": "Document converter to OSCAL"
+        },
+        {
+          "id": "contact",
+          "title": "Contact"
+        },
+        {
+          "id": "author",
+          "title": "Document content author"
+        }
+      ],
+      "parties": [
+        {
+          "uuid": "8238c306-4ee0-4321-a4fb-503adda3d8c1",
+          "type": "organization",
+          "name": "National Institute of Standards and Technology",
+          "short-name": "NIST",
+          "email-addresses": [
+            "capordino@nist.gov"
+          ],
+          "addresses": [
+            {
+              "addr-lines": [
+                "National Institute of Standards and Technology",
+                "Attn: Computer Security Division",
+                "Information Technology Laboratory",
+                "100 Bureau Drive (Mail Stop 2000)"
+              ],
+              "city": "Gaithersburg",
+              "state": "MD",
+              "postal-code": "20899-2000"
+            }
+          ]
+        },
+        {
+          "uuid": "49e0888a-e68c-43f1-a26d-7c88fb076e0e",
+          "type": "organization",
+          "name": "National Institute of Standards and Technology",
+          "short-name": "NIST",
+          "email-addresses": [
+            "cyberframework@nist.gov"
+          ],
+          "addresses": [
+            {
+              "addr-lines": [
+                "National Institute of Standards and Technology",
+                "Attn: Applied Cybersecurity Division",
+                "Information Technology Laboratory",
+                "100 Bureau Drive (Mail Stop 2000)"
+              ],
+              "city": "Gaithersburg",
+              "state": "MD",
+              "postal-code": "20899-2000"
+            }
+          ]
+        }
+      ],
+      "responsible-parties": [
+        {
+          "role-id": "publisher",
+          "party-uuids": [
+            "8238c306-4ee0-4321-a4fb-503adda3d8c1"
+          ]
+        },
+        {
+          "role-id": "contact",
+          "party-uuids": [
+            "8238c306-4ee0-4321-a4fb-503adda3d8c1"
+          ]
+        },
+        {
+          "role-id": "author",
+          "party-uuids": [
+            "49e0888a-e68c-43f1-a26d-7c88fb076e0e"
+          ]
+        }
+      ]
+    },
+    "groups": [
+      {
+        "id": "GV",
+        "class": "function",
+        "title": "GOVERN",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "00001"
+          },
+          {
+            "name": "label",
+            "value": "GOVERN (GV)"
+          }
+        ],
+        "parts": [
+          {
+            "id": "GV_overview",
+            "name": "overview",
+            "prose": "The organization's cybersecurity risk management strategy, expectations, and policy are established, communicated, and monitored"
+          }
+        ],
+        "controls": [
+          {
+            "id": "GV.OC",
+            "class": "category",
+            "title": "Organizational Context",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00001.00001"
+              },
+              {
+                "name": "label",
+                "value": "Organizational Context (GV.OC)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "GV.OC_statement",
+                "name": "statement",
+                "prose": "The circumstances - mission, stakeholder expectations, dependencies, and legal, regulatory, and contractual requirements - surrounding the organization's cybersecurity risk management decisions are understood"
+              }
+            ],
+            "controls": [
+              {
+                "id": "GV.OC-01",
+                "class": "subcategory",
+                "title": "GV.OC-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00001.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OC-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OC-01_statement",
+                    "name": "statement",
+                    "prose": "The organizational mission is understood and informs cybersecurity risk management"
+                  },
+                  {
+                    "id": "GV.OC-01.001",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Share the organization's mission (e.g., through vision and mission statements, marketing, and service strategies) to provide a basis for identifying risks that may impede that mission"
+                  }
+                ]
+              },
+              {
+                "id": "GV.OC-02",
+                "class": "subcategory",
+                "title": "GV.OC-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00001.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OC-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OC-02_statement",
+                    "name": "statement",
+                    "prose": "Internal and external stakeholders are understood, and their needs and expectations regarding cybersecurity risk management are understood and considered"
+                  },
+                  {
+                    "id": "GV.OC-02.002",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify relevant internal stakeholders and their cybersecurity-related expectations (e.g., performance and risk expectations of officers, directors, and advisors; cultural expectations of employees)"
+                  },
+                  {
+                    "id": "GV.OC-02.003",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify relevant external stakeholders and their cybersecurity-related expectations (e.g., privacy expectations of customers, business expectations of partnerships, compliance expectations of regulators, ethics expectations of society)"
+                  }
+                ]
+              },
+              {
+                "id": "GV.OC-03",
+                "class": "subcategory",
+                "title": "GV.OC-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00001.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OC-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OC-03_statement",
+                    "name": "statement",
+                    "prose": "Legal, regulatory, and contractual requirements regarding cybersecurity - including privacy and civil liberties obligations - are understood and managed"
+                  },
+                  {
+                    "id": "GV.OC-03.004",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine a process to track and manage legal and regulatory requirements regarding protection of individuals' information (e.g., Health Insurance Portability and Accountability Act, California Consumer Privacy Act, General Data Protection Regulation)"
+                  },
+                  {
+                    "id": "GV.OC-03.005",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine a process to track and manage contractual requirements for cybersecurity management of supplier, customer, and partner information"
+                  },
+                  {
+                    "id": "GV.OC-03.006",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Align the organization's cybersecurity strategy with legal, regulatory, and contractual requirements"
+                  }
+                ]
+              },
+              {
+                "id": "GV.OC-04",
+                "class": "subcategory",
+                "title": "GV.OC-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00001.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OC-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OC-04_statement",
+                    "name": "statement",
+                    "prose": "Critical objectives, capabilities, and services that external stakeholders depend on or expect from the organization are understood and communicated"
+                  },
+                  {
+                    "id": "GV.OC-04.007",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish criteria for determining the criticality of capabilities and services as viewed by internal and external stakeholders"
+                  },
+                  {
+                    "id": "GV.OC-04.008",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine (e.g., from a business impact analysis) assets and business operations that are vital to achieving mission objectives and the potential impact of a loss (or partial loss) of such operations"
+                  },
+                  {
+                    "id": "GV.OC-04.009",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish and communicate resilience objectives (e.g., recovery time objectives) for delivering critical capabilities and services in various operating states (e.g., under attack, during recovery, normal operation)"
+                  }
+                ]
+              },
+              {
+                "id": "GV.OC-05",
+                "class": "subcategory",
+                "title": "GV.OC-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00001.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OC-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OC-05_statement",
+                    "name": "statement",
+                    "prose": "Outcomes, capabilities, and services that the organization depends on are understood and communicated"
+                  },
+                  {
+                    "id": "GV.OC-05.010",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Create an inventory of the organization's dependencies on external resources (e.g., facilities, cloud-based hosting providers) and their relationships to organizational assets and business functions"
+                  },
+                  {
+                    "id": "GV.OC-05.011",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify and document external dependencies that are potential points of failure for the organization's critical capabilities and services, and share that information with appropriate personnel"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "GV.OV",
+            "class": "category",
+            "title": "Oversight",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00001.00005"
+              },
+              {
+                "name": "label",
+                "value": "Oversight (GV.OV)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "GV.OV_statement",
+                "name": "statement",
+                "prose": "Results of organization-wide cybersecurity risk management activities and performance are used to inform, improve, and adjust the risk management strategy"
+              }
+            ],
+            "controls": [
+              {
+                "id": "GV.OV-01",
+                "class": "subcategory",
+                "title": "GV.OV-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00005.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OV-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OV-01_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity risk management strategy outcomes are reviewed to inform and adjust strategy and direction"
+                  },
+                  {
+                    "id": "GV.OV-01.058",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Measure how well the risk management strategy and risk results have helped leaders make decisions and achieve organizational objectives"
+                  },
+                  {
+                    "id": "GV.OV-01.059",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Examine whether cybersecurity risk strategies that impede operations or innovation should be adjusted"
+                  }
+                ]
+              },
+              {
+                "id": "GV.OV-02",
+                "class": "subcategory",
+                "title": "GV.OV-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00005.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OV-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OV-02_statement",
+                    "name": "statement",
+                    "prose": "The cybersecurity risk management strategy is reviewed and adjusted to ensure coverage of organizational requirements and risks"
+                  },
+                  {
+                    "id": "GV.OV-02.060",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review audit findings to confirm whether the existing cybersecurity strategy has ensured compliance with internal and external requirements"
+                  },
+                  {
+                    "id": "GV.OV-02.061",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review the performance oversight of those in cybersecurity-related roles to determine whether policy changes are necessary"
+                  },
+                  {
+                    "id": "GV.OV-02.062",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review strategy in light of cybersecurity incidents"
+                  }
+                ]
+              },
+              {
+                "id": "GV.OV-03",
+                "class": "subcategory",
+                "title": "GV.OV-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00005.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.OV-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.OV-03_statement",
+                    "name": "statement",
+                    "prose": "Organizational cybersecurity risk management performance is evaluated and reviewed for adjustments needed"
+                  },
+                  {
+                    "id": "GV.OV-03.063",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review key performance indicators (KPIs) to ensure that organization-wide policies and procedures achieve objectives"
+                  },
+                  {
+                    "id": "GV.OV-03.064",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review key risk indicators (KRIs) to identify risks the organization faces, including likelihood and potential impact"
+                  },
+                  {
+                    "id": "GV.OV-03.065",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Collect and communicate metrics on cybersecurity risk management with senior leadership"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "GV.PO",
+            "class": "category",
+            "title": "Policy",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00001.00004"
+              },
+              {
+                "name": "label",
+                "value": "Policy (GV.PO)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "GV.PO_statement",
+                "name": "statement",
+                "prose": "Organizational cybersecurity policy is established, communicated, and enforced"
+              }
+            ],
+            "controls": [
+              {
+                "id": "GV.PO-01",
+                "class": "subcategory",
+                "title": "GV.PO-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00004.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.PO-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.PO-01_statement",
+                    "name": "statement",
+                    "prose": "Policy for managing cybersecurity risks is established based on organizational context, cybersecurity strategy, and priorities and is communicated and enforced"
+                  },
+                  {
+                    "id": "GV.PO-01.049",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Create, disseminate, and maintain an understandable, usable risk management policy with statements of management intent, expectations, and direction"
+                  },
+                  {
+                    "id": "GV.PO-01.050",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically review policy and supporting processes and procedures to ensure that they align with risk management strategy objectives and priorities, as well as the high-level direction of the cybersecurity policy"
+                  },
+                  {
+                    "id": "GV.PO-01.051",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require approval from senior management on policy"
+                  },
+                  {
+                    "id": "GV.PO-01.052",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Communicate cybersecurity risk management policy and supporting processes and procedures across the organization"
+                  },
+                  {
+                    "id": "GV.PO-01.053",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require personnel to acknowledge receipt of policy when first hired, annually, and whenever policy is updated"
+                  }
+                ]
+              },
+              {
+                "id": "GV.PO-02",
+                "class": "subcategory",
+                "title": "GV.PO-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00004.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.PO-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.PO-02_statement",
+                    "name": "statement",
+                    "prose": "Policy for managing cybersecurity risks is reviewed, updated, communicated, and enforced to reflect changes in requirements, threats, technology, and organizational mission"
+                  },
+                  {
+                    "id": "GV.PO-02.054",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update policy based on periodic reviews of cybersecurity risk management results to ensure that policy and supporting processes and procedures adequately maintain risk at an acceptable level"
+                  },
+                  {
+                    "id": "GV.PO-02.055",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Provide a timeline for reviewing changes to the organization's risk environment (e.g., changes in risk or in the organization's mission objectives), and communicate recommended policy updates"
+                  },
+                  {
+                    "id": "GV.PO-02.056",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update policy to reflect changes in legal and regulatory requirements"
+                  },
+                  {
+                    "id": "GV.PO-02.057",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update policy to reflect changes in technology (e.g., adoption of artificial intelligence) and changes to the business (e.g., acquisition of a new business, new contract requirements)"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "GV.RM",
+            "class": "category",
+            "title": "Risk Management Strategy",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00001.00002"
+              },
+              {
+                "name": "label",
+                "value": "Risk Management Strategy (GV.RM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "GV.RM_statement",
+                "name": "statement",
+                "prose": "The organization's priorities, constraints, risk tolerance and appetite statements, and assumptions are established, communicated, and used to support operational risk decisions"
+              }
+            ],
+            "controls": [
+              {
+                "id": "GV.RM-01",
+                "class": "subcategory",
+                "title": "GV.RM-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-01_statement",
+                    "name": "statement",
+                    "prose": "Risk management objectives are established and agreed to by organizational stakeholders"
+                  },
+                  {
+                    "id": "GV.RM-01.012",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update near-term and long-term cybersecurity risk management objectives as part of annual strategic planning and when major changes occur"
+                  },
+                  {
+                    "id": "GV.RM-01.013",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish measurable objectives for cybersecurity risk management (e.g., manage the quality of user training, ensure adequate risk protection for industrial control systems)"
+                  },
+                  {
+                    "id": "GV.RM-01.014",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Senior leaders agree about cybersecurity objectives and use them for measuring and managing risk and performance"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RM-02",
+                "class": "subcategory",
+                "title": "GV.RM-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-02_statement",
+                    "name": "statement",
+                    "prose": "Risk appetite and risk tolerance statements are established, communicated, and maintained"
+                  },
+                  {
+                    "id": "GV.RM-02.015",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine and communicate risk appetite statements that convey expectations about the appropriate level of risk for the organization"
+                  },
+                  {
+                    "id": "GV.RM-02.016",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Translate risk appetite statements into specific, measurable, and broadly understandable risk tolerance statements"
+                  },
+                  {
+                    "id": "GV.RM-02.017",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Refine organizational objectives and risk appetite periodically based on known risk exposure and residual risk"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RM-03",
+                "class": "subcategory",
+                "title": "GV.RM-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-03_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity risk management activities and outcomes are included in enterprise risk management processes"
+                  },
+                  {
+                    "id": "GV.RM-03.018",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Aggregate and manage cybersecurity risks alongside other enterprise risks (e.g., compliance, financial, operational, regulatory, reputational, safety)"
+                  },
+                  {
+                    "id": "GV.RM-03.019",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include cybersecurity risk managers in enterprise risk management planning"
+                  },
+                  {
+                    "id": "GV.RM-03.020",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish criteria for escalating cybersecurity risks within enterprise risk management"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RM-04",
+                "class": "subcategory",
+                "title": "GV.RM-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-04_statement",
+                    "name": "statement",
+                    "prose": "Strategic direction that describes appropriate risk response options is established and communicated"
+                  },
+                  {
+                    "id": "GV.RM-04.021",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Specify criteria for accepting and avoiding cybersecurity risk for various classifications of data"
+                  },
+                  {
+                    "id": "GV.RM-04.022",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine whether to purchase cybersecurity insurance"
+                  },
+                  {
+                    "id": "GV.RM-04.023",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document conditions under which shared responsibility models are acceptable (e.g., outsourcing certain cybersecurity functions, having a third party perform financial transactions on behalf of the organization, using public cloud-based services)"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RM-05",
+                "class": "subcategory",
+                "title": "GV.RM-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-05_statement",
+                    "name": "statement",
+                    "prose": "Lines of communication across the organization are established for cybersecurity risks, including risks from suppliers and other third parties"
+                  },
+                  {
+                    "id": "GV.RM-05.024",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine how to update senior executives, directors, and management on the organization's cybersecurity posture at agreed-upon intervals"
+                  },
+                  {
+                    "id": "GV.RM-05.025",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify how all departments across the organization - such as management, operations, internal auditors, legal, acquisition, physical security, and HR - will communicate with each other about cybersecurity risks"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RM-06",
+                "class": "subcategory",
+                "title": "GV.RM-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-06_statement",
+                    "name": "statement",
+                    "prose": "A standardized method for calculating, documenting, categorizing, and prioritizing cybersecurity risks is established and communicated"
+                  },
+                  {
+                    "id": "GV.RM-06.026",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish criteria for using a quantitative approach to cybersecurity risk analysis, and specify probability and exposure formulas"
+                  },
+                  {
+                    "id": "GV.RM-06.027",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Create and use templates (e.g., a risk register) to document cybersecurity risk information (e.g., risk description, exposure, treatment, and ownership)"
+                  },
+                  {
+                    "id": "GV.RM-06.028",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish criteria for risk prioritization at the appropriate levels within the enterprise"
+                  },
+                  {
+                    "id": "GV.RM-06.029",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use a consistent list of risk categories to support integrating, aggregating, and comparing cybersecurity risks"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RM-07",
+                "class": "subcategory",
+                "title": "GV.RM-07",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00002.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RM-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RM-07_statement",
+                    "name": "statement",
+                    "prose": "Strategic opportunities (i.e., positive risks) are characterized and are included in organizational cybersecurity risk discussions"
+                  },
+                  {
+                    "id": "GV.RM-07.030",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and communicate guidance and methods for identifying opportunities and including them in risk discussions (e.g., strengths, weaknesses, opportunities, and threats (SWOT) analysis)"
+                  },
+                  {
+                    "id": "GV.RM-07.031",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify stretch goals and document them"
+                  },
+                  {
+                    "id": "GV.RM-07.032",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Calculate, document, and prioritize positive risks alongside negative risks"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "GV.RR",
+            "class": "category",
+            "title": "Roles, Responsibilities, and Authorities",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00001.00003"
+              },
+              {
+                "name": "label",
+                "value": "Roles, Responsibilities, and Authorities (GV.RR)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "GV.RR_statement",
+                "name": "statement",
+                "prose": "Cybersecurity roles, responsibilities, and authorities to foster accountability, performance assessment, and continuous improvement are established and communicated"
+              }
+            ],
+            "controls": [
+              {
+                "id": "GV.RR-01",
+                "class": "subcategory",
+                "title": "GV.RR-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00003.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RR-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RR-01_statement",
+                    "name": "statement",
+                    "prose": "Organizational leadership is responsible and accountable for cybersecurity risk and fosters a culture that is risk-aware, ethical, and continually improving"
+                  },
+                  {
+                    "id": "GV.RR-01.033",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Leaders (e.g., directors) agree on their roles and responsibilities in developing, implementing, and assessing the organization's cybersecurity strategy"
+                  },
+                  {
+                    "id": "GV.RR-01.034",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Share leaders' expectations regarding a secure and ethical culture, especially when current events present the opportunity to highlight positive or negative examples of cybersecurity risk management"
+                  },
+                  {
+                    "id": "GV.RR-01.035",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Leaders direct the CISO to maintain a comprehensive cybersecurity risk strategy and review and update it at least annually and after major events"
+                  },
+                  {
+                    "id": "GV.RR-01.036",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct reviews to ensure adequate authority and coordination among those responsible for managing cybersecurity risk"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RR-02",
+                "class": "subcategory",
+                "title": "GV.RR-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00003.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RR-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RR-02_statement",
+                    "name": "statement",
+                    "prose": "Roles, responsibilities, and authorities related to cybersecurity risk management are established, communicated, understood, and enforced"
+                  },
+                  {
+                    "id": "GV.RR-02.037",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document risk management roles and responsibilities in policy"
+                  },
+                  {
+                    "id": "GV.RR-02.038",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document who is responsible and accountable for cybersecurity risk management activities and how those teams and individuals are to be consulted and informed"
+                  },
+                  {
+                    "id": "GV.RR-02.039",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include cybersecurity responsibilities and performance requirements in personnel descriptions"
+                  },
+                  {
+                    "id": "GV.RR-02.040",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document performance goals for personnel with cybersecurity risk management responsibilities, and periodically measure performance to identify areas for improvement"
+                  },
+                  {
+                    "id": "GV.RR-02.041",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Clearly articulate cybersecurity responsibilities within operations, risk functions, and internal audit functions"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RR-03",
+                "class": "subcategory",
+                "title": "GV.RR-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00003.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RR-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RR-03_statement",
+                    "name": "statement",
+                    "prose": "Adequate resources are allocated commensurate with the cybersecurity risk strategy, roles, responsibilities, and policies"
+                  },
+                  {
+                    "id": "GV.RR-03.042",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct periodic management reviews to ensure that those given cybersecurity risk management responsibilities have the necessary authority"
+                  },
+                  {
+                    "id": "GV.RR-03.043",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify resource allocation and investment in line with risk tolerance and response"
+                  },
+                  {
+                    "id": "GV.RR-03.044",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Provide adequate and sufficient people, process, and technical resources to support the cybersecurity strategy"
+                  }
+                ]
+              },
+              {
+                "id": "GV.RR-04",
+                "class": "subcategory",
+                "title": "GV.RR-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00003.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.RR-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.RR-04_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity is included in human resources practices"
+                  },
+                  {
+                    "id": "GV.RR-04.045",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Integrate cybersecurity risk management considerations into human resources processes (e.g., personnel screening, onboarding, change notification, offboarding)"
+                  },
+                  {
+                    "id": "GV.RR-04.046",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Consider cybersecurity knowledge to be a positive factor in hiring, training, and retention decisions"
+                  },
+                  {
+                    "id": "GV.RR-04.047",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct background checks prior to onboarding new personnel for sensitive roles, and periodically repeat background checks for personnel with such roles"
+                  },
+                  {
+                    "id": "GV.RR-04.048",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and enforce obligations for personnel to be aware of, adhere to, and uphold security policies as they relate to their roles"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "GV.SC",
+            "class": "category",
+            "title": "Cybersecurity Supply Chain Risk Management",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00001.00006"
+              },
+              {
+                "name": "label",
+                "value": "Cybersecurity Supply Chain Risk Management (GV.SC)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "GV.SC_statement",
+                "name": "statement",
+                "prose": "Cyber supply chain risk management processes are identified, established, managed, monitored, and improved by organizational stakeholders"
+              }
+            ],
+            "controls": [
+              {
+                "id": "GV.SC-01",
+                "class": "subcategory",
+                "title": "GV.SC-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-01_statement",
+                    "name": "statement",
+                    "prose": "A cybersecurity supply chain risk management program, strategy, objectives, policies, and processes are established and agreed to by organizational stakeholders"
+                  },
+                  {
+                    "id": "GV.SC-01.066",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish a strategy that expresses the objectives of the cybersecurity supply chain risk management program"
+                  },
+                  {
+                    "id": "GV.SC-01.067",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Develop the cybersecurity supply chain risk management program, including a plan (with milestones), policies, and procedures that guide implementation and improvement of the program, and share the policies and procedures with the organizational stakeholders"
+                  },
+                  {
+                    "id": "GV.SC-01.068",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Develop and implement program processes based on the strategy, objectives, policies, and procedures that are agreed upon and performed by the organizational stakeholders"
+                  },
+                  {
+                    "id": "GV.SC-01.069",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish a cross-organizational mechanism that ensures alignment between functions that contribute to cybersecurity supply chain risk management, such as cybersecurity, IT, operations, legal, human resources, and engineering"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-02",
+                "class": "subcategory",
+                "title": "GV.SC-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-02_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity roles and responsibilities for suppliers, customers, and partners are established, communicated, and coordinated internally and externally"
+                  },
+                  {
+                    "id": "GV.SC-02.070",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify one or more specific roles or positions that will be responsible and accountable for planning, resourcing, and executing cybersecurity supply chain risk management activities"
+                  },
+                  {
+                    "id": "GV.SC-02.071",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document cybersecurity supply chain risk management roles and responsibilities in policy"
+                  },
+                  {
+                    "id": "GV.SC-02.072",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Create responsibility matrixes to document who will be responsible and accountable for cybersecurity supply chain risk management activities and how those teams and individuals will be consulted and informed"
+                  },
+                  {
+                    "id": "GV.SC-02.073",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include cybersecurity supply chain risk management responsibilities and performance requirements in personnel descriptions to ensure clarity and improve accountability"
+                  },
+                  {
+                    "id": "GV.SC-02.074",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document performance goals for personnel with cybersecurity risk management-specific responsibilities, and periodically measure them to demonstrate and improve performance"
+                  },
+                  {
+                    "id": "GV.SC-02.075",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Develop roles and responsibilities for suppliers, customers, and business partners to address shared responsibilities for applicable cybersecurity risks, and integrate them into organizational policies and applicable third-party agreements"
+                  },
+                  {
+                    "id": "GV.SC-02.076",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Internally communicate cybersecurity supply chain risk management roles and responsibilities for third parties"
+                  },
+                  {
+                    "id": "GV.SC-02.077",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish rules and protocols for information sharing and reporting processes between the organization and its suppliers"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-03",
+                "class": "subcategory",
+                "title": "GV.SC-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-03_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity supply chain risk management is integrated into cybersecurity and enterprise risk management, risk assessment, and improvement processes"
+                  },
+                  {
+                    "id": "GV.SC-03.078",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify areas of alignment and overlap with cybersecurity and enterprise risk management"
+                  },
+                  {
+                    "id": "GV.SC-03.079",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish integrated control sets for cybersecurity risk management and cybersecurity supply chain risk management"
+                  },
+                  {
+                    "id": "GV.SC-03.080",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Integrate cybersecurity supply chain risk management into improvement processes"
+                  },
+                  {
+                    "id": "GV.SC-03.081",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Escalate material cybersecurity risks in supply chains to senior management, and address them at the enterprise risk management level"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-04",
+                "class": "subcategory",
+                "title": "GV.SC-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-04_statement",
+                    "name": "statement",
+                    "prose": "Suppliers are known and prioritized by criticality"
+                  },
+                  {
+                    "id": "GV.SC-04.082",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Develop criteria for supplier criticality based on, for example, the sensitivity of data processed or possessed by suppliers, the degree of access to the organization's systems, and the importance of the products or services to the organization's mission"
+                  },
+                  {
+                    "id": "GV.SC-04.083",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Keep a record of all suppliers, and prioritize suppliers based on the criticality criteria"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-05",
+                "class": "subcategory",
+                "title": "GV.SC-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-05_statement",
+                    "name": "statement",
+                    "prose": "Requirements to address cybersecurity risks in supply chains are established, prioritized, and integrated into contracts and other types of agreements with suppliers and other relevant third parties"
+                  },
+                  {
+                    "id": "GV.SC-05.084",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish security requirements for suppliers, products, and services commensurate with their criticality level and potential impact if compromised"
+                  },
+                  {
+                    "id": "GV.SC-05.085",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include all cybersecurity and supply chain requirements that third parties must follow and how compliance with the requirements may be verified in default contractual language"
+                  },
+                  {
+                    "id": "GV.SC-05.086",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define the rules and protocols for information sharing between the organization and its suppliers and sub-tier suppliers in agreements"
+                  },
+                  {
+                    "id": "GV.SC-05.087",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Manage risk by including security requirements in agreements based on their criticality and potential impact if compromised"
+                  },
+                  {
+                    "id": "GV.SC-05.088",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define security requirements in service-level agreements (SLAs) for monitoring suppliers for acceptable security performance throughout the supplier relationship lifecycle"
+                  },
+                  {
+                    "id": "GV.SC-05.089",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Contractually require suppliers to disclose cybersecurity features, functions, and vulnerabilities of their products and services for the life of the product or the term of service"
+                  },
+                  {
+                    "id": "GV.SC-05.090",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Contractually require suppliers to provide and maintain a current component inventory (e.g., software or hardware bill of materials) for critical products"
+                  },
+                  {
+                    "id": "GV.SC-05.091",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Contractually require suppliers to vet their employees and guard against insider threats"
+                  },
+                  {
+                    "id": "GV.SC-05.092",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Contractually require suppliers to provide evidence of performing acceptable security practices through, for example, self-attestation, conformance to known standards, certifications, or inspections"
+                  },
+                  {
+                    "id": "GV.SC-05.093",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Specify in contracts and other agreements the rights and responsibilities of the organization, its suppliers, and their supply chains, with respect to potential cybersecurity risks"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-06",
+                "class": "subcategory",
+                "title": "GV.SC-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-06_statement",
+                    "name": "statement",
+                    "prose": "Planning and due diligence are performed to reduce risks before entering into formal supplier or other third-party relationships"
+                  },
+                  {
+                    "id": "GV.SC-06.094",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Perform thorough due diligence on prospective suppliers that is consistent with procurement planning and commensurate with the level of risk, criticality, and complexity of each supplier relationship"
+                  },
+                  {
+                    "id": "GV.SC-06.095",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assess the suitability of the technology and cybersecurity capabilities and the risk management practices of prospective suppliers"
+                  },
+                  {
+                    "id": "GV.SC-06.096",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct supplier risk assessments against business and applicable cybersecurity requirements"
+                  },
+                  {
+                    "id": "GV.SC-06.097",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assess the authenticity, integrity, and security of critical products prior to acquisition and use"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-07",
+                "class": "subcategory",
+                "title": "GV.SC-07",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-07_statement",
+                    "name": "statement",
+                    "prose": "The risks posed by a supplier, their products and services, and other third parties are understood, recorded, prioritized, assessed, responded to, and monitored over the course of the relationship"
+                  },
+                  {
+                    "id": "GV.SC-07.098",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Adjust assessment formats and frequencies based on the third party's reputation and the criticality of the products or services they provide"
+                  },
+                  {
+                    "id": "GV.SC-07.099",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Evaluate third parties' evidence of compliance with contractual cybersecurity requirements, such as self-attestations, warranties, certifications, and other artifacts"
+                  },
+                  {
+                    "id": "GV.SC-07.100",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor critical suppliers to ensure that they are fulfilling their security obligations throughout the supplier relationship lifecycle using a variety of methods and techniques, such as inspections, audits, tests, or other forms of evaluation"
+                  },
+                  {
+                    "id": "GV.SC-07.101",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor critical suppliers, services, and products for changes to their risk profiles, and reevaluate supplier criticality and risk impact accordingly"
+                  },
+                  {
+                    "id": "GV.SC-07.102",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Plan for unexpected supplier and supply chain-related interruptions to ensure business continuity"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-08",
+                "class": "subcategory",
+                "title": "GV.SC-08",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-08_statement",
+                    "name": "statement",
+                    "prose": "Relevant suppliers and other third parties are included in incident planning, response, and recovery activities"
+                  },
+                  {
+                    "id": "GV.SC-08.103",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and use rules and protocols for reporting incident response and recovery activities and the status between the organization and its suppliers"
+                  },
+                  {
+                    "id": "GV.SC-08.104",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify and document the roles and responsibilities of the organization and its suppliers for incident response"
+                  },
+                  {
+                    "id": "GV.SC-08.105",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include critical suppliers in incident response exercises and simulations"
+                  },
+                  {
+                    "id": "GV.SC-08.106",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and coordinate crisis communication methods and protocols between the organization and its critical suppliers"
+                  },
+                  {
+                    "id": "GV.SC-08.107",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct collaborative lessons learned sessions with critical suppliers"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-09",
+                "class": "subcategory",
+                "title": "GV.SC-09",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00009"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-09"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-09_statement",
+                    "name": "statement",
+                    "prose": "Supply chain security practices are integrated into cybersecurity and enterprise risk management programs, and their performance is monitored throughout the technology product and service life cycle"
+                  },
+                  {
+                    "id": "GV.SC-09.108",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Policies and procedures require provenance records for all acquired technology products and services"
+                  },
+                  {
+                    "id": "GV.SC-09.109",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically provide risk reporting to leaders about how acquired components are proven to be untampered and authentic"
+                  },
+                  {
+                    "id": "GV.SC-09.110",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Communicate regularly among cybersecurity risk managers and operations personnel about the need to acquire software patches, updates, and upgrades only from authenticated and trustworthy software providers"
+                  },
+                  {
+                    "id": "GV.SC-09.111",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review policies to ensure that they require approved supplier personnel to perform maintenance on supplier products"
+                  },
+                  {
+                    "id": "GV.SC-09.112",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Policies and procedure require checking upgrades to critical hardware for unauthorized changes"
+                  }
+                ]
+              },
+              {
+                "id": "GV.SC-10",
+                "class": "subcategory",
+                "title": "GV.SC-10",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00001.00006.00010"
+                  },
+                  {
+                    "name": "label",
+                    "value": "GV.SC-10"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "GV.SC-10_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity supply chain risk management plans include provisions for activities that occur after the conclusion of a partnership or service agreement"
+                  },
+                  {
+                    "id": "GV.SC-10.113",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish processes for terminating critical relationships under both normal and adverse circumstances"
+                  },
+                  {
+                    "id": "GV.SC-10.114",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and implement plans for component end-of-life maintenance support and obsolescence"
+                  },
+                  {
+                    "id": "GV.SC-10.115",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Verify that supplier access to organization resources is deactivated promptly when it is no longer needed"
+                  },
+                  {
+                    "id": "GV.SC-10.116",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Verify that assets containing the organization's data are returned or properly disposed of in a timely, controlled, and safe manner"
+                  },
+                  {
+                    "id": "GV.SC-10.117",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Develop and execute a plan for terminating or transitioning supplier relationships that takes supply chain security risk and resiliency into account"
+                  },
+                  {
+                    "id": "GV.SC-10.118",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Mitigate risks to data and systems created by supplier termination"
+                  },
+                  {
+                    "id": "GV.SC-10.119",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Manage data leakage risks associated with supplier termination"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ID",
+        "class": "function",
+        "title": "IDENTIFY",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "00002"
+          },
+          {
+            "name": "label",
+            "value": "IDENTIFY (ID)"
+          }
+        ],
+        "parts": [
+          {
+            "id": "ID_overview",
+            "name": "overview",
+            "prose": "The organization's current cybersecurity risks are understood"
+          }
+        ],
+        "controls": [
+          {
+            "id": "ID.AM",
+            "class": "category",
+            "title": "Asset Management",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00001"
+              },
+              {
+                "name": "label",
+                "value": "Asset Management (ID.AM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.AM_statement",
+                "name": "statement",
+                "prose": "Assets (e.g., data, hardware, software, systems, facilities, services, people) that enable the organization to achieve business purposes are identified and managed consistent with their relative importance to organizational objectives and the organization's risk strategy"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.AM-01",
+                "class": "subcategory",
+                "title": "ID.AM-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-01_statement",
+                    "name": "statement",
+                    "prose": "Inventories of hardware managed by the organization are maintained"
+                  },
+                  {
+                    "id": "ID.AM-01.120",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain inventories for all types of hardware, including IT, IoT, OT, and mobile devices"
+                  },
+                  {
+                    "id": "ID.AM-01.121",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Constantly monitor networks to detect new hardware and automatically update inventories"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-02",
+                "class": "subcategory",
+                "title": "ID.AM-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-02_statement",
+                    "name": "statement",
+                    "prose": "Inventories of software, services, and systems managed by the organization are maintained"
+                  },
+                  {
+                    "id": "ID.AM-02.122",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain inventories for all types of software and services, including commercial-off-the-shelf, open-source, custom applications, API services, and cloud-based applications and services"
+                  },
+                  {
+                    "id": "ID.AM-02.123",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Constantly monitor all platforms, including containers and virtual machines, for software and service inventory changes"
+                  },
+                  {
+                    "id": "ID.AM-02.124",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain an inventory of the organization's systems"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-03",
+                "class": "subcategory",
+                "title": "ID.AM-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-03_statement",
+                    "name": "statement",
+                    "prose": "Representations of the organization's authorized network communication and internal and external network data flows are maintained"
+                  },
+                  {
+                    "id": "ID.AM-03.125",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain baselines of communication and data flows within the organization's wired and wireless networks"
+                  },
+                  {
+                    "id": "ID.AM-03.126",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain baselines of communication and data flows between the organization and third parties"
+                  },
+                  {
+                    "id": "ID.AM-03.127",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain baselines of communication and data flows for the organization's infrastructure-as-a-service (IaaS) usage"
+                  },
+                  {
+                    "id": "ID.AM-03.128",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain documentation of expected network ports, protocols, and services that are typically used among authorized systems"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-04",
+                "class": "subcategory",
+                "title": "ID.AM-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-04_statement",
+                    "name": "statement",
+                    "prose": "Inventories of services provided by suppliers are maintained"
+                  },
+                  {
+                    "id": "ID.AM-04.129",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Inventory all external services used by the organization, including third-party infrastructure-as-a-service (IaaS), platform-as-a-service (PaaS), and software-as-a-service (SaaS) offerings; APIs; and other externally hosted application services"
+                  },
+                  {
+                    "id": "ID.AM-04.130",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update the inventory when a new external service is going to be utilized to ensure adequate cybersecurity risk management monitoring of the organization's use of that service"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-05",
+                "class": "subcategory",
+                "title": "ID.AM-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-05_statement",
+                    "name": "statement",
+                    "prose": "Assets are prioritized based on classification, criticality, resources, and impact on the mission"
+                  },
+                  {
+                    "id": "ID.AM-05.131",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define criteria for prioritizing each class of assets"
+                  },
+                  {
+                    "id": "ID.AM-05.132",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Apply the prioritization criteria to assets"
+                  },
+                  {
+                    "id": "ID.AM-05.133",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Track the asset priorities and update them periodically or when significant changes to the organization occur"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-06",
+                "class": "subcategory",
+                "title": "ID.AM-06",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-06_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity roles and responsibilities for the entire workforce and third-party stakeholders (e.g., suppliers, customers, partners) are established"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-07",
+                "class": "subcategory",
+                "title": "ID.AM-07",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-07_statement",
+                    "name": "statement",
+                    "prose": "Inventories of data and corresponding metadata for designated data types are maintained"
+                  },
+                  {
+                    "id": "ID.AM-07.134",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain a list of the designated data types of interest (e.g., personally identifiable information, protected health information, financial account numbers, organization intellectual property, operational technology data)"
+                  },
+                  {
+                    "id": "ID.AM-07.135",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Continuously discover and analyze ad hoc data to identify new instances of designated data types"
+                  },
+                  {
+                    "id": "ID.AM-07.136",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assign data classifications to designated data types through tags or labels"
+                  },
+                  {
+                    "id": "ID.AM-07.137",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Track the provenance, data owner, and geolocation of each instance of designated data types"
+                  }
+                ]
+              },
+              {
+                "id": "ID.AM-08",
+                "class": "subcategory",
+                "title": "ID.AM-08",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00001.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.AM-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.AM-08_statement",
+                    "name": "statement",
+                    "prose": "Systems, hardware, software, services, and data are managed throughout their life cycles"
+                  },
+                  {
+                    "id": "ID.AM-08.138",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Integrate cybersecurity considerations throughout the life cycles of systems, hardware, software, and services"
+                  },
+                  {
+                    "id": "ID.AM-08.139",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Integrate cybersecurity considerations into product life cycles"
+                  },
+                  {
+                    "id": "ID.AM-08.140",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify unofficial uses of technology to meet mission objectives (i.e., shadow IT)"
+                  },
+                  {
+                    "id": "ID.AM-08.141",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically identify redundant systems, hardware, software, and services that unnecessarily increase the organization's attack surface"
+                  },
+                  {
+                    "id": "ID.AM-08.142",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Properly configure and secure systems, hardware, software, and services prior to their deployment in production"
+                  },
+                  {
+                    "id": "ID.AM-08.143",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update inventories when systems, hardware, software, and services are moved or transferred within the organization"
+                  },
+                  {
+                    "id": "ID.AM-08.144",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely destroy stored data based on the organization's data retention policy using the prescribed destruction method, and keep and manage a record of the destructions"
+                  },
+                  {
+                    "id": "ID.AM-08.145",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely sanitize data storage when hardware is being retired, decommissioned, reassigned, or sent for repairs or replacement"
+                  },
+                  {
+                    "id": "ID.AM-08.146",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Offer methods for destroying paper, storage media, and other physical forms of data storage"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ID.BE",
+            "class": "category",
+            "title": "Business Environment",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00002"
+              },
+              {
+                "name": "label",
+                "value": "Business Environment (ID.BE)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.BE_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.BE-01",
+                "class": "subcategory",
+                "title": "ID.BE-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.BE-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.BE-01_statement",
+                    "name": "statement",
+                    "prose": "The organization’s role in the supply chain is identified and communicated"
+                  }
+                ]
+              },
+              {
+                "id": "ID.BE-02",
+                "class": "subcategory",
+                "title": "ID.BE-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00002.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.BE-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.BE-02_statement",
+                    "name": "statement",
+                    "prose": "The organization’s place in critical infrastructure and its industry sector is identified and communicated"
+                  }
+                ]
+              },
+              {
+                "id": "ID.BE-03",
+                "class": "subcategory",
+                "title": "ID.BE-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00002.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.BE-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.BE-03_statement",
+                    "name": "statement",
+                    "prose": "Priorities for organizational mission, objectives, and activities are established and communicated"
+                  }
+                ]
+              },
+              {
+                "id": "ID.BE-04",
+                "class": "subcategory",
+                "title": "ID.BE-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00002.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.BE-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.BE-04_statement",
+                    "name": "statement",
+                    "prose": "Dependencies and critical functions for delivery of critical services are established"
+                  }
+                ]
+              },
+              {
+                "id": "ID.BE-05",
+                "class": "subcategory",
+                "title": "ID.BE-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00002.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.BE-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.BE-05_statement",
+                    "name": "statement",
+                    "prose": "Resilience requirements to support delivery of critical services are established for all operating states (e.g. under duress/attack, during recovery, normal operations)"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ID.GV",
+            "class": "category",
+            "title": "Governance",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00003"
+              },
+              {
+                "name": "label",
+                "value": "Governance (ID.GV)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.GV_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.GV-01",
+                "class": "subcategory",
+                "title": "ID.GV-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00003.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.GV-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.GV-01_statement",
+                    "name": "statement",
+                    "prose": "Organizational cybersecurity policy is established and communicated"
+                  }
+                ]
+              },
+              {
+                "id": "ID.GV-02",
+                "class": "subcategory",
+                "title": "ID.GV-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00003.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.GV-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.GV-02_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity roles and responsibilities are coordinated and aligned with internal roles and external partners"
+                  }
+                ]
+              },
+              {
+                "id": "ID.GV-03",
+                "class": "subcategory",
+                "title": "ID.GV-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00003.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.GV-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.GV-03_statement",
+                    "name": "statement",
+                    "prose": "Legal and regulatory requirements regarding cybersecurity, including privacy and civil liberties obligations, are understood and managed"
+                  }
+                ]
+              },
+              {
+                "id": "ID.GV-04",
+                "class": "subcategory",
+                "title": "ID.GV-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00003.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.GV-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.GV-04_statement",
+                    "name": "statement",
+                    "prose": "Governance and risk management processes address cybersecurity risks"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ID.IM",
+            "class": "category",
+            "title": "Improvement",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00007"
+              },
+              {
+                "name": "label",
+                "value": "Improvement (ID.IM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.IM_statement",
+                "name": "statement",
+                "prose": "Improvements to organizational cybersecurity risk management processes, procedures and activities are identified across all CSF Functions"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.IM-01",
+                "class": "subcategory",
+                "title": "ID.IM-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00007.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.IM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.IM-01_statement",
+                    "name": "statement",
+                    "prose": "Improvements are identified from evaluations"
+                  },
+                  {
+                    "id": "ID.IM-01.177",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Perform self-assessments of critical services that take current threats and TTPs into consideration"
+                  },
+                  {
+                    "id": "ID.IM-01.178",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Invest in third-party assessments or independent audits of the effectiveness of the organization's cybersecurity program to identify areas that need improvement"
+                  },
+                  {
+                    "id": "ID.IM-01.179",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Constantly evaluate compliance with selected cybersecurity requirements through automated means"
+                  }
+                ]
+              },
+              {
+                "id": "ID.IM-02",
+                "class": "subcategory",
+                "title": "ID.IM-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00007.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.IM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.IM-02_statement",
+                    "name": "statement",
+                    "prose": "Improvements are identified from security tests and exercises, including those done in coordination with suppliers and relevant third parties"
+                  },
+                  {
+                    "id": "ID.IM-02.180",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify improvements for future incident response activities based on findings from incident response assessments (e.g., tabletop exercises and simulations, tests, internal reviews, independent audits)"
+                  },
+                  {
+                    "id": "ID.IM-02.181",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify improvements for future business continuity, disaster recovery, and incident response activities based on exercises performed in coordination with critical service providers and product suppliers"
+                  },
+                  {
+                    "id": "ID.IM-02.182",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Involve internal stakeholders (e.g., senior executives, legal department, HR) in security tests and exercises as appropriate"
+                  },
+                  {
+                    "id": "ID.IM-02.183",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Perform penetration testing to identify opportunities to improve the security posture of selected high-risk systems as approved by leadership"
+                  },
+                  {
+                    "id": "ID.IM-02.184",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Exercise contingency plans for responding to and recovering from the discovery that products or services did not originate with the contracted supplier or partner or were altered before receipt"
+                  },
+                  {
+                    "id": "ID.IM-02.185",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Collect and analyze performance metrics using security tools and services to inform improvements to the cybersecurity program"
+                  }
+                ]
+              },
+              {
+                "id": "ID.IM-03",
+                "class": "subcategory",
+                "title": "ID.IM-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00007.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.IM-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.IM-03_statement",
+                    "name": "statement",
+                    "prose": "Improvements are identified from execution of operational processes, procedures, and activities"
+                  },
+                  {
+                    "id": "ID.IM-03.186",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct collaborative lessons learned sessions with suppliers"
+                  },
+                  {
+                    "id": "ID.IM-03.187",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Annually review cybersecurity policies, processes, and procedures to take lessons learned into account"
+                  },
+                  {
+                    "id": "ID.IM-03.188",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use metrics to assess operational cybersecurity performance over time"
+                  }
+                ]
+              },
+              {
+                "id": "ID.IM-04",
+                "class": "subcategory",
+                "title": "ID.IM-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00007.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.IM-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.IM-04_statement",
+                    "name": "statement",
+                    "prose": "Incident response plans and other cybersecurity plans that affect operations are established, communicated, maintained, and improved"
+                  },
+                  {
+                    "id": "ID.IM-04.189",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish contingency plans (e.g., incident response, business continuity, disaster recovery) for responding to and recovering from adverse events that can interfere with operations, expose confidential information, or otherwise endanger the organization's mission and viability"
+                  },
+                  {
+                    "id": "ID.IM-04.190",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include contact and communication information, processes for handling common scenarios, and criteria for prioritization, escalation, and elevation in all contingency plans"
+                  },
+                  {
+                    "id": "ID.IM-04.191",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Create a vulnerability management plan to identify and assess all types of vulnerabilities and to prioritize, test, and implement risk responses"
+                  },
+                  {
+                    "id": "ID.IM-04.192",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Communicate cybersecurity plans (including updates) to those responsible for carrying them out and to affected parties"
+                  },
+                  {
+                    "id": "ID.IM-04.193",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review and update all cybersecurity plans annually or when a need for significant improvements is identified"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ID.RA",
+            "class": "category",
+            "title": "Risk Assessment",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00004"
+              },
+              {
+                "name": "label",
+                "value": "Risk Assessment (ID.RA)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.RA_statement",
+                "name": "statement",
+                "prose": "The cybersecurity risk to the organization, assets, and individuals is understood by the organization"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.RA-01",
+                "class": "subcategory",
+                "title": "ID.RA-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-01_statement",
+                    "name": "statement",
+                    "prose": "Vulnerabilities in assets are identified, validated, and recorded"
+                  },
+                  {
+                    "id": "ID.RA-01.147",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use vulnerability management technologies to identify unpatched and misconfigured software"
+                  },
+                  {
+                    "id": "ID.RA-01.148",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assess network and system architectures for design and implementation weaknesses that affect cybersecurity"
+                  },
+                  {
+                    "id": "ID.RA-01.149",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review, analyze, or test organization-developed software to identify design, coding, and default configuration vulnerabilities"
+                  },
+                  {
+                    "id": "ID.RA-01.150",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assess facilities that house critical computing assets for physical vulnerabilities and resilience issues"
+                  },
+                  {
+                    "id": "ID.RA-01.151",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor sources of cyber threat intelligence for information on new vulnerabilities in products and services"
+                  },
+                  {
+                    "id": "ID.RA-01.152",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review processes and procedures for weaknesses that could be exploited to affect cybersecurity"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-02",
+                "class": "subcategory",
+                "title": "ID.RA-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-02_statement",
+                    "name": "statement",
+                    "prose": "Cyber threat intelligence is received from information sharing forums and sources"
+                  },
+                  {
+                    "id": "ID.RA-02.153",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Configure cybersecurity tools and technologies with detection or response capabilities to securely ingest cyber threat intelligence feeds"
+                  },
+                  {
+                    "id": "ID.RA-02.154",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Receive and review advisories from reputable third parties on current threat actors and their tactics, techniques, and procedures (TTPs)"
+                  },
+                  {
+                    "id": "ID.RA-02.155",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor sources of cyber threat intelligence for information on the types of vulnerabilities that emerging technologies may have"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-03",
+                "class": "subcategory",
+                "title": "ID.RA-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-03_statement",
+                    "name": "statement",
+                    "prose": "Internal and external threats to the organization are identified and recorded"
+                  },
+                  {
+                    "id": "ID.RA-03.156",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use cyber threat intelligence to maintain awareness of the types of threat actors likely to target the organization and the TTPs they are likely to use"
+                  },
+                  {
+                    "id": "ID.RA-03.157",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Perform threat hunting to look for signs of threat actors within the environment"
+                  },
+                  {
+                    "id": "ID.RA-03.158",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Implement processes for identifying internal threat actors"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-04",
+                "class": "subcategory",
+                "title": "ID.RA-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-04_statement",
+                    "name": "statement",
+                    "prose": "Potential impacts and likelihoods of threats exploiting vulnerabilities are identified and recorded"
+                  },
+                  {
+                    "id": "ID.RA-04.159",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Business leaders and cybersecurity risk management practitioners work together to estimate the likelihood and impact of risk scenarios and record them in risk registers"
+                  },
+                  {
+                    "id": "ID.RA-04.160",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Enumerate the potential business impacts of unauthorized access to the organization's communications, systems, and data processed in or by those systems"
+                  },
+                  {
+                    "id": "ID.RA-04.161",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Account for the potential impacts of cascading failures for systems of systems"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-05",
+                "class": "subcategory",
+                "title": "ID.RA-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-05_statement",
+                    "name": "statement",
+                    "prose": "Threats, vulnerabilities, likelihoods, and impacts are used to understand inherent risk and inform risk response prioritization"
+                  },
+                  {
+                    "id": "ID.RA-05.162",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Develop threat models to better understand risks to the data and identify appropriate risk responses"
+                  },
+                  {
+                    "id": "ID.RA-05.163",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Prioritize cybersecurity resource allocations and investments based on estimated likelihoods and impacts"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-06",
+                "class": "subcategory",
+                "title": "ID.RA-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-06_statement",
+                    "name": "statement",
+                    "prose": "Risk responses are chosen, prioritized, planned, tracked, and communicated"
+                  },
+                  {
+                    "id": "ID.RA-06.164",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Apply the vulnerability management plan's criteria for deciding whether to accept, transfer, mitigate, or avoid risk"
+                  },
+                  {
+                    "id": "ID.RA-06.165",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Apply the vulnerability management plan's criteria for selecting compensating controls to mitigate risk"
+                  },
+                  {
+                    "id": "ID.RA-06.166",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Track the progress of risk response implementation (e.g., plan of action and milestones (POA&M), risk register, risk detail report)"
+                  },
+                  {
+                    "id": "ID.RA-06.167",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use risk assessment findings to inform risk response decisions and actions"
+                  },
+                  {
+                    "id": "ID.RA-06.168",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Communicate planned risk responses to affected stakeholders in priority order"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-07",
+                "class": "subcategory",
+                "title": "ID.RA-07",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-07_statement",
+                    "name": "statement",
+                    "prose": "Changes and exceptions are managed, assessed for risk impact, recorded, and tracked"
+                  },
+                  {
+                    "id": "ID.RA-07.169",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Implement and follow procedures for the formal documentation, review, testing, and approval of proposed changes and requested exceptions"
+                  },
+                  {
+                    "id": "ID.RA-07.170",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document the possible risks of making or not making each proposed change, and provide guidance on rolling back changes"
+                  },
+                  {
+                    "id": "ID.RA-07.171",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Document the risks related to each requested exception and the plan for responding to those risks"
+                  },
+                  {
+                    "id": "ID.RA-07.172",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically review risks that were accepted based upon planned future actions or milestones"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-08",
+                "class": "subcategory",
+                "title": "ID.RA-08",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-08_statement",
+                    "name": "statement",
+                    "prose": "Processes for receiving, analyzing, and responding to vulnerability disclosures are established"
+                  },
+                  {
+                    "id": "ID.RA-08.173",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct vulnerability information sharing between the organization and its suppliers following the rules and protocols defined in contracts"
+                  },
+                  {
+                    "id": "ID.RA-08.174",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assign responsibilities and verify the execution of procedures for processing, analyzing the impact of, and responding to cybersecurity threat, vulnerability, or incident disclosures by suppliers, customers, partners, and government cybersecurity organizations"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-09",
+                "class": "subcategory",
+                "title": "ID.RA-09",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00009"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-09"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-09_statement",
+                    "name": "statement",
+                    "prose": "The authenticity and integrity of hardware and software are assessed prior to acquisition and use"
+                  },
+                  {
+                    "id": "ID.RA-09.175",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Assess the authenticity and cybersecurity of critical technology products and services prior to acquisition and use"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RA-10",
+                "class": "subcategory",
+                "title": "ID.RA-10",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00004.00010"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RA-10"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RA-10_statement",
+                    "name": "statement",
+                    "prose": "Critical suppliers are assessed prior to acquisition"
+                  },
+                  {
+                    "id": "ID.RA-10.176",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Conduct supplier risk assessments against business and applicable cybersecurity requirements, including the supply chain"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ID.RM",
+            "class": "category",
+            "title": "Risk Management Strategy",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00005"
+              },
+              {
+                "name": "label",
+                "value": "Risk Management Strategy (ID.RM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.RM_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.RM-01",
+                "class": "subcategory",
+                "title": "ID.RM-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00005.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RM-01_statement",
+                    "name": "statement",
+                    "prose": "Risk management processes are established, managed, and agreed to by organizational stakeholders"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RM-02",
+                "class": "subcategory",
+                "title": "ID.RM-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00005.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RM-02_statement",
+                    "name": "statement",
+                    "prose": "Organizational risk tolerance is determined and clearly expressed"
+                  }
+                ]
+              },
+              {
+                "id": "ID.RM-03",
+                "class": "subcategory",
+                "title": "ID.RM-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00005.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.RM-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.RM-03_statement",
+                    "name": "statement",
+                    "prose": "The organization’s determination of risk tolerance is informed by its role in critical infrastructure and sector specific risk analysis"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ID.SC",
+            "class": "category",
+            "title": "Supply Chain Risk Management",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00002.00006"
+              },
+              {
+                "name": "label",
+                "value": "Supply Chain Risk Management (ID.SC)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "ID.SC_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "ID.SC-01",
+                "class": "subcategory",
+                "title": "ID.SC-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00006.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.SC-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.SC-01_statement",
+                    "name": "statement",
+                    "prose": "Cyber supply chain risk management processes are identified, established, assessed, managed, and agreed to by organizational stakeholders"
+                  }
+                ]
+              },
+              {
+                "id": "ID.SC-02",
+                "class": "subcategory",
+                "title": "ID.SC-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00006.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.SC-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.SC-02_statement",
+                    "name": "statement",
+                    "prose": "Suppliers and third party partners of information systems, components, and services are identified, prioritized, and assessed using a cyber supply chain risk assessment process"
+                  }
+                ]
+              },
+              {
+                "id": "ID.SC-03",
+                "class": "subcategory",
+                "title": "ID.SC-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00006.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.SC-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.SC-03_statement",
+                    "name": "statement",
+                    "prose": "Contracts with suppliers and third-party partners are used to implement appropriate measures designed to meet the objectives of an organization’s cybersecurity program and Cyber Supply Chain Risk Management Plan."
+                  }
+                ]
+              },
+              {
+                "id": "ID.SC-04",
+                "class": "subcategory",
+                "title": "ID.SC-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00006.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.SC-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.SC-04_statement",
+                    "name": "statement",
+                    "prose": "Suppliers and third-party partners are routinely assessed using audits, test results, or other forms of evaluations to confirm they are meeting their contractual obligations."
+                  }
+                ]
+              },
+              {
+                "id": "ID.SC-05",
+                "class": "subcategory",
+                "title": "ID.SC-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00002.00006.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "ID.SC-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "ID.SC-05_statement",
+                    "name": "statement",
+                    "prose": "Response and recovery planning and testing are conducted with suppliers and third-party providers"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "PR",
+        "class": "function",
+        "title": "PROTECT",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "00003"
+          },
+          {
+            "name": "label",
+            "value": "PROTECT (PR)"
+          }
+        ],
+        "parts": [
+          {
+            "id": "PR_overview",
+            "name": "overview",
+            "prose": "Safeguards to manage the organization's cybersecurity risks are used"
+          }
+        ],
+        "controls": [
+          {
+            "id": "PR.AA",
+            "class": "category",
+            "title": "Identity Management, Authentication, and Access Control",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00001"
+              },
+              {
+                "name": "label",
+                "value": "Identity Management, Authentication, and Access Control (PR.AA)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.AA_statement",
+                "name": "statement",
+                "prose": "Access to physical and logical assets is limited to authorized users, services, and hardware and managed commensurate with the assessed risk of unauthorized access"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.AA-01",
+                "class": "subcategory",
+                "title": "PR.AA-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00001.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AA-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AA-01_statement",
+                    "name": "statement",
+                    "prose": "Identities and credentials for authorized users, services, and hardware are managed by the organization"
+                  },
+                  {
+                    "id": "PR.AA-01.194",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Initiate requests for new access or additional access for employees, contractors, and others, and track, review, and fulfill the requests, with permission from system or data owners when needed"
+                  },
+                  {
+                    "id": "PR.AA-01.195",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Issue, manage, and revoke cryptographic certificates and identity tokens, cryptographic keys (i.e., key management), and other credentials"
+                  },
+                  {
+                    "id": "PR.AA-01.196",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Select a unique identifier for each device from immutable hardware characteristics or an identifier securely provisioned to the device"
+                  },
+                  {
+                    "id": "PR.AA-01.197",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Physically label authorized hardware with an identifier for inventory and servicing purposes"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AA-02",
+                "class": "subcategory",
+                "title": "PR.AA-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00001.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AA-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AA-02_statement",
+                    "name": "statement",
+                    "prose": "Identities are proofed and bound to credentials based on the context of interactions"
+                  },
+                  {
+                    "id": "PR.AA-02.198",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Verify a person's claimed identity at enrollment time using government-issued identity credentials (e.g., passport, visa, driver's license)"
+                  },
+                  {
+                    "id": "PR.AA-02.199",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Issue a different credential for each person (i.e., no credential sharing)"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AA-03",
+                "class": "subcategory",
+                "title": "PR.AA-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00001.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AA-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AA-03_statement",
+                    "name": "statement",
+                    "prose": "Users, services, and hardware are authenticated"
+                  },
+                  {
+                    "id": "PR.AA-03.200",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require multifactor authentication"
+                  },
+                  {
+                    "id": "PR.AA-03.201",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Enforce policies for the minimum strength of passwords, PINs, and similar authenticators"
+                  },
+                  {
+                    "id": "PR.AA-03.202",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically reauthenticate users, services, and hardware based on risk (e.g., in zero trust architectures)"
+                  },
+                  {
+                    "id": "PR.AA-03.203",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Ensure that authorized personnel can access accounts essential for protecting safety under emergency conditions"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AA-04",
+                "class": "subcategory",
+                "title": "PR.AA-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00001.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AA-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AA-04_statement",
+                    "name": "statement",
+                    "prose": "Identity assertions are protected, conveyed, and verified"
+                  },
+                  {
+                    "id": "PR.AA-04.204",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Protect identity assertions that are used to convey authentication and user information through single sign-on systems"
+                  },
+                  {
+                    "id": "PR.AA-04.205",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Protect identity assertions that are used to convey authentication and user information between federated systems"
+                  },
+                  {
+                    "id": "PR.AA-04.206",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Implement standards-based approaches for identity assertions in all contexts, and follow all guidance for the generation (e.g., data models, metadata), protection (e.g., digital signing, encryption), and verification (e.g., signature validation) of identity assertions"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AA-05",
+                "class": "subcategory",
+                "title": "PR.AA-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00001.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AA-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AA-05_statement",
+                    "name": "statement",
+                    "prose": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+                  },
+                  {
+                    "id": "PR.AA-05.207",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review logical and physical access privileges periodically and whenever someone changes roles or leaves the organization, and promptly rescind privileges that are no longer needed"
+                  },
+                  {
+                    "id": "PR.AA-05.208",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Take attributes of the requester and the requested resource into account for authorization decisions (e.g., geolocation, day/time, requester endpoint's cyber health)"
+                  },
+                  {
+                    "id": "PR.AA-05.209",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Restrict access and privileges to the minimum necessary (e.g., zero trust architecture)"
+                  },
+                  {
+                    "id": "PR.AA-05.210",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically review the privileges associated with critical business functions to confirm proper separation of duties"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AA-06",
+                "class": "subcategory",
+                "title": "PR.AA-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00001.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AA-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AA-06_statement",
+                    "name": "statement",
+                    "prose": "Physical access to assets is managed, monitored, and enforced commensurate with risk"
+                  },
+                  {
+                    "id": "PR.AA-06.211",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use security guards, security cameras, locked entrances, alarm systems, and other physical controls to monitor facilities and restrict access"
+                  },
+                  {
+                    "id": "PR.AA-06.212",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Employ additional physical security controls for areas that contain high-risk assets"
+                  },
+                  {
+                    "id": "PR.AA-06.213",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Escort guests, vendors, and other third parties within areas that contain business-critical assets"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.AC",
+            "class": "category",
+            "title": "Identity Management, Authentication and Access Control",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00002"
+              },
+              {
+                "name": "label",
+                "value": "Identity Management, Authentication and Access Control (PR.AC)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.AC_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.AC-01",
+                "class": "subcategory",
+                "title": "PR.AC-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-01_statement",
+                    "name": "statement",
+                    "prose": "Identities and credentials are issued, managed, verified, revoked, and audited for authorized devices, users and processes"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AC-02",
+                "class": "subcategory",
+                "title": "PR.AC-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-02_statement",
+                    "name": "statement",
+                    "prose": "Physical access to assets is managed and protected"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AC-03",
+                "class": "subcategory",
+                "title": "PR.AC-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-03_statement",
+                    "name": "statement",
+                    "prose": "Remote access is managed"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AC-04",
+                "class": "subcategory",
+                "title": "PR.AC-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-04_statement",
+                    "name": "statement",
+                    "prose": "Access permissions and authorizations are managed, incorporating the principles of least privilege and separation of duties"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AC-05",
+                "class": "subcategory",
+                "title": "PR.AC-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-05_statement",
+                    "name": "statement",
+                    "prose": "Network integrity is protected (e.g., network segregation, network segmentation)"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AC-06",
+                "class": "subcategory",
+                "title": "PR.AC-06",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-06_statement",
+                    "name": "statement",
+                    "prose": "Identities are proofed and bound to credentials and asserted in interactions"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AC-07",
+                "class": "subcategory",
+                "title": "PR.AC-07",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00002.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AC-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AC-07_statement",
+                    "name": "statement",
+                    "prose": "Users, devices, and other assets are authenticated (e.g., single-factor, multi-factor) commensurate with the risk of the transaction (e.g., individuals’ security and privacy risks and other organizational risks)"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.AT",
+            "class": "category",
+            "title": "Awareness and Training",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00003"
+              },
+              {
+                "name": "label",
+                "value": "Awareness and Training (PR.AT)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.AT_statement",
+                "name": "statement",
+                "prose": "The organization's personnel are provided with cybersecurity awareness and training so that they can perform their cybersecurity-related tasks"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.AT-01",
+                "class": "subcategory",
+                "title": "PR.AT-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00003.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AT-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AT-01_statement",
+                    "name": "statement",
+                    "prose": "Personnel are provided with awareness and training so that they possess the knowledge and skills to perform general tasks with cybersecurity risks in mind"
+                  },
+                  {
+                    "id": "PR.AT-01.214",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Provide basic cybersecurity awareness and training to employees, contractors, partners, suppliers, and all other users of the organization's non-public resources"
+                  },
+                  {
+                    "id": "PR.AT-01.215",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Train personnel to recognize social engineering attempts and other common attacks, report attacks and suspicious activity, comply with acceptable use policies, and perform basic cyber hygiene tasks (e.g., patching software, choosing passwords, protecting credentials)"
+                  },
+                  {
+                    "id": "PR.AT-01.216",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Explain the consequences of cybersecurity policy violations, both to individual users and the organization as a whole"
+                  },
+                  {
+                    "id": "PR.AT-01.217",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically assess or test users on their understanding of basic cybersecurity practices"
+                  },
+                  {
+                    "id": "PR.AT-01.218",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require annual refreshers to reinforce existing practices and introduce new practices"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AT-02",
+                "class": "subcategory",
+                "title": "PR.AT-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00003.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AT-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AT-02_statement",
+                    "name": "statement",
+                    "prose": "Individuals in specialized roles are provided with awareness and training so that they possess the knowledge and skills to perform relevant tasks with cybersecurity risks in mind"
+                  },
+                  {
+                    "id": "PR.AT-02.219",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Identify the specialized roles within the organization that require additional cybersecurity training, such as physical and cybersecurity personnel, finance personnel, senior leadership, and anyone with access to business-critical data"
+                  },
+                  {
+                    "id": "PR.AT-02.220",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Provide role-based cybersecurity awareness and training to all those in specialized roles, including contractors, partners, suppliers, and other third parties"
+                  },
+                  {
+                    "id": "PR.AT-02.221",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Periodically assess or test users on their understanding of cybersecurity practices for their specialized roles"
+                  },
+                  {
+                    "id": "PR.AT-02.222",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require annual refreshers to reinforce existing practices and introduce new practices"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AT-03",
+                "class": "subcategory",
+                "title": "PR.AT-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00003.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AT-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AT-03_statement",
+                    "name": "statement",
+                    "prose": "Third-party stakeholders (e.g., suppliers, customers, partners) understand their roles and responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AT-04",
+                "class": "subcategory",
+                "title": "PR.AT-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00003.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AT-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AT-04_statement",
+                    "name": "statement",
+                    "prose": "Senior executives understand their roles and responsibilities"
+                  }
+                ]
+              },
+              {
+                "id": "PR.AT-05",
+                "class": "subcategory",
+                "title": "PR.AT-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00003.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.AT-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.AT-05_statement",
+                    "name": "statement",
+                    "prose": "Physical and cybersecurity personnel understand their roles and responsibilities"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.DS",
+            "class": "category",
+            "title": "Data Security",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00004"
+              },
+              {
+                "name": "label",
+                "value": "Data Security (PR.DS)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.DS_statement",
+                "name": "statement",
+                "prose": "Data are managed consistent with the organization's risk strategy to protect the confidentiality, integrity, and availability of information"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.DS-01",
+                "class": "subcategory",
+                "title": "PR.DS-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-01_statement",
+                    "name": "statement",
+                    "prose": "The confidentiality, integrity, and availability of data-at-rest are protected"
+                  },
+                  {
+                    "id": "PR.DS-01.223",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use encryption, digital signatures, and cryptographic hashes to protect the confidentiality and integrity of stored data in files, databases, virtual machine disk images, container images, and other resources"
+                  },
+                  {
+                    "id": "PR.DS-01.224",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use full disk encryption to protect data stored on user endpoints"
+                  },
+                  {
+                    "id": "PR.DS-01.225",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Confirm the integrity of software by validating signatures"
+                  },
+                  {
+                    "id": "PR.DS-01.226",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Restrict the use of removable media to prevent data exfiltration"
+                  },
+                  {
+                    "id": "PR.DS-01.227",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Physically secure removable media containing unencrypted sensitive information, such as within locked offices or file cabinets"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-02",
+                "class": "subcategory",
+                "title": "PR.DS-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-02_statement",
+                    "name": "statement",
+                    "prose": "The confidentiality, integrity, and availability of data-in-transit are protected"
+                  },
+                  {
+                    "id": "PR.DS-02.228",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use encryption, digital signatures, and cryptographic hashes to protect the confidentiality and integrity of network communications"
+                  },
+                  {
+                    "id": "PR.DS-02.229",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Automatically encrypt or block outbound emails and other communications that contain sensitive data, depending on the data classification"
+                  },
+                  {
+                    "id": "PR.DS-02.230",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Block access to personal email, file sharing, file storage services, and other personal communications applications and services from organizational systems and networks"
+                  },
+                  {
+                    "id": "PR.DS-02.231",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Prevent reuse of sensitive data from production environments (e.g., customer records) in development, testing, and other non-production environments"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-03",
+                "class": "subcategory",
+                "title": "PR.DS-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-03_statement",
+                    "name": "statement",
+                    "prose": "Assets are formally managed throughout removal, transfers, and disposition"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-04",
+                "class": "subcategory",
+                "title": "PR.DS-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-04_statement",
+                    "name": "statement",
+                    "prose": "Adequate capacity to ensure availability is maintained"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-05",
+                "class": "subcategory",
+                "title": "PR.DS-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-05_statement",
+                    "name": "statement",
+                    "prose": "Protections against data leaks are implemented"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-06",
+                "class": "subcategory",
+                "title": "PR.DS-06",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-06_statement",
+                    "name": "statement",
+                    "prose": "Integrity checking mechanisms are used to verify software, firmware, and information integrity"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-07",
+                "class": "subcategory",
+                "title": "PR.DS-07",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-07_statement",
+                    "name": "statement",
+                    "prose": "The development and testing environment(s) are separate from the production environment"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-08",
+                "class": "subcategory",
+                "title": "PR.DS-08",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-08_statement",
+                    "name": "statement",
+                    "prose": "Integrity checking mechanisms are used to verify hardware integrity"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-10",
+                "class": "subcategory",
+                "title": "PR.DS-10",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00010"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-10"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-10_statement",
+                    "name": "statement",
+                    "prose": "The confidentiality, integrity, and availability of data-in-use are protected"
+                  },
+                  {
+                    "id": "PR.DS-10.232",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Remove data that must remain confidential (e.g., from processors and memory) as soon as it is no longer needed"
+                  },
+                  {
+                    "id": "PR.DS-10.233",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Protect data in use from access by other users and processes of the same platform"
+                  }
+                ]
+              },
+              {
+                "id": "PR.DS-11",
+                "class": "subcategory",
+                "title": "PR.DS-11",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00004.00011"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.DS-11"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.DS-11_statement",
+                    "name": "statement",
+                    "prose": "Backups of data are created, protected, maintained, and tested"
+                  },
+                  {
+                    "id": "PR.DS-11.234",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Continuously back up critical data in near-real-time, and back up other data frequently at agreed-upon schedules"
+                  },
+                  {
+                    "id": "PR.DS-11.235",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Test backups and restores for all types of data sources at least annually"
+                  },
+                  {
+                    "id": "PR.DS-11.236",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely store some backups offline and offsite so that an incident or disaster will not damage them"
+                  },
+                  {
+                    "id": "PR.DS-11.237",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Enforce geographic separation and geolocation restrictions for data backup storage"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.IP",
+            "class": "category",
+            "title": "Information Protection Processes and Procedures",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00005"
+              },
+              {
+                "name": "label",
+                "value": "Information Protection Processes and Procedures (PR.IP)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.IP_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.IP-01",
+                "class": "subcategory",
+                "title": "PR.IP-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-01_statement",
+                    "name": "statement",
+                    "prose": "A baseline configuration of information technology/industrial control systems is created and maintained incorporating security principles (e.g. concept of least functionality)"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-02",
+                "class": "subcategory",
+                "title": "PR.IP-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-02_statement",
+                    "name": "statement",
+                    "prose": "A System Development Life Cycle to manage systems is implemented"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-03",
+                "class": "subcategory",
+                "title": "PR.IP-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-03_statement",
+                    "name": "statement",
+                    "prose": "Configuration change control processes are in place"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-04",
+                "class": "subcategory",
+                "title": "PR.IP-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-04_statement",
+                    "name": "statement",
+                    "prose": "Backups of information are conducted, maintained, and tested"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-05",
+                "class": "subcategory",
+                "title": "PR.IP-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-05_statement",
+                    "name": "statement",
+                    "prose": "Policy and regulations regarding the physical operating environment for organizational assets are met"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-06",
+                "class": "subcategory",
+                "title": "PR.IP-06",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-06_statement",
+                    "name": "statement",
+                    "prose": "Data is destroyed according to policy"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-07",
+                "class": "subcategory",
+                "title": "PR.IP-07",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-07_statement",
+                    "name": "statement",
+                    "prose": "Protection processes are improved"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-08",
+                "class": "subcategory",
+                "title": "PR.IP-08",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-08_statement",
+                    "name": "statement",
+                    "prose": "Effectiveness of protection technologies is shared"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-09",
+                "class": "subcategory",
+                "title": "PR.IP-09",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00009"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-09"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-09_statement",
+                    "name": "statement",
+                    "prose": "Response plans (Incident Response and Business Continuity) and recovery plans (Incident Recovery and Disaster Recovery) are in place and managed"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-10",
+                "class": "subcategory",
+                "title": "PR.IP-10",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00010"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-10"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-10_statement",
+                    "name": "statement",
+                    "prose": "Response and recovery plans are tested"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-11",
+                "class": "subcategory",
+                "title": "PR.IP-11",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00011"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-11"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-11_statement",
+                    "name": "statement",
+                    "prose": "Cybersecurity is included in human resources practices (e.g., deprovisioning, personnel screening)"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IP-12",
+                "class": "subcategory",
+                "title": "PR.IP-12",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00005.00012"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IP-12"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IP-12_statement",
+                    "name": "statement",
+                    "prose": "A vulnerability management plan is developed and implemented"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.IR",
+            "class": "category",
+            "title": "Technology Infrastructure Resilience",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00009"
+              },
+              {
+                "name": "label",
+                "value": "Technology Infrastructure Resilience (PR.IR)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.IR_statement",
+                "name": "statement",
+                "prose": "Security architectures are managed with the organization's risk strategy to protect asset confidentiality, integrity, and availability, and organizational resilience"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.IR-01",
+                "class": "subcategory",
+                "title": "PR.IR-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00009.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IR-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IR-01_statement",
+                    "name": "statement",
+                    "prose": "Networks and environments are protected from unauthorized logical access and usage"
+                  },
+                  {
+                    "id": "PR.IR-01.260",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Logically segment organization networks and cloud-based platforms according to trust boundaries and platform types (e.g., IT, IoT, OT, mobile, guests), and permit required communications only between segments"
+                  },
+                  {
+                    "id": "PR.IR-01.261",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Logically segment organization networks from external networks, and permit only necessary communications to enter the organization's networks from the external networks"
+                  },
+                  {
+                    "id": "PR.IR-01.262",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Implement zero trust architectures to restrict network access to each resource to the minimum necessary"
+                  },
+                  {
+                    "id": "PR.IR-01.263",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Check the cyber health of endpoints before allowing them to access and use production resources"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IR-02",
+                "class": "subcategory",
+                "title": "PR.IR-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00009.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IR-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IR-02_statement",
+                    "name": "statement",
+                    "prose": "The organization's technology assets are protected from environmental threats"
+                  },
+                  {
+                    "id": "PR.IR-02.264",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Protect organizational equipment from known environmental threats, such as flooding, fire, wind, and excessive heat and humidity"
+                  },
+                  {
+                    "id": "PR.IR-02.265",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Include protection from environmental threats and provisions for adequate operating infrastructure in requirements for service providers that operate systems on the organization's behalf"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IR-03",
+                "class": "subcategory",
+                "title": "PR.IR-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00009.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IR-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IR-03_statement",
+                    "name": "statement",
+                    "prose": "Mechanisms are implemented to achieve resilience requirements in normal and adverse situations"
+                  },
+                  {
+                    "id": "PR.IR-03.266",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Avoid single points of failure in systems and infrastructure"
+                  },
+                  {
+                    "id": "PR.IR-03.267",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use load balancing to increase capacity and improve reliability"
+                  },
+                  {
+                    "id": "PR.IR-03.268",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use high-availability components like redundant storage and power supplies to improve system reliability"
+                  }
+                ]
+              },
+              {
+                "id": "PR.IR-04",
+                "class": "subcategory",
+                "title": "PR.IR-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00009.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.IR-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.IR-04_statement",
+                    "name": "statement",
+                    "prose": "Adequate resource capacity to ensure availability is maintained"
+                  },
+                  {
+                    "id": "PR.IR-04.269",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor usage of storage, power, compute, network bandwidth, and other resources"
+                  },
+                  {
+                    "id": "PR.IR-04.270",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Forecast future needs, and scale resources accordingly"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.MA",
+            "class": "category",
+            "title": "Maintenance",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00006"
+              },
+              {
+                "name": "label",
+                "value": "Maintenance (PR.MA)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.MA_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.MA-01",
+                "class": "subcategory",
+                "title": "PR.MA-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00006.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.MA-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.MA-01_statement",
+                    "name": "statement",
+                    "prose": "Maintenance and repair of organizational assets are performed and logged, with approved and controlled tools"
+                  }
+                ]
+              },
+              {
+                "id": "PR.MA-02",
+                "class": "subcategory",
+                "title": "PR.MA-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00006.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.MA-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.MA-02_statement",
+                    "name": "statement",
+                    "prose": "Remote maintenance of organizational assets is approved, logged, and performed in a manner that prevents unauthorized access"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.PS",
+            "class": "category",
+            "title": "Platform Security",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00008"
+              },
+              {
+                "name": "label",
+                "value": "Platform Security (PR.PS)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.PS_statement",
+                "name": "statement",
+                "prose": "The hardware, software (e.g., firmware, operating systems, applications), and services of physical and virtual platforms are managed consistent with the organization's risk strategy to protect their confidentiality, integrity, and availability"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.PS-01",
+                "class": "subcategory",
+                "title": "PR.PS-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00008.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PS-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PS-01_statement",
+                    "name": "statement",
+                    "prose": "Configuration management practices are established and applied"
+                  },
+                  {
+                    "id": "PR.PS-01.238",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Establish, test, deploy, and maintain hardened baselines that enforce the organization's cybersecurity policies and provide only essential capabilities (i.e., principle of least functionality)"
+                  },
+                  {
+                    "id": "PR.PS-01.239",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review all default configuration settings that may potentially impact cybersecurity when installing or upgrading software"
+                  },
+                  {
+                    "id": "PR.PS-01.240",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor implemented software for deviations from approved baselines"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PS-02",
+                "class": "subcategory",
+                "title": "PR.PS-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00008.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PS-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PS-02_statement",
+                    "name": "statement",
+                    "prose": "Software is maintained, replaced, and removed commensurate with risk"
+                  },
+                  {
+                    "id": "PR.PS-02.241",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Perform routine and emergency patching within the timeframes specified in the vulnerability management plan"
+                  },
+                  {
+                    "id": "PR.PS-02.242",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Update container images, and deploy new container instances to replace rather than update existing instances"
+                  },
+                  {
+                    "id": "PR.PS-02.243",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Replace end-of-life software and service versions with supported, maintained versions"
+                  },
+                  {
+                    "id": "PR.PS-02.244",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Uninstall and remove unauthorized software and services that pose undue risks"
+                  },
+                  {
+                    "id": "PR.PS-02.245",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Uninstall and remove any unnecessary software components (e.g., operating system utilities) that attackers might misuse"
+                  },
+                  {
+                    "id": "PR.PS-02.246",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and implement plans for software and service end-of-life maintenance support and obsolescence"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PS-03",
+                "class": "subcategory",
+                "title": "PR.PS-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00008.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PS-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PS-03_statement",
+                    "name": "statement",
+                    "prose": "Hardware is maintained, replaced, and removed commensurate with risk"
+                  },
+                  {
+                    "id": "PR.PS-03.247",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Replace hardware when it lacks needed security capabilities or when it cannot support software with needed security capabilities"
+                  },
+                  {
+                    "id": "PR.PS-03.248",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Define and implement plans for hardware end-of-life maintenance support and obsolescence"
+                  },
+                  {
+                    "id": "PR.PS-03.249",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Perform hardware disposal in a secure, responsible, and auditable manner"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PS-04",
+                "class": "subcategory",
+                "title": "PR.PS-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00008.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PS-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PS-04_statement",
+                    "name": "statement",
+                    "prose": "Log records are generated and made available for continuous monitoring"
+                  },
+                  {
+                    "id": "PR.PS-04.250",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Configure all operating systems, applications, and services (including cloud-based services) to generate log records"
+                  },
+                  {
+                    "id": "PR.PS-04.251",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Configure log generators to securely share their logs with the organization's logging infrastructure systems and services"
+                  },
+                  {
+                    "id": "PR.PS-04.252",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Configure log generators to record the data needed by zero-trust architectures"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PS-05",
+                "class": "subcategory",
+                "title": "PR.PS-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00008.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PS-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PS-05_statement",
+                    "name": "statement",
+                    "prose": "Installation and execution of unauthorized software are prevented"
+                  },
+                  {
+                    "id": "PR.PS-05.253",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "When risk warrants it, restrict software execution to permitted products only or deny the execution of prohibited and unauthorized software"
+                  },
+                  {
+                    "id": "PR.PS-05.254",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Verify the source of new software and the software's integrity before installing it"
+                  },
+                  {
+                    "id": "PR.PS-05.255",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Configure platforms to use only approved DNS services that block access to known malicious domains"
+                  },
+                  {
+                    "id": "PR.PS-05.256",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Configure platforms to allow the installation of organization-approved software only"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PS-06",
+                "class": "subcategory",
+                "title": "PR.PS-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00008.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PS-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PS-06_statement",
+                    "name": "statement",
+                    "prose": "Secure software development practices are integrated, and their performance is monitored throughout the software development life cycle"
+                  },
+                  {
+                    "id": "PR.PS-06.257",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Protect all components of organization-developed software from tampering and unauthorized access"
+                  },
+                  {
+                    "id": "PR.PS-06.258",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Secure all software produced by the organization, with minimal vulnerabilities in their releases"
+                  },
+                  {
+                    "id": "PR.PS-06.259",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Maintain the software used in production environments, and securely dispose of software once it is no longer needed"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "PR.PT",
+            "class": "category",
+            "title": "Protective Technology",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00003.00007"
+              },
+              {
+                "name": "label",
+                "value": "Protective Technology (PR.PT)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "PR.PT_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "PR.PT-01",
+                "class": "subcategory",
+                "title": "PR.PT-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00007.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PT-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PT-01_statement",
+                    "name": "statement",
+                    "prose": "Audit/log records are determined, documented, implemented, and reviewed in accordance with policy"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PT-02",
+                "class": "subcategory",
+                "title": "PR.PT-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00007.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PT-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PT-02_statement",
+                    "name": "statement",
+                    "prose": "Removable media is protected and its use restricted according to policy"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PT-03",
+                "class": "subcategory",
+                "title": "PR.PT-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00007.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PT-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PT-03_statement",
+                    "name": "statement",
+                    "prose": "The principle of least functionality is incorporated by configuring systems to provide only essential capabilities"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PT-04",
+                "class": "subcategory",
+                "title": "PR.PT-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00007.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PT-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PT-04_statement",
+                    "name": "statement",
+                    "prose": "Communications and control networks are protected"
+                  }
+                ]
+              },
+              {
+                "id": "PR.PT-05",
+                "class": "subcategory",
+                "title": "PR.PT-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00003.00007.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "PR.PT-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "PR.PT-05_statement",
+                    "name": "statement",
+                    "prose": "Mechanisms (e.g., failsafe, load balancing, hot swap) are implemented to achieve resilience requirements in normal and adverse situations"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "DE",
+        "class": "function",
+        "title": "DETECT",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "00004"
+          },
+          {
+            "name": "label",
+            "value": "DETECT (DE)"
+          }
+        ],
+        "parts": [
+          {
+            "id": "DE_overview",
+            "name": "overview",
+            "prose": "Possible cybersecurity attacks and compromises are found and analyzed"
+          }
+        ],
+        "controls": [
+          {
+            "id": "DE.AE",
+            "class": "category",
+            "title": "Adverse Event Analysis",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00004.00001"
+              },
+              {
+                "name": "label",
+                "value": "Adverse Event Analysis (DE.AE)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "DE.AE_statement",
+                "name": "statement",
+                "prose": "Anomalies, indicators of compromise, and other potentially adverse events are analyzed to characterize the events and detect cybersecurity incidents"
+              }
+            ],
+            "controls": [
+              {
+                "id": "DE.AE-01",
+                "class": "subcategory",
+                "title": "DE.AE-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-01_statement",
+                    "name": "statement",
+                    "prose": "A baseline of network operations and expected data flows for users and systems is established and managed"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-02",
+                "class": "subcategory",
+                "title": "DE.AE-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-02_statement",
+                    "name": "statement",
+                    "prose": "Potentially adverse events are analyzed to better understand associated activities"
+                  },
+                  {
+                    "id": "DE.AE-02.290",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use security information and event management (SIEM) or other tools to continuously monitor log events for known malicious and suspicious activity"
+                  },
+                  {
+                    "id": "DE.AE-02.291",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Utilize up-to-date cyber threat intelligence in log analysis tools to improve detection accuracy and characterize threat actors, their methods, and indicators of compromise"
+                  },
+                  {
+                    "id": "DE.AE-02.292",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Regularly conduct manual reviews of log events for technologies that cannot be sufficiently monitored through automation"
+                  },
+                  {
+                    "id": "DE.AE-02.293",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use log analysis tools to generate reports on their findings"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-03",
+                "class": "subcategory",
+                "title": "DE.AE-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-03_statement",
+                    "name": "statement",
+                    "prose": "Information is correlated from multiple sources"
+                  },
+                  {
+                    "id": "DE.AE-03.294",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Constantly transfer log data generated by other sources to a relatively small number of log servers"
+                  },
+                  {
+                    "id": "DE.AE-03.295",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use event correlation technology (e.g., SIEM) to collect information captured by multiple sources"
+                  },
+                  {
+                    "id": "DE.AE-03.296",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Utilize cyber threat intelligence to help correlate events among log sources"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-04",
+                "class": "subcategory",
+                "title": "DE.AE-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-04_statement",
+                    "name": "statement",
+                    "prose": "The estimated impact and scope of adverse events are understood"
+                  },
+                  {
+                    "id": "DE.AE-04.297",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use SIEMs or other tools to estimate impact and scope, and review and refine the estimates"
+                  },
+                  {
+                    "id": "DE.AE-04.298",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "A person creates their own estimates of impact and scope"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-05",
+                "class": "subcategory",
+                "title": "DE.AE-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-05_statement",
+                    "name": "statement",
+                    "prose": "Incident alert thresholds are established"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-06",
+                "class": "subcategory",
+                "title": "DE.AE-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-06_statement",
+                    "name": "statement",
+                    "prose": "Information on adverse events is provided to authorized staff and tools"
+                  },
+                  {
+                    "id": "DE.AE-06.299",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use cybersecurity software to generate alerts and provide them to the security operations center (SOC), incident responders, and incident response tools"
+                  },
+                  {
+                    "id": "DE.AE-06.300",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Incident responders and other authorized personnel can access log analysis findings at all times"
+                  },
+                  {
+                    "id": "DE.AE-06.301",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Automatically create and assign tickets in the organization's ticketing system when certain types of alerts occur"
+                  },
+                  {
+                    "id": "DE.AE-06.302",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Manually create and assign tickets in the organization's ticketing system when technical staff discover indicators of compromise"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-07",
+                "class": "subcategory",
+                "title": "DE.AE-07",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-07_statement",
+                    "name": "statement",
+                    "prose": "Cyber threat intelligence and other contextual information are integrated into the analysis"
+                  },
+                  {
+                    "id": "DE.AE-07.303",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely provide cyber threat intelligence feeds to detection technologies, processes, and personnel"
+                  },
+                  {
+                    "id": "DE.AE-07.304",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely provide information from asset inventories to detection technologies, processes, and personnel"
+                  },
+                  {
+                    "id": "DE.AE-07.305",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Rapidly acquire and analyze vulnerability disclosures for the organization's technologies from suppliers, vendors, and third-party security advisories"
+                  }
+                ]
+              },
+              {
+                "id": "DE.AE-08",
+                "class": "subcategory",
+                "title": "DE.AE-08",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00001.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.AE-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.AE-08_statement",
+                    "name": "statement",
+                    "prose": "Incidents are declared when adverse events meet the defined incident criteria"
+                  },
+                  {
+                    "id": "DE.AE-08.306",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Apply incident criteria to known and assumed characteristics of activity in order to determine whether an incident should be declared"
+                  },
+                  {
+                    "id": "DE.AE-08.307",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Take known false positives into account when applying incident criteria"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "DE.CM",
+            "class": "category",
+            "title": "Continuous Monitoring",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00004.00002"
+              },
+              {
+                "name": "label",
+                "value": "Continuous Monitoring (DE.CM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "DE.CM_statement",
+                "name": "statement",
+                "prose": "Assets are monitored to find anomalies, indicators of compromise, and other potentially adverse events"
+              }
+            ],
+            "controls": [
+              {
+                "id": "DE.CM-01",
+                "class": "subcategory",
+                "title": "DE.CM-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-01_statement",
+                    "name": "statement",
+                    "prose": "Networks and network services are monitored to find potentially adverse events"
+                  },
+                  {
+                    "id": "DE.CM-01.271",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor DNS, BGP, and other network services for adverse events"
+                  },
+                  {
+                    "id": "DE.CM-01.272",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor wired and wireless networks for connections from unauthorized endpoints"
+                  },
+                  {
+                    "id": "DE.CM-01.273",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor facilities for unauthorized or rogue wireless networks"
+                  },
+                  {
+                    "id": "DE.CM-01.274",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Compare actual network flows against baselines to detect deviations"
+                  },
+                  {
+                    "id": "DE.CM-01.275",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor network communications to identify changes in security postures for zero trust purposes"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-02",
+                "class": "subcategory",
+                "title": "DE.CM-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-02_statement",
+                    "name": "statement",
+                    "prose": "The physical environment is monitored to find potentially adverse events"
+                  },
+                  {
+                    "id": "DE.CM-02.276",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor logs from physical access control systems (e.g., badge readers) to find unusual access patterns (e.g., deviations from the norm) and failed access attempts"
+                  },
+                  {
+                    "id": "DE.CM-02.277",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review and monitor physical access records (e.g., from visitor registration, sign-in sheets)"
+                  },
+                  {
+                    "id": "DE.CM-02.278",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor physical access controls (e.g., locks, latches, hinge pins, alarms) for signs of tampering"
+                  },
+                  {
+                    "id": "DE.CM-02.279",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor the physical environment using alarm systems, cameras, and security guards"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-03",
+                "class": "subcategory",
+                "title": "DE.CM-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-03_statement",
+                    "name": "statement",
+                    "prose": "Personnel activity and technology usage are monitored to find potentially adverse events"
+                  },
+                  {
+                    "id": "DE.CM-03.280",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use behavior analytics software to detect anomalous user activity to mitigate insider threats"
+                  },
+                  {
+                    "id": "DE.CM-03.281",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor logs from logical access control systems to find unusual access patterns and failed access attempts"
+                  },
+                  {
+                    "id": "DE.CM-03.282",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Continuously monitor deception technology, including user accounts, for any usage"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-04",
+                "class": "subcategory",
+                "title": "DE.CM-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-04_statement",
+                    "name": "statement",
+                    "prose": "Malicious code is detected"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-05",
+                "class": "subcategory",
+                "title": "DE.CM-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-05_statement",
+                    "name": "statement",
+                    "prose": "Unauthorized mobile code is detected"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-06",
+                "class": "subcategory",
+                "title": "DE.CM-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-06_statement",
+                    "name": "statement",
+                    "prose": "External service provider activities and services are monitored to find potentially adverse events"
+                  },
+                  {
+                    "id": "DE.CM-06.283",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor remote and onsite administration and maintenance activities that external providers perform on organizational systems"
+                  },
+                  {
+                    "id": "DE.CM-06.284",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor activity from cloud-based services, internet service providers, and other service providers for deviations from expected behavior"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-07",
+                "class": "subcategory",
+                "title": "DE.CM-07",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-07_statement",
+                    "name": "statement",
+                    "prose": "Monitoring for unauthorized personnel, connections, devices, and software is performed"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-08",
+                "class": "subcategory",
+                "title": "DE.CM-08",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-08_statement",
+                    "name": "statement",
+                    "prose": "Vulnerability scans are performed"
+                  }
+                ]
+              },
+              {
+                "id": "DE.CM-09",
+                "class": "subcategory",
+                "title": "DE.CM-09",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00002.00009"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.CM-09"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.CM-09_statement",
+                    "name": "statement",
+                    "prose": "Computing hardware and software, runtime environments, and their data are monitored to find potentially adverse events"
+                  },
+                  {
+                    "id": "DE.CM-09.285",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor email, web, file sharing, collaboration services, and other common attack vectors to detect malware, phishing, data leaks and exfiltration, and other adverse events"
+                  },
+                  {
+                    "id": "DE.CM-09.286",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor authentication attempts to identify attacks against credentials and unauthorized credential reuse"
+                  },
+                  {
+                    "id": "DE.CM-09.287",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor software configurations for deviations from security baselines"
+                  },
+                  {
+                    "id": "DE.CM-09.288",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor hardware and software for signs of tampering"
+                  },
+                  {
+                    "id": "DE.CM-09.289",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use technologies with a presence on endpoints to detect cyber health issues (e.g., missing patches, malware infections, unauthorized software), and redirect the endpoints to a remediation environment before access is authorized"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "DE.DP",
+            "class": "category",
+            "title": "Detection Processes",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00004.00003"
+              },
+              {
+                "name": "label",
+                "value": "Detection Processes (DE.DP)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "DE.DP_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "DE.DP-01",
+                "class": "subcategory",
+                "title": "DE.DP-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00003.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.DP-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.DP-01_statement",
+                    "name": "statement",
+                    "prose": "Roles and responsibilities for detection are well defined to ensure accountability"
+                  }
+                ]
+              },
+              {
+                "id": "DE.DP-02",
+                "class": "subcategory",
+                "title": "DE.DP-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00003.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.DP-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.DP-02_statement",
+                    "name": "statement",
+                    "prose": "Detection activities comply with all applicable requirements"
+                  }
+                ]
+              },
+              {
+                "id": "DE.DP-03",
+                "class": "subcategory",
+                "title": "DE.DP-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00003.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.DP-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.DP-03_statement",
+                    "name": "statement",
+                    "prose": "Detection processes are tested"
+                  }
+                ]
+              },
+              {
+                "id": "DE.DP-04",
+                "class": "subcategory",
+                "title": "DE.DP-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00003.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.DP-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.DP-04_statement",
+                    "name": "statement",
+                    "prose": "Event detection information is communicated"
+                  }
+                ]
+              },
+              {
+                "id": "DE.DP-05",
+                "class": "subcategory",
+                "title": "DE.DP-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00004.00003.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "DE.DP-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "DE.DP-05_statement",
+                    "name": "statement",
+                    "prose": "Detection processes are continuously improved"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "RS",
+        "class": "function",
+        "title": "RESPOND",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "00005"
+          },
+          {
+            "name": "label",
+            "value": "RESPOND (RS)"
+          }
+        ],
+        "parts": [
+          {
+            "id": "RS_overview",
+            "name": "overview",
+            "prose": "Actions regarding a detected cybersecurity incident are taken"
+          }
+        ],
+        "controls": [
+          {
+            "id": "RS.AN",
+            "class": "category",
+            "title": "Incident Analysis",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00005.00003"
+              },
+              {
+                "name": "label",
+                "value": "Incident Analysis (RS.AN)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RS.AN_statement",
+                "name": "statement",
+                "prose": "Investigations are conducted to ensure effective response and support forensics and recovery activities"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RS.AN-01",
+                "class": "subcategory",
+                "title": "RS.AN-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-01_statement",
+                    "name": "statement",
+                    "prose": "Notifications from detection systems are investigated"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-02",
+                "class": "subcategory",
+                "title": "RS.AN-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-02_statement",
+                    "name": "statement",
+                    "prose": "The impact of the incident is understood"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-03",
+                "class": "subcategory",
+                "title": "RS.AN-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-03_statement",
+                    "name": "statement",
+                    "prose": "Analysis is performed to establish what has taken place during an incident and the root cause of the incident"
+                  },
+                  {
+                    "id": "RS.AN-03.321",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Determine the sequence of events that occurred during the incident and which assets and resources were involved in each event"
+                  },
+                  {
+                    "id": "RS.AN-03.322",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Attempt to determine what vulnerabilities, threats, and threat actors were directly or indirectly involved in the incident"
+                  },
+                  {
+                    "id": "RS.AN-03.323",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Analyze the incident to find the underlying, systemic root causes"
+                  },
+                  {
+                    "id": "RS.AN-03.324",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Check any cyber deception technology for additional information on attacker behavior"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-04",
+                "class": "subcategory",
+                "title": "RS.AN-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-04_statement",
+                    "name": "statement",
+                    "prose": "Incidents are categorized consistent with response plans"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-05",
+                "class": "subcategory",
+                "title": "RS.AN-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-05_statement",
+                    "name": "statement",
+                    "prose": "Processes are established to receive, analyze and respond to vulnerabilities disclosed to the organization from internal and external sources (e.g. internal testing, security bulletins, or security researchers)"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-06",
+                "class": "subcategory",
+                "title": "RS.AN-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-06_statement",
+                    "name": "statement",
+                    "prose": "Actions performed during an investigation are recorded, and the records' integrity and provenance are preserved"
+                  },
+                  {
+                    "id": "RS.AN-06.325",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require each incident responder and others (e.g., system administrators, cybersecurity engineers) who perform incident response tasks to record their actions and make the record immutable"
+                  },
+                  {
+                    "id": "RS.AN-06.326",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Require the incident lead to document the incident in detail and be responsible for preserving the integrity of the documentation and the sources of all information being reported"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-07",
+                "class": "subcategory",
+                "title": "RS.AN-07",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00007"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-07"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-07_statement",
+                    "name": "statement",
+                    "prose": "Incident data and metadata are collected, and their integrity and provenance are preserved"
+                  },
+                  {
+                    "id": "RS.AN-07.327",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Collect, preserve, and safeguard the integrity of all pertinent incident data and metadata (e.g., data source, date/time of collection) based on evidence preservation and chain-of-custody procedures"
+                  }
+                ]
+              },
+              {
+                "id": "RS.AN-08",
+                "class": "subcategory",
+                "title": "RS.AN-08",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00003.00008"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.AN-08"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.AN-08_statement",
+                    "name": "statement",
+                    "prose": "An incident's magnitude is estimated and validated"
+                  },
+                  {
+                    "id": "RS.AN-08.328",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Review other potential targets of the incident to search for indicators of compromise and evidence of persistence"
+                  },
+                  {
+                    "id": "RS.AN-08.329",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Automatically run tools on targets to look for indicators of compromise and evidence of persistence"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RS.CO",
+            "class": "category",
+            "title": "Incident Response Reporting and Communication",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00005.00004"
+              },
+              {
+                "name": "label",
+                "value": "Incident Response Reporting and Communication (RS.CO)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RS.CO_statement",
+                "name": "statement",
+                "prose": "Response activities are coordinated with internal and external stakeholders as required by laws, regulations, or policies"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RS.CO-01",
+                "class": "subcategory",
+                "title": "RS.CO-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00004.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.CO-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.CO-01_statement",
+                    "name": "statement",
+                    "prose": "Personnel know their roles and order of operations when a response is needed"
+                  }
+                ]
+              },
+              {
+                "id": "RS.CO-02",
+                "class": "subcategory",
+                "title": "RS.CO-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00004.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.CO-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.CO-02_statement",
+                    "name": "statement",
+                    "prose": "Internal and external stakeholders are notified of incidents"
+                  },
+                  {
+                    "id": "RS.CO-02.330",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Follow the organization's breach notification procedures after discovering a data breach incident, including notifying affected customers"
+                  },
+                  {
+                    "id": "RS.CO-02.331",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Notify business partners and customers of incidents in accordance with contractual requirements"
+                  },
+                  {
+                    "id": "RS.CO-02.332",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Notify law enforcement agencies and regulatory bodies of incidents based on criteria in the incident response plan and management approval"
+                  }
+                ]
+              },
+              {
+                "id": "RS.CO-03",
+                "class": "subcategory",
+                "title": "RS.CO-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00004.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.CO-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.CO-03_statement",
+                    "name": "statement",
+                    "prose": "Information is shared with designated internal and external stakeholders"
+                  },
+                  {
+                    "id": "RS.CO-03.333",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely share information consistent with response plans and information sharing agreements"
+                  },
+                  {
+                    "id": "RS.CO-03.334",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Voluntarily share information about an attacker's observed TTPs, with all sensitive data removed, with an Information Sharing and Analysis Center (ISAC)"
+                  },
+                  {
+                    "id": "RS.CO-03.335",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Notify HR when malicious insider activity occurs"
+                  },
+                  {
+                    "id": "RS.CO-03.336",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Regularly update senior leadership on the status of major incidents"
+                  },
+                  {
+                    "id": "RS.CO-03.337",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Follow the rules and protocols defined in contracts for incident information sharing between the organization and its suppliers"
+                  },
+                  {
+                    "id": "RS.CO-03.338",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Coordinate crisis communication methods between the organization and its critical suppliers"
+                  }
+                ]
+              },
+              {
+                "id": "RS.CO-04",
+                "class": "subcategory",
+                "title": "RS.CO-04",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00004.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.CO-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.CO-04_statement",
+                    "name": "statement",
+                    "prose": "Coordination with stakeholders occurs consistent with response plans"
+                  }
+                ]
+              },
+              {
+                "id": "RS.CO-05",
+                "class": "subcategory",
+                "title": "RS.CO-05",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00004.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.CO-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.CO-05_statement",
+                    "name": "statement",
+                    "prose": "Voluntary information sharing occurs with external stakeholders to achieve broader cybersecurity situational awareness"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RS.IM",
+            "class": "category",
+            "title": "Improvements",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00005.00006"
+              },
+              {
+                "name": "label",
+                "value": "Improvements (RS.IM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RS.IM_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RS.IM-01",
+                "class": "subcategory",
+                "title": "RS.IM-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00006.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.IM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.IM-01_statement",
+                    "name": "statement",
+                    "prose": "Response plans incorporate lessons learned"
+                  }
+                ]
+              },
+              {
+                "id": "RS.IM-02",
+                "class": "subcategory",
+                "title": "RS.IM-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00006.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.IM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.IM-02_statement",
+                    "name": "statement",
+                    "prose": "Response strategies are updated"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RS.MA",
+            "class": "category",
+            "title": "Incident Management",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00005.00001"
+              },
+              {
+                "name": "label",
+                "value": "Incident Management (RS.MA)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RS.MA_statement",
+                "name": "statement",
+                "prose": "Responses to detected cybersecurity incidents are managed"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RS.MA-01",
+                "class": "subcategory",
+                "title": "RS.MA-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00001.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MA-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MA-01_statement",
+                    "name": "statement",
+                    "prose": "The incident response plan is executed in coordination with relevant third parties once an incident is declared"
+                  },
+                  {
+                    "id": "RS.MA-01.308",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Detection technologies automatically report confirmed incidents"
+                  },
+                  {
+                    "id": "RS.MA-01.309",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Request incident response assistance from the organization's incident response outsourcer"
+                  },
+                  {
+                    "id": "RS.MA-01.310",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Designate an incident lead for each incident"
+                  },
+                  {
+                    "id": "RS.MA-01.311",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Initiate execution of additional cybersecurity plans as needed to support incident response (for example, business continuity and disaster recovery)"
+                  }
+                ]
+              },
+              {
+                "id": "RS.MA-02",
+                "class": "subcategory",
+                "title": "RS.MA-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00001.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MA-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MA-02_statement",
+                    "name": "statement",
+                    "prose": "Incident reports are triaged and validated"
+                  },
+                  {
+                    "id": "RS.MA-02.312",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Preliminarily review incident reports to confirm that they are cybersecurity-related and necessitate incident response activities"
+                  },
+                  {
+                    "id": "RS.MA-02.313",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Apply criteria to estimate the severity of an incident"
+                  }
+                ]
+              },
+              {
+                "id": "RS.MA-03",
+                "class": "subcategory",
+                "title": "RS.MA-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00001.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MA-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MA-03_statement",
+                    "name": "statement",
+                    "prose": "Incidents are categorized and prioritized"
+                  },
+                  {
+                    "id": "RS.MA-03.314",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Further review and categorize incidents based on the type of incident (e.g., data breach, ransomware, DDoS, account compromise)"
+                  },
+                  {
+                    "id": "RS.MA-03.315",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Prioritize incidents based on their scope, likely impact, and time-critical nature"
+                  },
+                  {
+                    "id": "RS.MA-03.316",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Select incident response strategies for active incidents by balancing the need to quickly recover from an incident with the need to observe the attacker or conduct a more thorough investigation"
+                  }
+                ]
+              },
+              {
+                "id": "RS.MA-04",
+                "class": "subcategory",
+                "title": "RS.MA-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00001.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MA-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MA-04_statement",
+                    "name": "statement",
+                    "prose": "Incidents are escalated or elevated as needed"
+                  },
+                  {
+                    "id": "RS.MA-04.317",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Track and validate the status of all ongoing incidents"
+                  },
+                  {
+                    "id": "RS.MA-04.318",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Coordinate incident escalation or elevation with designated internal and external stakeholders"
+                  }
+                ]
+              },
+              {
+                "id": "RS.MA-05",
+                "class": "subcategory",
+                "title": "RS.MA-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00001.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MA-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MA-05_statement",
+                    "name": "statement",
+                    "prose": "The criteria for initiating incident recovery are applied"
+                  },
+                  {
+                    "id": "RS.MA-05.319",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Apply incident recovery criteria to known and assumed characteristics of the incident to determine whether incident recovery processes should be initiated"
+                  },
+                  {
+                    "id": "RS.MA-05.320",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Take the possible operational disruption of incident recovery activities into account"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RS.MI",
+            "class": "category",
+            "title": "Incident Mitigation",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00005.00005"
+              },
+              {
+                "name": "label",
+                "value": "Incident Mitigation (RS.MI)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RS.MI_statement",
+                "name": "statement",
+                "prose": "Activities are performed to prevent expansion of an event and mitigate its effects"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RS.MI-01",
+                "class": "subcategory",
+                "title": "RS.MI-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00005.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MI-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MI-01_statement",
+                    "name": "statement",
+                    "prose": "Incidents are contained"
+                  },
+                  {
+                    "id": "RS.MI-01.339",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Cybersecurity technologies (e.g., antivirus software) and cybersecurity features of other technologies (e.g., operating systems, network infrastructure devices) automatically perform containment actions"
+                  },
+                  {
+                    "id": "RS.MI-01.340",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Allow incident responders to manually select and perform containment actions"
+                  },
+                  {
+                    "id": "RS.MI-01.341",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Allow a third party (e.g., internet service provider, managed security service provider) to perform containment actions on behalf of the organization"
+                  },
+                  {
+                    "id": "RS.MI-01.342",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Automatically transfer compromised endpoints to a remediation virtual local area network (VLAN)"
+                  }
+                ]
+              },
+              {
+                "id": "RS.MI-02",
+                "class": "subcategory",
+                "title": "RS.MI-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00005.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MI-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MI-02_statement",
+                    "name": "statement",
+                    "prose": "Incidents are eradicated"
+                  },
+                  {
+                    "id": "RS.MI-02.343",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Cybersecurity technologies and cybersecurity features of other technologies (e.g., operating systems, network infrastructure devices) automatically perform eradication actions"
+                  },
+                  {
+                    "id": "RS.MI-02.344",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Allow incident responders to manually select and perform eradication actions"
+                  },
+                  {
+                    "id": "RS.MI-02.345",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Allow a third party (e.g., managed security service provider) to perform eradication actions on behalf of the organization"
+                  }
+                ]
+              },
+              {
+                "id": "RS.MI-03",
+                "class": "subcategory",
+                "title": "RS.MI-03",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00005.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.MI-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.MI-03_statement",
+                    "name": "statement",
+                    "prose": "Newly identified vulnerabilities are mitigated or documented as accepted risks"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RS.RP",
+            "class": "category",
+            "title": "Response Planning",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00005.00002"
+              },
+              {
+                "name": "label",
+                "value": "Response Planning (RS.RP)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RS.RP_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RS.RP-01",
+                "class": "subcategory",
+                "title": "RS.RP-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00005.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RS.RP-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RS.RP-01_statement",
+                    "name": "statement",
+                    "prose": "Response plan is executed during or after an incident"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "RC",
+        "class": "function",
+        "title": "RECOVER",
+        "props": [
+          {
+            "name": "sort-id",
+            "value": "00006"
+          },
+          {
+            "name": "label",
+            "value": "RECOVER (RC)"
+          }
+        ],
+        "parts": [
+          {
+            "id": "RC_overview",
+            "name": "overview",
+            "prose": "Assets and operations affected by a cybersecurity incident are restored"
+          }
+        ],
+        "controls": [
+          {
+            "id": "RC.CO",
+            "class": "category",
+            "title": "Incident Recovery Communication",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00006.00002"
+              },
+              {
+                "name": "label",
+                "value": "Incident Recovery Communication (RC.CO)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RC.CO_statement",
+                "name": "statement",
+                "prose": "Restoration activities are coordinated with internal and external parties"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RC.CO-01",
+                "class": "subcategory",
+                "title": "RC.CO-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.CO-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.CO-01_statement",
+                    "name": "statement",
+                    "prose": "Public relations are managed"
+                  }
+                ]
+              },
+              {
+                "id": "RC.CO-02",
+                "class": "subcategory",
+                "title": "RC.CO-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00002.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.CO-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.CO-02_statement",
+                    "name": "statement",
+                    "prose": "Reputation is repaired after an incident"
+                  }
+                ]
+              },
+              {
+                "id": "RC.CO-03",
+                "class": "subcategory",
+                "title": "RC.CO-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "3rd",
+                    "remarks": "3rd Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00002.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.CO-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.CO-03_statement",
+                    "name": "statement",
+                    "prose": "Recovery activities and progress in restoring operational capabilities are communicated to designated internal and external stakeholders"
+                  },
+                  {
+                    "id": "RC.CO-03.358",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Securely share recovery information, including restoration progress, consistent with response plans and information sharing agreements"
+                  },
+                  {
+                    "id": "RC.CO-03.359",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Regularly update senior leadership on recovery status and restoration progress for major incidents"
+                  },
+                  {
+                    "id": "RC.CO-03.360",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Follow the rules and protocols defined in contracts for incident information sharing between the organization and its suppliers"
+                  },
+                  {
+                    "id": "RC.CO-03.361",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Coordinate crisis communication between the organization and its critical suppliers"
+                  }
+                ]
+              },
+              {
+                "id": "RC.CO-04",
+                "class": "subcategory",
+                "title": "RC.CO-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00002.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.CO-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.CO-04_statement",
+                    "name": "statement",
+                    "prose": "Public updates on incident recovery are shared using approved methods and messaging"
+                  },
+                  {
+                    "id": "RC.CO-04.362",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Follow the organization's breach notification procedures for recovering from a data breach incident"
+                  },
+                  {
+                    "id": "RC.CO-04.363",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Explain the steps being taken to recover from the incident and to prevent a recurrence"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RC.IM",
+            "class": "category",
+            "title": "Improvements",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00006.00002"
+              },
+              {
+                "name": "label",
+                "value": "Improvements (RC.IM)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RC.IM_statement",
+                "name": "statement"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RC.IM-01",
+                "class": "subcategory",
+                "title": "RC.IM-01",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00002.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.IM-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.IM-01_statement",
+                    "name": "statement",
+                    "prose": "Recovery plans incorporate lessons learned"
+                  }
+                ]
+              },
+              {
+                "id": "RC.IM-02",
+                "class": "subcategory",
+                "title": "RC.IM-02",
+                "props": [
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00002.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.IM-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.IM-02_statement",
+                    "name": "statement",
+                    "prose": "Recovery strategies are updated"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "RC.RP",
+            "class": "category",
+            "title": "Incident Recovery Plan Execution",
+            "props": [
+              {
+                "name": "sort-id",
+                "value": "00006.00001"
+              },
+              {
+                "name": "label",
+                "value": "Incident Recovery Plan Execution (RC.RP)"
+              }
+            ],
+            "parts": [
+              {
+                "id": "RC.RP_statement",
+                "name": "statement",
+                "prose": "Restoration activities are performed to ensure operational availability of systems and services affected by cybersecurity incidents"
+              }
+            ],
+            "controls": [
+              {
+                "id": "RC.RP-01",
+                "class": "subcategory",
+                "title": "RC.RP-01",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00001.00001"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.RP-01"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.RP-01_statement",
+                    "name": "statement",
+                    "prose": "The recovery portion of the incident response plan is executed once initiated from the incident response process"
+                  },
+                  {
+                    "id": "RC.RP-01.346",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Begin recovery procedures during or after incident response processes"
+                  },
+                  {
+                    "id": "RC.RP-01.347",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Make all individuals with recovery responsibilities aware of the plans for recovery and the authorizations required to implement each aspect of the plans"
+                  }
+                ]
+              },
+              {
+                "id": "RC.RP-02",
+                "class": "subcategory",
+                "title": "RC.RP-02",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00001.00002"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.RP-02"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.RP-02_statement",
+                    "name": "statement",
+                    "prose": "Recovery actions are selected, scoped, prioritized, and performed"
+                  },
+                  {
+                    "id": "RC.RP-02.348",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Select recovery actions based on the criteria defined in the incident response plan and available resources"
+                  },
+                  {
+                    "id": "RC.RP-02.349",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Change planned recovery actions based on a reassessment of organizational needs and resources"
+                  }
+                ]
+              },
+              {
+                "id": "RC.RP-03",
+                "class": "subcategory",
+                "title": "RC.RP-03",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00001.00003"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.RP-03"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.RP-03_statement",
+                    "name": "statement",
+                    "prose": "The integrity of backups and other restoration assets is verified before using them for restoration"
+                  },
+                  {
+                    "id": "RC.RP-03.350",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Check restoration assets for indicators of compromise, file corruption, and other integrity issues before use"
+                  }
+                ]
+              },
+              {
+                "id": "RC.RP-04",
+                "class": "subcategory",
+                "title": "RC.RP-04",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00001.00004"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.RP-04"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.RP-04_statement",
+                    "name": "statement",
+                    "prose": "Critical mission functions and cybersecurity risk management are considered to establish post-incident operational norms"
+                  },
+                  {
+                    "id": "RC.RP-04.351",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Use business impact and system categorization records (including service delivery objectives) to validate that essential services are restored in the appropriate order"
+                  },
+                  {
+                    "id": "RC.RP-04.352",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Work with system owners to confirm the successful restoration of systems and the return to normal operations"
+                  },
+                  {
+                    "id": "RC.RP-04.353",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Monitor the performance of restored systems to verify the adequacy of the restoration"
+                  }
+                ]
+              },
+              {
+                "id": "RC.RP-05",
+                "class": "subcategory",
+                "title": "RC.RP-05",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00001.00005"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.RP-05"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.RP-05_statement",
+                    "name": "statement",
+                    "prose": "The integrity of restored assets is verified, systems and services are restored, and normal operating status is confirmed"
+                  },
+                  {
+                    "id": "RC.RP-05.354",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Check restored assets for indicators of compromise and remediation of root causes of the incident before production use"
+                  },
+                  {
+                    "id": "RC.RP-05.355",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Verify the correctness and adequacy of the restoration actions taken before putting a restored system online"
+                  }
+                ]
+              },
+              {
+                "id": "RC.RP-06",
+                "class": "subcategory",
+                "title": "RC.RP-06",
+                "props": [
+                  {
+                    "name": "risk-party",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "value": "1st",
+                    "remarks": "1st Party Risk"
+                  },
+                  {
+                    "name": "sort-id",
+                    "value": "00006.00001.00006"
+                  },
+                  {
+                    "name": "label",
+                    "value": "RC.RP-06"
+                  }
+                ],
+                "parts": [
+                  {
+                    "id": "RC.RP-06_statement",
+                    "name": "statement",
+                    "prose": "The end of incident recovery is declared based on criteria, and incident-related documentation is completed"
+                  },
+                  {
+                    "id": "RC.RP-06.356",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Prepare an after-action report that documents the incident itself, the response and recovery actions taken, and lessons learned"
+                  },
+                  {
+                    "id": "RC.RP-06.357",
+                    "name": "example",
+                    "ns": "https://csrc.nist.gov/ns/csf",
+                    "prose": "Declare the end of incident recovery once the criteria are met"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "back-matter": {
+      "resources": [
+        {
+          "uuid": "3ab41d8a-66e3-4732-ae28-07405dad5127",
+          "title": "The NIST Cybersecurity Framework 2.0 (PDF)",
+          "rlinks": [
+            {
+              "href": "https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.29.ipd.pdf",
+              "media-type": "application/pdf"
+            }
+          ]
+        },
+        {
+          "uuid": "0451580b-8ef9-4f52-9182-bc887d6cf369",
+          "title": "The NIST Cybersecurity Framework 2.0 (DOI link)",
+          "rlinks": [
+            {
+              "href": "https://doi.org/10.6028/NIST.CSWP.29.ipd",
+              "media-type": "application/pdf"
+            }
+          ]
+        },
+        {
+          "uuid": "a7f54afa-16cf-4200-a043-85aa554b93e4",
+          "title": "The NIST Cybersecurity Framework",
+          "rlinks": [
+            {
+              "href": "https://www.nist.gov/cyberframework",
+              "media-type": "application/html"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/lemma/services/framework.py
+++ b/src/lemma/services/framework.py
@@ -3,6 +3,11 @@
 Provides the business logic layer between CLI commands and the
 parser/indexer infrastructure. All framework operations go through
 this service.
+
+Bundled public domain catalogs:
+- nist-800-53: NIST SP 800-53 Rev 5
+- nist-csf-2.0: NIST Cybersecurity Framework 2.0
+- nist-800-171: NIST SP 800-171 Rev 3
 """
 
 from __future__ import annotations
@@ -23,6 +28,8 @@ def get_framework_registry() -> dict[str, Path]:
     data_dir = Path(__file__).parent.parent / "data" / "frameworks"
     return {
         "nist-800-53": data_dir / "nist-800-53-rev5.json",
+        "nist-csf-2.0": data_dir / "nist-csf-2.0.json",
+        "nist-800-171": data_dir / "nist-800-171-rev3.json",
     }
 
 

--- a/tests/services/test_bundled_frameworks.py
+++ b/tests/services/test_bundled_frameworks.py
@@ -1,0 +1,93 @@
+"""Tests for bundled framework catalog registration and ingestion.
+
+Validates that all registered catalogs exist, parse successfully,
+and produce non-trivial control counts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lemma.services.framework import get_framework_registry
+from lemma.services.parsers.oscal import parse_catalog
+
+
+class TestBundledFrameworks:
+    """Verify all bundled framework catalogs are valid and registered."""
+
+    def test_registry_contains_expected_frameworks(self):
+        """Registry includes all three bundled public domain frameworks."""
+        registry = get_framework_registry()
+        assert "nist-800-53" in registry
+        assert "nist-csf-2.0" in registry
+        assert "nist-800-171" in registry
+
+    def test_all_registry_paths_exist(self):
+        """Every registered catalog path points to a real file."""
+        registry = get_framework_registry()
+        for name, path in registry.items():
+            assert path.exists(), f"Catalog file missing for '{name}': {path}"
+
+    @pytest.mark.parametrize(
+        ("framework_name", "min_controls"),
+        [
+            ("nist-800-53", 1000),
+            ("nist-csf-2.0", 200),
+            ("nist-800-171", 100),
+        ],
+    )
+    def test_catalog_parses_with_expected_control_count(
+        self, framework_name: str, min_controls: int
+    ):
+        """Each bundled catalog parses to at least the expected number of controls."""
+        registry = get_framework_registry()
+        catalog_path = registry[framework_name]
+
+        raw = json.loads(catalog_path.read_text())
+        catalog_data = raw.get("catalog", raw)
+        controls = parse_catalog(catalog_data)
+
+        assert len(controls) >= min_controls, (
+            f"{framework_name} produced {len(controls)} controls, expected >= {min_controls}"
+        )
+
+    @pytest.mark.parametrize("framework_name", ["nist-800-53", "nist-csf-2.0", "nist-800-171"])
+    def test_catalog_controls_have_required_fields(self, framework_name: str):
+        """Each control record has id, title, prose, and family keys."""
+        registry = get_framework_registry()
+        catalog_path = registry[framework_name]
+
+        raw = json.loads(catalog_path.read_text())
+        catalog_data = raw.get("catalog", raw)
+        controls = parse_catalog(catalog_data)
+
+        for control in controls[:10]:  # Spot-check first 10
+            assert "id" in control, f"Missing 'id' in {framework_name} control"
+            assert "title" in control, f"Missing 'title' in {framework_name} control"
+            assert "prose" in control, f"Missing 'prose' in {framework_name} control"
+            assert "family" in control, f"Missing 'family' in {framework_name} control"
+
+    def test_add_bundled_csf_indexes_successfully(self, tmp_path: Path):
+        """lemma framework add nist-csf-2.0 indexes controls."""
+        from lemma.services.framework import add_bundled_framework
+
+        (tmp_path / ".lemma").mkdir()
+        result = add_bundled_framework("nist-csf-2.0", project_dir=tmp_path)
+
+        assert result["name"] == "nist-csf-2.0"
+        assert result["control_count"] >= 200
+        assert result["indexed"] is True
+
+    def test_add_bundled_171_indexes_successfully(self, tmp_path: Path):
+        """lemma framework add nist-800-171 indexes controls."""
+        from lemma.services.framework import add_bundled_framework
+
+        (tmp_path / ".lemma").mkdir()
+        result = add_bundled_framework("nist-800-171", project_dir=tmp_path)
+
+        assert result["name"] == "nist-800-171"
+        assert result["control_count"] >= 100
+        assert result["indexed"] is True


### PR DESCRIPTION
## Description

Bundles two additional public domain OSCAL framework catalogs from [usnistgov/oscal-content](https://github.com/usnistgov/oscal-content), bringing the total to three:

| Framework | Controls | Source |
|-----------|----------|--------|
| NIST SP 800-53 Rev 5 | 1,196 | Already bundled |
| NIST CSF 2.0 | 219 | **New** |
| NIST SP 800-171 Rev 3 | 130 | **New** |

The original issue (#57) called for HIPAA and FedRAMP as well. HIPAA has no public domain OSCAL catalog (it requires PDF ingestion of the HHS document), and the FedRAMP repo (GSA/fedramp-automation) was archived in July 2025. SP 800-171 is a stronger substitute — it's the foundational CUI protection standard that feeds into CMMC and is directly available as an OSCAL catalog.

The acceptance criterion of "at least 3 public domain framework catalogs bundled" is now met. OCSF event types are deferred as a separate architectural concern per the issue description.

Fixes #57

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` (or equivalent) with no errors
- [x] I have run `ruff format` (or equivalent)
- [x] I have run `pytest` (or equivalent) and all tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors
