### PR TITLE
feat(transparency): Integrate trace logging into mapper pipeline

### DIFF
--- a/src/lemma/models/trace.py
+++ b/src/lemma/models/trace.py
@@ -1,0 +1,74 @@
+"""AI trace model — structured audit trail for every AI decision.
+
+Every AI operation in Lemma (mapping, evaluation, summarization) produces
+an AITrace record. Traces are append-only and version-controlled, ensuring
+full transparency and auditability of AI-generated compliance assertions.
+
+Trace lifecycle:
+    PROPOSED → ACCEPTED (engineer approves)
+    PROPOSED → REJECTED (engineer rejects with rationale)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class TraceStatus(StrEnum):
+    """Review status for an AI trace entry.
+
+    Attributes:
+        PROPOSED: AI output awaiting human review.
+        ACCEPTED: Engineer has approved the AI determination.
+        REJECTED: Engineer has rejected with rationale.
+    """
+
+    PROPOSED = "PROPOSED"
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+
+
+class AITrace(BaseModel):
+    """A single AI decision trace record.
+
+    Captures the full context of an AI operation: what went in,
+    what prompt was used, which model produced the output, and
+    the resulting determination with confidence.
+
+    Attributes:
+        trace_id: Unique identifier for this trace entry.
+        timestamp: UTC timestamp of when the trace was created.
+        operation: Type of AI operation (e.g., 'map', 'evaluate').
+        input_text: The input text provided to the AI.
+        prompt: The full prompt sent to the model.
+        model_id: Model identifier (e.g., 'ollama/llama3.2').
+        model_version: Model version string.
+        raw_output: The raw response from the model.
+        confidence: AI-generated confidence score (0.0-1.0).
+        determination: The AI's determination (e.g., 'MAPPED', 'LOW_CONFIDENCE').
+        control_id: Target control identifier.
+        framework: Target framework name.
+        status: Human review status (PROPOSED, ACCEPTED, REJECTED).
+        review_rationale: Rationale for acceptance/rejection (required for REJECTED).
+        parent_trace_id: For review entries, the trace_id of the original trace.
+    """
+
+    trace_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    operation: str
+    input_text: str
+    prompt: str
+    model_id: str
+    model_version: str
+    raw_output: str
+    confidence: float
+    determination: str
+    control_id: str
+    framework: str
+    status: TraceStatus = TraceStatus.PROPOSED
+    review_rationale: str = ""
+    parent_trace_id: str = ""

--- a/src/lemma/services/mapper.py
+++ b/src/lemma/services/mapper.py
@@ -4,7 +4,8 @@ Orchestrates the full mapping pipeline:
 1. Chunk policy documents
 2. Retrieve similar controls via vector search
 3. Enrich with LLM-generated rationales and confidence scores
-4. Aggregate results into a MappingReport
+4. Log every AI decision to the append-only trace log
+5. Aggregate results into a MappingReport
 """
 
 from __future__ import annotations
@@ -13,9 +14,11 @@ import json
 from pathlib import Path
 
 from lemma.models.mapping import MappingReport, MappingResult
+from lemma.models.trace import AITrace
 from lemma.services.chunker import chunk_policies
 from lemma.services.indexer import ControlIndexer
 from lemma.services.llm import LLMClient
+from lemma.services.trace_log import TraceLog
 
 _MAPPING_PROMPT = """\
 You are a GRC compliance analyst. Given a policy excerpt and a security control, \
@@ -35,6 +38,25 @@ Example: {{"confidence": 0.85, "rationale": "The policy directly addresses..."}}
 """
 
 
+def _get_model_id(llm_client: LLMClient) -> str:
+    """Extract model identifier from an LLM client.
+
+    Args:
+        llm_client: LLM client instance.
+
+    Returns:
+        Model identifier string (e.g., 'ollama/llama3.2').
+    """
+    model = str(getattr(llm_client, "model", "unknown"))
+    # Determine provider from class name
+    class_name = type(llm_client).__name__.lower()
+    if "ollama" in class_name:
+        return f"ollama/{model}"
+    if "openai" in class_name:
+        return f"openai/{model}"
+    return model
+
+
 def map_policies(
     *,
     framework: str,
@@ -45,6 +67,9 @@ def map_policies(
     output_format: str = "json",
 ) -> MappingReport:
     """Run the full control mapping pipeline.
+
+    Every AI call is automatically logged to the append-only trace log
+    at ``<project_dir>/.lemma/traces/``.
 
     Args:
         framework: Name of the indexed framework to map against.
@@ -74,6 +99,10 @@ def map_policies(
         msg = "No policy documents found in policies/. Add .md files and try again."
         raise ValueError(msg)
 
+    # Initialize trace log
+    trace_log = TraceLog(log_dir=project_dir / ".lemma" / "traces")
+    model_id = _get_model_id(llm_client)
+
     # Map each chunk to controls
     results: list[MappingResult] = []
 
@@ -100,6 +129,22 @@ def map_policies(
                 rationale = f"LLM response could not be parsed: {raw_response[:200]}"
 
             status = "MAPPED" if confidence >= threshold else "LOW_CONFIDENCE"
+
+            # Log trace entry for this AI decision
+            trace_log.append(
+                AITrace(
+                    operation="map",
+                    input_text=chunk["text"][:500],
+                    prompt=prompt,
+                    model_id=model_id,
+                    model_version="",
+                    raw_output=raw_response,
+                    confidence=confidence,
+                    determination=status,
+                    control_id=candidate["control_id"],
+                    framework=framework,
+                )
+            )
 
             results.append(
                 MappingResult(

--- a/src/lemma/services/trace_log.py
+++ b/src/lemma/services/trace_log.py
@@ -1,0 +1,148 @@
+"""Append-only AI trace log — tamper-evident audit trail.
+
+Stores AITrace records as newline-delimited JSON (JSONL) files,
+organized by date. The log is strictly append-only: there are no
+update, delete, or clear operations.
+
+File layout:
+    .lemma/traces/
+        2026-04-21.jsonl
+        2026-04-22.jsonl
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lemma.models.trace import AITrace, TraceStatus
+
+
+class TraceLog:
+    """Append-only trace log for AI decision audit trail.
+
+    Args:
+        log_dir: Directory where JSONL trace files are stored.
+    """
+
+    def __init__(self, log_dir: Path) -> None:
+        """Initialize the trace log.
+
+        Args:
+            log_dir: Path to the trace log directory.
+        """
+        self._log_dir = log_dir
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+
+    def _log_file(self, dt: datetime | None = None) -> Path:
+        """Get the log file path for a given date.
+
+        Args:
+            dt: Datetime to determine the file. Defaults to now (UTC).
+
+        Returns:
+            Path to the JSONL log file.
+        """
+        if dt is None:
+            dt = datetime.now(UTC)
+        return self._log_dir / f"{dt.strftime('%Y-%m-%d')}.jsonl"
+
+    def append(self, trace: AITrace) -> None:
+        """Append a trace entry to the log.
+
+        Args:
+            trace: The AITrace record to persist.
+        """
+        log_file = self._log_file(trace.timestamp)
+        with log_file.open("a") as f:
+            f.write(trace.model_dump_json() + "\n")
+
+    def read_all(self) -> list[AITrace]:
+        """Read all trace entries from all log files.
+
+        Returns:
+            List of AITrace records, ordered by file then line.
+        """
+        traces: list[AITrace] = []
+        for log_file in sorted(self._log_dir.glob("*.jsonl")):
+            for line in log_file.read_text().strip().splitlines():
+                if line.strip():
+                    traces.append(AITrace.model_validate_json(line))
+        return traces
+
+    def filter_by_model(self, model_id: str) -> list[AITrace]:
+        """Return traces produced by a specific model.
+
+        Args:
+            model_id: Model identifier to filter by.
+
+        Returns:
+            List of matching AITrace records.
+        """
+        return [t for t in self.read_all() if t.model_id == model_id]
+
+    def filter_by_operation(self, operation: str) -> list[AITrace]:
+        """Return traces of a specific operation type.
+
+        Args:
+            operation: Operation type to filter by (e.g., 'map').
+
+        Returns:
+            List of matching AITrace records.
+        """
+        return [t for t in self.read_all() if t.operation == operation]
+
+    def review(
+        self,
+        trace_id: str,
+        *,
+        status: TraceStatus,
+        rationale: str = "",
+    ) -> None:
+        """Record a human review decision for a trace.
+
+        Creates a new trace entry linked to the original via parent_trace_id.
+        This preserves the append-only property - the original is never modified.
+
+        Args:
+            trace_id: The trace_id of the entry being reviewed.
+            status: The new review status (ACCEPTED or REJECTED).
+            rationale: Required rationale for REJECTED status.
+
+        Raises:
+            ValueError: If rejecting without a rationale.
+            ValueError: If the trace_id is not found.
+        """
+        if status == TraceStatus.REJECTED and not rationale:
+            msg = "Rationale is required when rejecting an AI determination."
+            raise ValueError(msg)
+
+        # Find the original trace
+        original = None
+        for trace in self.read_all():
+            if trace.trace_id == trace_id:
+                original = trace
+                break
+
+        if original is None:
+            msg = f"Trace ID '{trace_id}' not found in log."
+            raise ValueError(msg)
+
+        # Create a review entry linked to the original
+        review_entry = AITrace(
+            operation=original.operation,
+            input_text=original.input_text,
+            prompt=original.prompt,
+            model_id=original.model_id,
+            model_version=original.model_version,
+            raw_output=original.raw_output,
+            confidence=original.confidence,
+            determination=original.determination,
+            control_id=original.control_id,
+            framework=original.framework,
+            status=status,
+            review_rationale=rationale,
+            parent_trace_id=trace_id,
+        )
+
+        self.append(review_entry)

--- a/tests/services/test_mapper.py
+++ b/tests/services/test_mapper.py
@@ -188,3 +188,137 @@ class TestMapper:
                 project_dir=tmp_path,
                 llm_client=mock_llm,
             )
+
+
+class TestMapperTraceIntegration:
+    """Tests for automatic trace logging during mapping."""
+
+    def test_map_writes_trace_entries(self, tmp_path):
+        """map_policies writes an AITrace entry for each AI call."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "access.md").write_text("# Access Control\n\nAll users must use MFA.\n")
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-7",
+                    "title": "Unsuccessful Logon Attempts",
+                    "prose": "Enforce lockout after failed logon attempts.",
+                    "family": "AC",
+                },
+            ],
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.9, "rationale": "MFA maps to logon controls."}
+        )
+
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+        )
+
+        # Verify trace entries were written
+        trace_log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        traces = trace_log.read_all()
+
+        assert len(traces) >= 1
+        trace = traces[0]
+        assert trace.operation == "map"
+        assert trace.model_id != ""
+        assert trace.confidence == 0.9
+        assert trace.control_id == "ac-7"
+        assert trace.framework == "nist-800-53"
+        assert trace.status.value == "PROPOSED"
+
+    def test_trace_contains_prompt_and_output(self, tmp_path):
+        """Trace entries include the full prompt and raw model output."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "test.md").write_text("# Test Policy\n\nEncrypt all data at rest.\n")
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "test-fw",
+            [
+                {
+                    "id": "sc-28",
+                    "title": "Protection of Information at Rest",
+                    "prose": "Protect confidentiality of data at rest.",
+                    "family": "SC",
+                },
+            ],
+        )
+
+        raw_response = '{"confidence": 0.92, "rationale": "Direct encryption match."}'
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = raw_response
+
+        map_policies(
+            framework="test-fw",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+        )
+
+        trace_log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        traces = trace_log.read_all()
+
+        assert len(traces) >= 1
+        trace = traces[0]
+        # Prompt should contain the policy text and control info
+        assert "Encrypt all data" in trace.input_text
+        assert "sc-28" in trace.prompt.lower() or "SC-28" in trace.prompt
+        assert trace.raw_output == raw_response
+
+    def test_trace_records_llm_parse_failure(self, tmp_path):
+        """When LLM returns unparseable output, trace still records it."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        lemma_dir = tmp_path / ".lemma"
+        lemma_dir.mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "test.md").write_text("# Test\n\nSome policy.\n")
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "test-fw",
+            [{"id": "c-1", "title": "C1", "prose": "Test.", "family": "F"}],
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = "NOT VALID JSON"
+
+        map_policies(
+            framework="test-fw",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+        )
+
+        trace_log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        traces = trace_log.read_all()
+
+        assert len(traces) >= 1
+        trace = traces[0]
+        assert trace.confidence == 0.0
+        assert trace.raw_output == "NOT VALID JSON"

--- a/tests/services/test_trace_log.py
+++ b/tests/services/test_trace_log.py
@@ -1,0 +1,325 @@
+"""Tests for the AI trace log — append-only audit trail for AI decisions.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lemma.models.trace import AITrace, TraceStatus
+from lemma.services.trace_log import TraceLog
+
+
+class TestAITraceModel:
+    """Tests for the AITrace Pydantic model."""
+
+    def test_trace_has_required_fields(self):
+        """AITrace model has all required schema fields."""
+        trace = AITrace(
+            operation="map",
+            input_text="MFA is required for all users",
+            prompt="You are a GRC compliance analyst...",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output='{"confidence": 0.85, "rationale": "..."}',
+            confidence=0.85,
+            determination="MAPPED",
+            control_id="ac-7",
+            framework="nist-800-53",
+        )
+
+        assert trace.operation == "map"
+        assert trace.model_id == "ollama/llama3.2"
+        assert trace.confidence == 0.85
+        assert trace.determination == "MAPPED"
+        assert trace.timestamp is not None
+
+    def test_trace_defaults_to_proposed_status(self):
+        """Traces default to PROPOSED review status."""
+        trace = AITrace(
+            operation="map",
+            input_text="test",
+            prompt="test",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output="test",
+            confidence=0.5,
+            determination="LOW_CONFIDENCE",
+            control_id="ac-1",
+            framework="nist-800-53",
+        )
+
+        assert trace.status == TraceStatus.PROPOSED
+
+    def test_trace_serializes_to_json(self):
+        """AITrace can be serialized to JSON."""
+        trace = AITrace(
+            operation="map",
+            input_text="test input",
+            prompt="test prompt",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output='{"confidence": 0.9}',
+            confidence=0.9,
+            determination="MAPPED",
+            control_id="ac-1",
+            framework="nist-800-53",
+        )
+
+        data = json.loads(trace.model_dump_json())
+        assert data["operation"] == "map"
+        assert data["model_id"] == "ollama/llama3.2"
+        assert "timestamp" in data
+        assert "trace_id" in data
+
+
+class TestTraceLog:
+    """Tests for the append-only trace log."""
+
+    def test_append_writes_trace_to_file(self, tmp_path: Path):
+        """append() writes a trace entry as a JSON line."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        trace = AITrace(
+            operation="map",
+            input_text="test",
+            prompt="test prompt",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output="output",
+            confidence=0.8,
+            determination="MAPPED",
+            control_id="ac-1",
+            framework="nist-800-53",
+        )
+
+        log.append(trace)
+
+        log_files = list((tmp_path / ".lemma" / "traces").glob("*.jsonl"))
+        assert len(log_files) == 1
+        lines = log_files[0].read_text().strip().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["operation"] == "map"
+
+    def test_append_is_additive(self, tmp_path: Path):
+        """Multiple appends add lines without overwriting."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        for i in range(3):
+            trace = AITrace(
+                operation="map",
+                input_text=f"policy {i}",
+                prompt="prompt",
+                model_id="ollama/llama3.2",
+                model_version="3.2",
+                raw_output="output",
+                confidence=0.5 + i * 0.1,
+                determination="MAPPED",
+                control_id=f"ac-{i}",
+                framework="nist-800-53",
+            )
+            log.append(trace)
+
+        log_files = list((tmp_path / ".lemma" / "traces").glob("*.jsonl"))
+        lines = log_files[0].read_text().strip().splitlines()
+        assert len(lines) == 3
+
+    def test_read_all_returns_all_traces(self, tmp_path: Path):
+        """read_all() returns all trace entries from the log."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        for i in range(2):
+            trace = AITrace(
+                operation="map",
+                input_text=f"text {i}",
+                prompt="prompt",
+                model_id="ollama/llama3.2",
+                model_version="3.2",
+                raw_output="out",
+                confidence=0.7,
+                determination="MAPPED",
+                control_id=f"c-{i}",
+                framework="fw",
+            )
+            log.append(trace)
+
+        all_traces = log.read_all()
+        assert len(all_traces) == 2
+        assert all(isinstance(t, AITrace) for t in all_traces)
+
+    def test_filter_by_model(self, tmp_path: Path):
+        """filter_by_model() returns only traces from a specific model."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        log.append(
+            AITrace(
+                operation="map",
+                input_text="a",
+                prompt="p",
+                model_id="ollama/llama3.2",
+                model_version="3.2",
+                raw_output="o",
+                confidence=0.8,
+                determination="MAPPED",
+                control_id="c-1",
+                framework="fw",
+            )
+        )
+        log.append(
+            AITrace(
+                operation="map",
+                input_text="b",
+                prompt="p",
+                model_id="openai/gpt-4o-mini",
+                model_version="2024-07-18",
+                raw_output="o",
+                confidence=0.9,
+                determination="MAPPED",
+                control_id="c-2",
+                framework="fw",
+            )
+        )
+
+        ollama_traces = log.filter_by_model("ollama/llama3.2")
+        assert len(ollama_traces) == 1
+        assert ollama_traces[0].model_id == "ollama/llama3.2"
+
+    def test_filter_by_operation(self, tmp_path: Path):
+        """filter_by_operation() returns only traces of a specific type."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        log.append(
+            AITrace(
+                operation="map",
+                input_text="a",
+                prompt="p",
+                model_id="m",
+                model_version="1",
+                raw_output="o",
+                confidence=0.8,
+                determination="MAPPED",
+                control_id="c-1",
+                framework="fw",
+            )
+        )
+        log.append(
+            AITrace(
+                operation="evaluate",
+                input_text="b",
+                prompt="p",
+                model_id="m",
+                model_version="1",
+                raw_output="o",
+                confidence=0.9,
+                determination="PASS",
+                control_id="c-2",
+                framework="fw",
+            )
+        )
+
+        map_traces = log.filter_by_operation("map")
+        assert len(map_traces) == 1
+        assert map_traces[0].operation == "map"
+
+    def test_trace_log_is_immutable(self, tmp_path: Path):
+        """Existing trace entries cannot be modified via the TraceLog API."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        trace = AITrace(
+            operation="map",
+            input_text="original",
+            prompt="p",
+            model_id="m",
+            model_version="1",
+            raw_output="o",
+            confidence=0.8,
+            determination="MAPPED",
+            control_id="c-1",
+            framework="fw",
+        )
+        log.append(trace)
+
+        # TraceLog has no update/delete methods
+        assert not hasattr(log, "update")
+        assert not hasattr(log, "delete")
+        assert not hasattr(log, "clear")
+
+    def test_review_trace_transitions_status(self, tmp_path: Path):
+        """review() appends a new trace entry with updated status."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        trace = AITrace(
+            operation="map",
+            input_text="text",
+            prompt="p",
+            model_id="m",
+            model_version="1",
+            raw_output="o",
+            confidence=0.9,
+            determination="MAPPED",
+            control_id="c-1",
+            framework="fw",
+        )
+        log.append(trace)
+
+        log.review(trace.trace_id, status=TraceStatus.ACCEPTED)
+
+        all_traces = log.read_all()
+        # Original + review entry
+        assert len(all_traces) == 2
+        review_entry = all_traces[-1]
+        assert review_entry.status == TraceStatus.ACCEPTED
+
+    def test_review_rejected_requires_rationale(self, tmp_path: Path):
+        """Rejecting a trace without a rationale raises ValueError."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        trace = AITrace(
+            operation="map",
+            input_text="text",
+            prompt="p",
+            model_id="m",
+            model_version="1",
+            raw_output="o",
+            confidence=0.5,
+            determination="LOW_CONFIDENCE",
+            control_id="c-1",
+            framework="fw",
+        )
+        log.append(trace)
+
+        with pytest.raises(ValueError, match=r"[Rr]ationale"):
+            log.review(trace.trace_id, status=TraceStatus.REJECTED)
+
+    def test_review_rejected_with_rationale_succeeds(self, tmp_path: Path):
+        """Rejecting a trace with a rationale succeeds."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+
+        trace = AITrace(
+            operation="map",
+            input_text="text",
+            prompt="p",
+            model_id="m",
+            model_version="1",
+            raw_output="o",
+            confidence=0.5,
+            determination="LOW_CONFIDENCE",
+            control_id="c-1",
+            framework="fw",
+        )
+        log.append(trace)
+
+        log.review(
+            trace.trace_id,
+            status=TraceStatus.REJECTED,
+            rationale="Control is not relevant to this policy scope.",
+        )
+
+        all_traces = log.read_all()
+        rejection = all_traces[-1]
+        assert rejection.status == TraceStatus.REJECTED
+        assert "not relevant" in rejection.review_rationale


### PR DESCRIPTION
## Description

Wires the AI trace log (PR #72) into the mapping engine so that every `lemma map` invocation automatically generates structured audit trail entries. This is the critical integration that makes AI transparency operational — not just a data model, but an active part of the pipeline.

**What changes:**
- `map_policies()` now initializes a `TraceLog` and writes an `AITrace` entry for each LLM call
- Model ID extracted from LLM client class (e.g., `ollama/llama3.2`, `openai/gpt-4o-mini`)
- Failed LLM parse attempts are still recorded (confidence 0.0, raw output preserved)
- All traces default to `PROPOSED` status for human-in-the-loop review

Refs #20

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` with no errors
- [x] I have run `ruff format`
- [x] I have run `pytest` and all tests pass (157 passed, 92.17% coverage)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors