### PR TITLE
feat(graph): Auto-populate knowledge graph from framework add and map

### DIFF
--- a/src/lemma/cli.py
+++ b/src/lemma/cli.py
@@ -10,11 +10,13 @@ Usage:
     lemma coverage       Per-framework coverage percentages
     lemma gaps           Identify unmapped controls
     lemma diff           Compare framework versions
+    lemma graph          Query the compliance knowledge graph
 """
 
 import typer
 
 from lemma.commands.framework import framework_app
+from lemma.commands.graph import graph_app
 from lemma.commands.harmonize import (
     coverage_command,
     diff_command,
@@ -41,6 +43,7 @@ app.command(name="coverage", help="Per-framework coverage percentages")(coverage
 app.command(name="gaps", help="Identify unmapped controls")(gaps_command)
 app.command(name="diff", help="Compare framework versions")(diff_command)
 app.add_typer(framework_app, name="framework", help="Manage compliance frameworks")
+app.add_typer(graph_app, name="graph", help="Query the compliance knowledge graph")
 
 
 if __name__ == "__main__":

--- a/src/lemma/commands/graph.py
+++ b/src/lemma/commands/graph.py
@@ -1,0 +1,100 @@
+"""Implementation of the `lemma graph` CLI commands.
+
+Provides sub-commands for querying the compliance knowledge graph:
+    lemma graph export          — Export the graph as JSON
+    lemma graph impact <node>   — Show compliance impact of a node
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from lemma.services.knowledge_graph import ComplianceGraph
+
+console = Console()
+
+graph_app = typer.Typer(
+    name="graph",
+    help="Query the compliance knowledge graph.",
+    no_args_is_help=True,
+)
+
+
+def _require_lemma_project() -> Path:
+    """Verify CWD is an initialized Lemma project, return project dir."""
+    cwd = Path.cwd()
+    if not (cwd / ".lemma").exists():
+        console.print("[red]Error:[/red] Not a Lemma project.")
+        console.print("Run [bold]lemma init[/bold] first.")
+        raise typer.Exit(code=1)
+    return cwd
+
+
+def _load_graph(project_dir: Path) -> ComplianceGraph:
+    """Load the project's knowledge graph.
+
+    Args:
+        project_dir: Root of the Lemma project.
+
+    Returns:
+        ComplianceGraph instance (empty if no graph file exists).
+    """
+    return ComplianceGraph.load(project_dir / ".lemma" / "graph.json")
+
+
+@graph_app.command(name="export", help="Export the knowledge graph as JSON.")
+def export_command() -> None:
+    """Export the full compliance graph as JSON for visualization."""
+    project_dir = _require_lemma_project()
+    graph = _load_graph(project_dir)
+
+    data = graph.export_json()
+    console.print(json.dumps(data, indent=2))
+
+
+@graph_app.command(name="impact", help="Analyze compliance impact of a node.")
+def impact_command(
+    node_id: str = typer.Argument(
+        help="Node ID to analyze (e.g., policy:access-control.md, control:nist-800-53:ac-1)"
+    ),
+) -> None:
+    """Show all controls and frameworks affected by a node."""
+    project_dir = _require_lemma_project()
+    graph = _load_graph(project_dir)
+
+    result = graph.impact(node_id)
+
+    controls = result.get("controls", [])
+    frameworks = result.get("frameworks", [])
+
+    if not controls and not frameworks:
+        console.print(
+            f"[dim]No impact found for [bold]{node_id}[/bold]. 0 controls affected.[/dim]"
+        )
+        return
+
+    console.print(f"\n[bold]Impact Analysis: {node_id}[/bold]\n")
+
+    if frameworks:
+        console.print(f"[cyan]Frameworks affected:[/cyan] {', '.join(frameworks)}")
+        console.print()
+
+    if controls:
+        table = Table(title=f"Controls Affected ({len(controls)})")
+        table.add_column("Control ID", style="bold")
+        table.add_column("Title")
+        table.add_column("Family")
+
+        for ctrl in controls:
+            table.add_row(
+                ctrl.get("control_id", ""),
+                ctrl.get("title", ""),
+                ctrl.get("family", ""),
+            )
+
+        console.print(table)

--- a/src/lemma/services/framework.py
+++ b/src/lemma/services/framework.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 
 from lemma.services.indexer import ControlIndexer
+from lemma.services.knowledge_graph import ComplianceGraph
 from lemma.services.parsers.oscal import parse_catalog
 
 
@@ -62,6 +63,12 @@ def add_bundled_framework(name: str, *, project_dir: Path) -> dict:
 
     indexer = ControlIndexer(index_dir=project_dir / ".lemma" / "index")
     indexer.index_controls(name, controls)
+
+    # Populate knowledge graph
+    graph_path = project_dir / ".lemma" / "graph.json"
+    graph = ComplianceGraph.load(graph_path)
+    graph.populate_from_controls(name, controls)
+    graph.save(graph_path)
 
     return {
         "name": name,
@@ -154,6 +161,12 @@ def import_framework(file_path: Path, *, project_dir: Path) -> dict:
 
     indexer = ControlIndexer(index_dir=project_dir / ".lemma" / "index")
     indexer.index_controls(name, controls)
+
+    # Populate knowledge graph
+    graph_path = project_dir / ".lemma" / "graph.json"
+    graph = ComplianceGraph.load(graph_path)
+    graph.populate_from_controls(name, controls)
+    graph.save(graph_path)
 
     return {
         "name": name,

--- a/src/lemma/services/knowledge_graph.py
+++ b/src/lemma/services/knowledge_graph.py
@@ -17,6 +17,8 @@ Edge types:
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import networkx as nx
@@ -292,3 +294,33 @@ class ComplianceGraph:
             edges.append({"source": source, "target": target, **attrs})
 
         return {"nodes": nodes, "edges": edges}
+
+    # --- Persistence ---
+
+    def save(self, path: Path) -> None:
+        """Save the graph to a JSON file.
+
+        Args:
+            path: File path to save the graph to.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = nx.node_link_data(self._graph)
+        path.write_text(json.dumps(data, indent=2, default=str))
+
+    @classmethod
+    def load(cls, path: Path) -> ComplianceGraph:
+        """Load a graph from a JSON file.
+
+        If the file does not exist, returns an empty graph.
+
+        Args:
+            path: File path to load the graph from.
+
+        Returns:
+            Loaded ComplianceGraph instance.
+        """
+        instance = cls()
+        if path.exists():
+            data = json.loads(path.read_text())
+            instance._graph = nx.node_link_graph(data, directed=True, multigraph=True)
+        return instance

--- a/src/lemma/services/mapper.py
+++ b/src/lemma/services/mapper.py
@@ -17,6 +17,7 @@ from lemma.models.mapping import MappingReport, MappingResult
 from lemma.models.trace import AITrace
 from lemma.services.chunker import chunk_policies
 from lemma.services.indexer import ControlIndexer
+from lemma.services.knowledge_graph import ComplianceGraph
 from lemma.services.llm import LLMClient
 from lemma.services.trace_log import TraceLog
 
@@ -157,6 +158,30 @@ def map_policies(
                     status=status,
                 )
             )
+
+    # Populate knowledge graph with mapping results
+    graph_path = project_dir / ".lemma" / "graph.json"
+    graph = ComplianceGraph.load(graph_path)
+
+    # Track unique policy sources to add as nodes
+    seen_policies: set[str] = set()
+    for result in results:
+        # Extract policy filename from chunk_id (e.g., 'access-control.md#1')
+        policy_path = result.chunk_id.split("#")[0]
+        if policy_path not in seen_policies:
+            graph.add_policy(policy_path, title=policy_path)
+            seen_policies.add(policy_path)
+
+        # Only add SATISFIES edges for MAPPED results
+        if result.status == "MAPPED":
+            graph.add_mapping(
+                policy=policy_path,
+                framework=framework,
+                control_id=result.control_id,
+                confidence=result.confidence,
+            )
+
+    graph.save(graph_path)
 
     return MappingReport(
         framework=framework,

--- a/tests/commands/test_graph_cli.py
+++ b/tests/commands/test_graph_cli.py
@@ -1,0 +1,143 @@
+"""Tests for graph persistence and CLI integration.
+
+Tests the save/load cycle for the knowledge graph and the
+`lemma graph` CLI commands.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from lemma.services.knowledge_graph import ComplianceGraph
+
+runner = CliRunner()
+
+
+class TestGraphPersistence:
+    """Tests for graph save/load to disk."""
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path):
+        """Graph can be saved to JSON and loaded back with all data intact."""
+        graph = ComplianceGraph()
+        graph.add_framework("fw", title="Test Framework")
+        graph.add_control(framework="fw", control_id="c-1", title="Control 1", family="F")
+        graph.add_policy("policy.md", title="My Policy")
+        graph.add_mapping(policy="policy.md", framework="fw", control_id="c-1", confidence=0.9)
+
+        save_path = tmp_path / "graph.json"
+        graph.save(save_path)
+
+        loaded = ComplianceGraph.load(save_path)
+        assert loaded.get_node("framework:fw") is not None
+        assert loaded.get_node("control:fw:c-1") is not None
+        assert loaded.get_node("policy:policy.md") is not None
+        assert loaded.framework_control_count("fw") == 1
+
+        edges = loaded.get_edges("policy:policy.md", "control:fw:c-1")
+        assert len(edges) >= 1
+        assert edges[0]["confidence"] == 0.9
+
+    def test_load_nonexistent_returns_empty_graph(self, tmp_path: Path):
+        """Loading from a nonexistent path returns an empty graph."""
+        graph = ComplianceGraph.load(tmp_path / "nonexistent.json")
+        assert graph.export_json()["nodes"] == []
+
+    def test_save_creates_parent_directories(self, tmp_path: Path):
+        """save() creates parent directories if they don't exist."""
+        graph = ComplianceGraph()
+        graph.add_framework("fw", title="Test")
+
+        save_path = tmp_path / "deep" / "nested" / "graph.json"
+        graph.save(save_path)
+
+        assert save_path.exists()
+
+
+class TestGraphExportCommand:
+    """Tests for the `lemma graph export` CLI command."""
+
+    def test_graph_export_outputs_json(self, tmp_path: Path, monkeypatch):
+        """lemma graph export outputs the graph as JSON."""
+        from lemma.cli import app
+
+        # Initialize project
+        (tmp_path / ".lemma").mkdir()
+        (tmp_path / ".lemma" / "index").mkdir(parents=True)
+
+        # Pre-populate graph
+        graph = ComplianceGraph()
+        graph.add_framework("nist-800-53", title="NIST 800-53")
+        graph.add_control(
+            framework="nist-800-53",
+            control_id="ac-1",
+            title="Access Control",
+            family="AC",
+        )
+        graph_path = tmp_path / ".lemma" / "graph.json"
+        graph.save(graph_path)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["graph", "export"])
+        assert result.exit_code == 0
+
+        output = json.loads(result.stdout)
+        assert "nodes" in output
+        assert "edges" in output
+        assert len(output["nodes"]) == 2
+
+    def test_graph_export_empty_project(self, tmp_path: Path, monkeypatch):
+        """lemma graph export with no graph outputs empty structure."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["graph", "export"])
+        assert result.exit_code == 0
+
+        output = json.loads(result.stdout)
+        assert output["nodes"] == []
+        assert output["edges"] == []
+
+
+class TestImpactCommand:
+    """Tests for the `lemma graph impact` CLI command."""
+
+    def test_impact_shows_affected_controls(self, tmp_path: Path, monkeypatch):
+        """lemma graph impact shows controls and frameworks affected by a node."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+
+        graph = ComplianceGraph()
+        graph.add_framework("fw-a", title="Framework A")
+        graph.add_control(framework="fw-a", control_id="c-1", title="Control 1", family="F")
+        graph.add_policy("policy.md", title="My Policy")
+        graph.add_mapping(policy="policy.md", framework="fw-a", control_id="c-1", confidence=0.9)
+        graph.save(tmp_path / ".lemma" / "graph.json")
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["graph", "impact", "policy:policy.md"])
+        assert result.exit_code == 0
+        assert "c-1" in result.stdout
+        assert "fw-a" in result.stdout
+
+    def test_impact_unknown_node(self, tmp_path: Path, monkeypatch):
+        """lemma graph impact with unknown node shows empty result."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+
+        graph = ComplianceGraph()
+        graph.save(tmp_path / ".lemma" / "graph.json")
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["graph", "impact", "policy:nonexistent"])
+        assert result.exit_code == 0
+        assert "No impact" in result.stdout or "0 controls" in result.stdout

--- a/tests/services/test_graph_population.py
+++ b/tests/services/test_graph_population.py
@@ -1,0 +1,184 @@
+"""Tests for automatic graph population during framework add and mapping.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from lemma.services.knowledge_graph import ComplianceGraph
+
+
+class TestFrameworkPopulatesGraph:
+    """Tests that framework add operations populate the knowledge graph."""
+
+    def test_add_bundled_framework_populates_graph(self, tmp_path: Path):
+        """add_bundled_framework writes Framework and Control nodes to graph."""
+        from lemma.services.framework import add_bundled_framework
+
+        # Initialize project structure
+        (tmp_path / ".lemma").mkdir()
+
+        add_bundled_framework("nist-800-53", project_dir=tmp_path)
+
+        # Load the persisted graph
+        graph = ComplianceGraph.load(tmp_path / ".lemma" / "graph.json")
+        fw_node = graph.get_node("framework:nist-800-53")
+        assert fw_node is not None
+        assert fw_node["type"] == "Framework"
+
+        # Should have controls
+        count = graph.framework_control_count("nist-800-53")
+        assert count > 0
+
+    def test_add_framework_is_idempotent(self, tmp_path: Path):
+        """Adding the same framework twice doesn't duplicate nodes."""
+        from lemma.services.framework import add_bundled_framework
+
+        (tmp_path / ".lemma").mkdir()
+
+        add_bundled_framework("nist-800-53", project_dir=tmp_path)
+        count_1 = ComplianceGraph.load(tmp_path / ".lemma" / "graph.json").framework_control_count(
+            "nist-800-53"
+        )
+
+        add_bundled_framework("nist-800-53", project_dir=tmp_path)
+        count_2 = ComplianceGraph.load(tmp_path / ".lemma" / "graph.json").framework_control_count(
+            "nist-800-53"
+        )
+
+        assert count_1 == count_2
+
+    def test_import_json_framework_populates_graph(self, tmp_path: Path):
+        """import_framework for JSON files also populates the graph."""
+        from lemma.services.framework import import_framework
+
+        (tmp_path / ".lemma").mkdir()
+
+        # Create a minimal OSCAL catalog JSON
+        catalog = {
+            "catalog": {
+                "uuid": "test-uuid",
+                "metadata": {"title": "Test Catalog"},
+                "groups": [
+                    {
+                        "id": "ac",
+                        "title": "Access Control",
+                        "controls": [
+                            {
+                                "id": "ac-1",
+                                "title": "Policy and Procedures",
+                                "parts": [
+                                    {
+                                        "name": "statement",
+                                        "prose": "Develop policy.",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        }
+        catalog_file = tmp_path / "test-catalog.json"
+        catalog_file.write_text(json.dumps(catalog))
+
+        import_framework(catalog_file, project_dir=tmp_path)
+
+        graph = ComplianceGraph.load(tmp_path / ".lemma" / "graph.json")
+        assert graph.get_node("framework:test-catalog") is not None
+        assert graph.framework_control_count("test-catalog") == 1
+
+
+class TestMapperPopulatesGraph:
+    """Tests that mapping operations populate the knowledge graph."""
+
+    def test_map_policies_adds_mapping_edges(self, tmp_path: Path):
+        """map_policies writes Policy nodes and SATISFIES edges to graph."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+
+        (tmp_path / ".lemma").mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "access.md").write_text("# Access Control\n\nAll users must use MFA.\n")
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "test-fw",
+            [
+                {
+                    "id": "ac-7",
+                    "title": "Unsuccessful Logon Attempts",
+                    "prose": "Enforce lockout.",
+                    "family": "AC",
+                },
+            ],
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.9, "rationale": "MFA maps to logon controls."}
+        )
+
+        map_policies(
+            framework="test-fw",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+        )
+
+        graph = ComplianceGraph.load(tmp_path / ".lemma" / "graph.json")
+
+        # Should have policy node(s)
+        exported = graph.export_json()
+        policy_nodes = [n for n in exported["nodes"] if n.get("type") == "Policy"]
+        assert len(policy_nodes) >= 1
+
+        # Should have SATISFIES edges
+        satisfies_edges = [e for e in exported["edges"] if e.get("relationship") == "SATISFIES"]
+        assert len(satisfies_edges) >= 1
+        assert satisfies_edges[0]["confidence"] == 0.9
+
+    def test_map_only_adds_mapped_results_to_graph(self, tmp_path: Path):
+        """Only MAPPED results (above threshold) are added as graph edges."""
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.mapper import map_policies
+
+        (tmp_path / ".lemma").mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "vague.md").write_text("# Vague Policy\n\nWe do security things.\n")
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "test-fw",
+            [
+                {
+                    "id": "c-1",
+                    "title": "Control 1",
+                    "prose": "Test.",
+                    "family": "F",
+                },
+            ],
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps({"confidence": 0.2, "rationale": "Weak match."})
+
+        map_policies(
+            framework="test-fw",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.6,
+        )
+
+        graph = ComplianceGraph.load(tmp_path / ".lemma" / "graph.json")
+        exported = graph.export_json()
+
+        satisfies_edges = [e for e in exported["edges"] if e.get("relationship") == "SATISFIES"]
+        # LOW_CONFIDENCE results should NOT create SATISFIES edges
+        assert len(satisfies_edges) == 0


### PR DESCRIPTION
## Description

Closes the critical gap in the knowledge graph (Issue #19): the graph is now **automatically populated** by existing workflows — no manual step required.

**Framework operations** — Both `lemma framework add` and `lemma framework import` now write Framework and Control nodes to `.lemma/graph.json` after indexing. Re-adding a framework is idempotent (no duplicate nodes).

**Mapping operations** — `lemma map` adds Policy nodes and `SATISFIES` edges for every MAPPED result. Only results above the confidence threshold create graph edges — `LOW_CONFIDENCE` results are excluded, keeping the graph trustworthy.

This means after running `lemma framework add nist-800-53 && lemma map`, the graph is fully queryable via `lemma graph export` and `lemma graph impact`.

**Depends on:** PR #75 (graph persistence and CLI commands) — merge #75 first.

Refs #19

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` with no errors
- [x] I have run `ruff format`
- [x] I have run `pytest` and all tests pass (184 passed, 92.32% coverage)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors