### PR TITLE
feat(graph): Add compliance knowledge graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pyyaml>=6.0",
     "chromadb>=0.5",
     "httpx>=0.27",
+    "networkx>=3.0",
 ]
 
 [project.optional-dependencies]

--- a/src/lemma/services/knowledge_graph.py
+++ b/src/lemma/services/knowledge_graph.py
@@ -1,0 +1,294 @@
+"""Compliance Knowledge Graph — queryable relationship model.
+
+Represents the relationships between frameworks, controls, policies,
+mappings, and harmonizations as a directed graph. Uses NetworkX as
+an embedded graph engine (no external database required).
+
+Node types:
+    - Framework: A compliance framework (e.g., NIST 800-53)
+    - Control: A specific control within a framework
+    - Policy: An organizational policy document
+
+Edge types:
+    - CONTAINS: Framework → Control
+    - SATISFIES: Policy → Control (with confidence score)
+    - HARMONIZED_WITH: Control ↔ Control (cross-framework equivalence)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx
+
+
+class ComplianceGraph:
+    """In-memory compliance knowledge graph backed by NetworkX."""
+
+    def __init__(self) -> None:
+        """Initialize an empty compliance graph."""
+        self._graph = nx.MultiDiGraph()
+
+    # --- Node operations ---
+
+    def add_framework(self, name: str, *, title: str = "") -> None:
+        """Add a Framework node to the graph.
+
+        Args:
+            name: Framework short name (e.g., 'nist-800-53').
+            title: Human-readable title.
+        """
+        node_id = f"framework:{name}"
+        self._graph.add_node(node_id, type="Framework", name=name, title=title)
+
+    def add_control(
+        self,
+        *,
+        framework: str,
+        control_id: str,
+        title: str,
+        family: str,
+        prose: str = "",
+    ) -> None:
+        """Add a Control node and a CONTAINS edge from its framework.
+
+        Args:
+            framework: Parent framework short name.
+            control_id: Control identifier (e.g., 'ac-1').
+            title: Control title.
+            family: Control family/group.
+            prose: Control prose text.
+        """
+        node_id = f"control:{framework}:{control_id}"
+        fw_id = f"framework:{framework}"
+
+        # Ensure framework node exists
+        if fw_id not in self._graph:
+            self.add_framework(framework)
+
+        self._graph.add_node(
+            node_id,
+            type="Control",
+            control_id=control_id,
+            title=title,
+            family=family,
+            prose=prose,
+        )
+        self._graph.add_edge(fw_id, node_id, relationship="CONTAINS")
+
+    def add_policy(self, path: str, *, title: str = "") -> None:
+        """Add a Policy node to the graph.
+
+        Args:
+            path: Policy file path or identifier.
+            title: Human-readable policy title.
+        """
+        node_id = f"policy:{path}"
+        self._graph.add_node(node_id, type="Policy", path=path, title=title)
+
+    # --- Edge operations ---
+
+    def add_mapping(
+        self,
+        *,
+        policy: str,
+        framework: str,
+        control_id: str,
+        confidence: float,
+    ) -> None:
+        """Add a SATISFIES edge from a policy to a control.
+
+        Args:
+            policy: Policy path/identifier.
+            framework: Framework short name.
+            control_id: Control identifier.
+            confidence: Mapping confidence score (0.0-1.0).
+        """
+        policy_id = f"policy:{policy}"
+        control_node = f"control:{framework}:{control_id}"
+
+        self._graph.add_edge(
+            policy_id,
+            control_node,
+            relationship="SATISFIES",
+            confidence=confidence,
+        )
+
+    def add_harmonization(
+        self,
+        *,
+        framework_a: str,
+        control_a: str,
+        framework_b: str,
+        control_b: str,
+        similarity: float,
+    ) -> None:
+        """Add a HARMONIZED_WITH edge between two controls.
+
+        Args:
+            framework_a: First framework short name.
+            control_a: First control identifier.
+            framework_b: Second framework short name.
+            control_b: Second control identifier.
+            similarity: Cosine similarity score.
+        """
+        node_a = f"control:{framework_a}:{control_a}"
+        node_b = f"control:{framework_b}:{control_b}"
+
+        self._graph.add_edge(node_a, node_b, relationship="HARMONIZED_WITH", similarity=similarity)
+        self._graph.add_edge(node_b, node_a, relationship="HARMONIZED_WITH", similarity=similarity)
+
+    # --- Bulk operations ---
+
+    def populate_from_controls(self, framework: str, controls: list[dict]) -> None:
+        """Bulk-load a framework's control records into the graph.
+
+        Idempotent — re-populating the same framework updates existing nodes.
+
+        Args:
+            framework: Framework short name.
+            controls: List of control record dicts with id, title, prose, family.
+        """
+        self.add_framework(framework)
+
+        for ctrl in controls:
+            self.add_control(
+                framework=framework,
+                control_id=ctrl["id"],
+                title=ctrl.get("title", ""),
+                family=ctrl.get("family", ""),
+                prose=ctrl.get("prose", ""),
+            )
+
+    # --- Query operations ---
+
+    def get_node(self, node_id: str) -> dict[str, Any] | None:
+        """Get node attributes by ID.
+
+        Returns:
+            Dict of node attributes, or None if not found.
+        """
+        if node_id in self._graph:
+            return dict(self._graph.nodes[node_id])
+        return None
+
+    def get_edges(self, source: str, target: str) -> list[dict[str, Any]]:
+        """Get all edges between two nodes.
+
+        Returns:
+            List of edge attribute dicts.
+        """
+        if not self._graph.has_node(source) or not self._graph.has_node(target):
+            return []
+
+        edges = []
+        if self._graph.has_edge(source, target):
+            edge_data = self._graph.get_edge_data(source, target)
+            if edge_data:
+                for _key, attrs in edge_data.items():
+                    edges.append(dict(attrs))
+        return edges
+
+    def query_neighbors(self, node_id: str) -> list[dict[str, Any]]:
+        """Get all nodes connected to the given node.
+
+        Returns:
+            List of dicts with 'id' and all node attributes.
+        """
+        if node_id not in self._graph:
+            return []
+
+        neighbors = []
+        # Successors (outgoing edges)
+        for neighbor in self._graph.successors(node_id):
+            attrs = dict(self._graph.nodes[neighbor])
+            attrs["id"] = neighbor
+            neighbors.append(attrs)
+        # Predecessors (incoming edges)
+        for neighbor in self._graph.predecessors(node_id):
+            if neighbor != node_id:
+                attrs = dict(self._graph.nodes[neighbor])
+                attrs["id"] = neighbor
+                if attrs not in neighbors:
+                    neighbors.append(attrs)
+        return neighbors
+
+    def impact(self, node_id: str) -> dict[str, Any]:
+        """Analyze the compliance impact of a node.
+
+        Traverses the graph to find all controls and frameworks
+        reachable from the given node.
+
+        Args:
+            node_id: Node to analyze impact for.
+
+        Returns:
+            Dict with 'controls' and 'frameworks' lists.
+        """
+        controls: list[dict] = []
+        frameworks: set[str] = set()
+        visited: set[str] = set()
+
+        def _traverse(nid: str) -> None:
+            if nid in visited:
+                return
+            visited.add(nid)
+
+            node = self.get_node(nid)
+            if node is None:
+                return
+
+            if node.get("type") == "Control":
+                controls.append({"id": node.get("control_id", ""), **node})
+            if node.get("type") == "Framework":
+                frameworks.add(node.get("name", ""))
+
+            # Follow outgoing edges
+            for neighbor in self._graph.successors(nid):
+                _traverse(neighbor)
+
+            # Follow incoming edges (e.g., Framework→Control)
+            for neighbor in self._graph.predecessors(nid):
+                _traverse(neighbor)
+
+        _traverse(node_id)
+
+        return {"controls": controls, "frameworks": sorted(frameworks)}
+
+    def framework_control_count(self, framework: str) -> int:
+        """Count controls belonging to a framework.
+
+        Args:
+            framework: Framework short name.
+
+        Returns:
+            Number of controls in the framework.
+        """
+        fw_id = f"framework:{framework}"
+        if fw_id not in self._graph:
+            return 0
+
+        return sum(
+            1
+            for n in self._graph.successors(fw_id)
+            if self._graph.nodes[n].get("type") == "Control"
+        )
+
+    # --- Export ---
+
+    def export_json(self) -> dict[str, Any]:
+        """Export the graph as a JSON-serializable dict.
+
+        Returns:
+            Dict with 'nodes' and 'edges' lists, suitable for
+            D3.js or Cytoscape rendering.
+        """
+        nodes = []
+        for node_id, attrs in self._graph.nodes(data=True):
+            nodes.append({"id": node_id, **attrs})
+
+        edges = []
+        for source, target, attrs in self._graph.edges(data=True):
+            edges.append({"source": source, "target": target, **attrs})
+
+        return {"nodes": nodes, "edges": edges}

--- a/tests/services/test_knowledge_graph.py
+++ b/tests/services/test_knowledge_graph.py
@@ -1,0 +1,177 @@
+"""Compliance Knowledge Graph — tests for graph data model and population.
+
+Tests the NetworkX-based knowledge graph that represents relationships
+between frameworks, controls, policies, and harmonization mappings.
+"""
+
+from __future__ import annotations
+
+from lemma.services.knowledge_graph import ComplianceGraph
+
+
+class TestComplianceGraph:
+    """Tests for the compliance knowledge graph."""
+
+    def test_add_framework_creates_framework_node(self):
+        """Adding a framework creates a Framework node."""
+        graph = ComplianceGraph()
+        graph.add_framework("nist-800-53", title="NIST SP 800-53 Rev 5")
+
+        node = graph.get_node("framework:nist-800-53")
+        assert node is not None
+        assert node["type"] == "Framework"
+        assert node["title"] == "NIST SP 800-53 Rev 5"
+
+    def test_add_control_creates_control_with_edges(self):
+        """Adding a control creates a Control node and CONTAINS edge from framework."""
+        graph = ComplianceGraph()
+        graph.add_framework("nist-800-53", title="NIST SP 800-53 Rev 5")
+        graph.add_control(
+            framework="nist-800-53",
+            control_id="ac-1",
+            title="Access Control Policy",
+            family="Access Control",
+        )
+
+        node = graph.get_node("control:nist-800-53:ac-1")
+        assert node is not None
+        assert node["type"] == "Control"
+        assert node["title"] == "Access Control Policy"
+        assert node["family"] == "Access Control"
+
+        # Framework → Control edge
+        edges = graph.get_edges("framework:nist-800-53", "control:nist-800-53:ac-1")
+        assert any(e["relationship"] == "CONTAINS" for e in edges)
+
+    def test_add_policy_creates_policy_node(self):
+        """Adding a policy creates a Policy node."""
+        graph = ComplianceGraph()
+        graph.add_policy("access-control.md", title="Access Control Policy")
+
+        node = graph.get_node("policy:access-control.md")
+        assert node is not None
+        assert node["type"] == "Policy"
+
+    def test_add_mapping_creates_satisfies_edge(self):
+        """Adding a mapping creates a SATISFIES edge from policy to control."""
+        graph = ComplianceGraph()
+        graph.add_framework("nist-800-53", title="NIST SP 800-53 Rev 5")
+        graph.add_control(
+            framework="nist-800-53",
+            control_id="ac-1",
+            title="Access Control Policy",
+            family="Access Control",
+        )
+        graph.add_policy("access-control.md", title="Access Control Policy")
+        graph.add_mapping(
+            policy="access-control.md",
+            framework="nist-800-53",
+            control_id="ac-1",
+            confidence=0.92,
+        )
+
+        edges = graph.get_edges("policy:access-control.md", "control:nist-800-53:ac-1")
+        assert len(edges) >= 1
+        assert edges[0]["relationship"] == "SATISFIES"
+        assert edges[0]["confidence"] == 0.92
+
+    def test_add_harmonization_creates_harmonized_with_edge(self):
+        """Adding harmonization creates HARMONIZED_WITH edges between controls."""
+        graph = ComplianceGraph()
+        graph.add_framework("nist-800-53", title="NIST SP 800-53 Rev 5")
+        graph.add_framework("nist-csf-2.0", title="NIST CSF 2.0")
+        graph.add_control(
+            framework="nist-800-53",
+            control_id="ac-1",
+            title="Access Control Policy",
+            family="Access Control",
+        )
+        graph.add_control(
+            framework="nist-csf-2.0",
+            control_id="pr.ac-01",
+            title="Identity Management",
+            family="Protect",
+        )
+        graph.add_harmonization(
+            framework_a="nist-800-53",
+            control_a="ac-1",
+            framework_b="nist-csf-2.0",
+            control_b="pr.ac-01",
+            similarity=0.88,
+        )
+
+        edges = graph.get_edges("control:nist-800-53:ac-1", "control:nist-csf-2.0:pr.ac-01")
+        assert len(edges) >= 1
+        assert edges[0]["relationship"] == "HARMONIZED_WITH"
+        assert edges[0]["similarity"] == 0.88
+
+    def test_populate_from_controls(self):
+        """populate_from_controls bulk-loads a framework's control records."""
+        graph = ComplianceGraph()
+        controls = [
+            {"id": "ac-1", "title": "Access Control", "prose": "...", "family": "AC"},
+            {"id": "ir-1", "title": "Incident Response", "prose": "...", "family": "IR"},
+        ]
+        graph.populate_from_controls("test-fw", controls)
+
+        assert graph.get_node("framework:test-fw") is not None
+        assert graph.get_node("control:test-fw:ac-1") is not None
+        assert graph.get_node("control:test-fw:ir-1") is not None
+        assert graph.framework_control_count("test-fw") == 2
+
+    def test_query_neighbors(self):
+        """query_neighbors returns connected nodes."""
+        graph = ComplianceGraph()
+        graph.add_framework("fw", title="Test")
+        graph.add_control(framework="fw", control_id="c1", title="C1", family="F")
+        graph.add_control(framework="fw", control_id="c2", title="C2", family="F")
+
+        neighbors = graph.query_neighbors("framework:fw")
+        node_ids = {n["id"] for n in neighbors}
+        assert "control:fw:c1" in node_ids
+        assert "control:fw:c2" in node_ids
+
+    def test_impact_analysis(self):
+        """impact returns all controls and frameworks affected by a policy."""
+        graph = ComplianceGraph()
+        graph.add_framework("fw-a", title="Framework A")
+        graph.add_framework("fw-b", title="Framework B")
+        graph.add_control(framework="fw-a", control_id="c1", title="C1", family="F")
+        graph.add_control(framework="fw-b", control_id="c2", title="C2", family="F")
+        graph.add_policy("policy.md", title="My Policy")
+        graph.add_mapping(policy="policy.md", framework="fw-a", control_id="c1", confidence=0.9)
+        graph.add_harmonization(
+            framework_a="fw-a",
+            control_a="c1",
+            framework_b="fw-b",
+            control_b="c2",
+            similarity=0.85,
+        )
+
+        impact = graph.impact("policy:policy.md")
+        assert "fw-a" in impact["frameworks"]
+        assert any(c["id"] == "c1" for c in impact["controls"])
+
+    def test_export_json(self):
+        """export_json produces a serializable dict with nodes and edges."""
+        graph = ComplianceGraph()
+        graph.add_framework("fw", title="Test")
+        graph.add_control(framework="fw", control_id="c1", title="C1", family="F")
+
+        data = graph.export_json()
+        assert "nodes" in data
+        assert "edges" in data
+        assert len(data["nodes"]) == 2
+        assert len(data["edges"]) == 1
+
+    def test_idempotent_population(self):
+        """Populating the same framework twice does not create duplicate nodes."""
+        graph = ComplianceGraph()
+        controls = [
+            {"id": "ac-1", "title": "Access Control", "prose": "...", "family": "AC"},
+        ]
+        graph.populate_from_controls("fw", controls)
+        graph.populate_from_controls("fw", controls)
+
+        assert graph.framework_control_count("fw") == 1
+        assert len(graph.export_json()["nodes"]) == 2  # 1 framework + 1 control


### PR DESCRIPTION
## Description

Implements the compliance knowledge graph as the foundation for Phase 2 — Intelligence Layer (Issue #19). Uses NetworkX as a lightweight, embedded graph engine — no external database required.

**Node types:** Framework, Control, Policy — with typed IDs (`framework:nist-800-53`, `control:nist-800-53:ac-1`, `policy:access-control.md`)

**Edge types:**
- `CONTAINS` — Framework → Control
- `SATISFIES` — Policy → Control (with confidence score)
- `HARMONIZED_WITH` — Control ↔ Control (bidirectional, with similarity score)

**Operations:** Bulk population from control records (idempotent), neighbor queries, bidirectional impact analysis (traces policy → controls → frameworks and back), JSON export for D3.js/Cytoscape rendering.

This PR covers the data model and in-memory graph engine. CLI commands (`lemma query`, `lemma impact`) and graph visualization will follow in subsequent PRs.

Refs #19

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` with no errors
- [x] I have run `ruff format`
- [x] I have run `pytest` and all tests pass (152 passed, 91% coverage)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors