### PR TITLE
feat(transparency): Add `lemma ai audit` CLI for trace log querying

### DIFF
--- a/src/lemma/commands/ai.py
+++ b/src/lemma/commands/ai.py
@@ -2,16 +2,21 @@
 
 Provides sub-commands for AI transparency and governance:
     lemma ai system-card     — Display the AI System Card
+    lemma ai audit           — Query and filter the AI trace log
 """
 
 from __future__ import annotations
 
+import json
+from collections import Counter
 from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.table import Table
 
 from lemma.models.system_card import get_default_system_card
+from lemma.services.trace_log import TraceLog
 
 console = Console()
 
@@ -50,3 +55,145 @@ def system_card_command(
         print(card.model_dump_json(indent=2))
     else:
         console.print(card.render_markdown())
+
+
+@ai_app.command(name="audit", help="Query and filter the AI trace log.")
+def audit_command(
+    model: str = typer.Option(
+        "",
+        "--model",
+        "-m",
+        help="Filter traces by model ID (e.g., ollama/llama3.2)",
+    ),
+    status: str = typer.Option(
+        "",
+        "--status",
+        "-s",
+        help="Filter traces by review status (PROPOSED, ACCEPTED, REJECTED)",
+    ),
+    output_format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format: table or json",
+    ),
+    summary: bool = typer.Option(
+        False,
+        "--summary",
+        help="Show aggregate statistics instead of individual traces",
+    ),
+) -> None:
+    """Display and filter AI trace log entries."""
+    project_dir = _require_lemma_project()
+    trace_log = TraceLog(log_dir=project_dir / ".lemma" / "traces")
+
+    # Load and filter traces
+    traces = trace_log.read_all()
+
+    if model:
+        traces = [t for t in traces if t.model_id == model]
+
+    if status:
+        traces = [t for t in traces if t.status.value == status]
+
+    if summary:
+        _show_summary(traces)
+        return
+
+    if not traces:
+        console.print("[dim]No trace entries found. 0 traces.[/dim]")
+        return
+
+    if output_format == "json":
+        data = [json.loads(t.model_dump_json()) for t in traces]
+        print(json.dumps(data, indent=2))
+    else:
+        _show_table(traces)
+
+
+def _show_table(traces: list) -> None:
+    """Render traces as a Rich table.
+
+    Args:
+        traces: List of AITrace records to display.
+    """
+    table = Table(title=f"AI Trace Log ({len(traces)} entries)")
+    table.add_column("Timestamp", style="dim", width=19)
+    table.add_column("Model", style="cyan", min_width=20, no_wrap=True)
+    table.add_column("Control", style="bold", min_width=20, no_wrap=True)
+    table.add_column("Confidence", justify="right")
+    table.add_column("Status")
+    table.add_column("Determination")
+
+    for trace in traces:
+        # Color-code status
+        status_str = trace.status.value
+        if status_str == "ACCEPTED":
+            status_display = f"[green]{status_str}[/green]"
+        elif status_str == "REJECTED":
+            status_display = f"[red]{status_str}[/red]"
+        else:
+            status_display = f"[yellow]{status_str}[/yellow]"
+
+        # Color-code confidence
+        conf = trace.confidence
+        if conf >= 0.8:
+            conf_display = f"[green]{conf:.2f}[/green]"
+        elif conf >= 0.6:
+            conf_display = f"[yellow]{conf:.2f}[/yellow]"
+        else:
+            conf_display = f"[red]{conf:.2f}[/red]"
+
+        table.add_row(
+            trace.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            trace.model_id,
+            f"{trace.framework}:{trace.control_id}",
+            conf_display,
+            status_display,
+            trace.determination,
+        )
+
+    console.print(table)
+
+
+def _show_summary(traces: list) -> None:
+    """Render aggregate statistics for the trace log.
+
+    Args:
+        traces: List of AITrace records to summarize.
+    """
+    if not traces:
+        console.print("[dim]No trace entries found. 0 traces.[/dim]")
+        return
+
+    console.print(f"\n[bold]AI Audit Summary[/bold] — {len(traces)} traces\n")
+
+    # Model distribution
+    model_counts = Counter(t.model_id for t in traces)
+    model_table = Table(title="Traces by Model")
+    model_table.add_column("Model", style="cyan")
+    model_table.add_column("Count", justify="right")
+    for model_id, count in model_counts.most_common():
+        model_table.add_row(model_id, str(count))
+    console.print(model_table)
+    console.print()
+
+    # Status distribution
+    status_counts = Counter(t.status.value for t in traces)
+    status_table = Table(title="Traces by Status")
+    status_table.add_column("Status")
+    status_table.add_column("Count", justify="right")
+    for status_val, count in status_counts.most_common():
+        status_table.add_row(status_val, str(count))
+    console.print(status_table)
+    console.print()
+
+    # Confidence statistics
+    confidences = [t.confidence for t in traces]
+    avg_conf = sum(confidences) / len(confidences)
+    min_conf = min(confidences)
+    max_conf = max(confidences)
+
+    console.print(
+        f"[bold]Confidence:[/bold] avg={avg_conf:.2f}, min={min_conf:.2f}, max={max_conf:.2f}"
+    )

--- a/tests/commands/test_ai_audit.py
+++ b/tests/commands/test_ai_audit.py
@@ -1,0 +1,177 @@
+"""Tests for `lemma ai audit` CLI commands.
+
+Follows TDD: tests written BEFORE the implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from lemma.models.trace import AITrace
+from lemma.services.trace_log import TraceLog
+
+runner = CliRunner()
+
+
+def _seed_traces(project_dir: Path) -> list[AITrace]:
+    """Helper to populate trace log with test data.
+
+    Returns:
+        List of the created AITrace records for assertion.
+    """
+    trace_log = TraceLog(log_dir=project_dir / ".lemma" / "traces")
+
+    traces = [
+        AITrace(
+            operation="map",
+            input_text="All users must use MFA.",
+            prompt="Map this policy...",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output='{"confidence": 0.9}',
+            confidence=0.9,
+            determination="MAPPED",
+            control_id="ac-7",
+            framework="nist-800-53",
+        ),
+        AITrace(
+            operation="map",
+            input_text="Data must be encrypted at rest.",
+            prompt="Map this policy...",
+            model_id="openai/gpt-4o-mini",
+            model_version="2024-07-18",
+            raw_output='{"confidence": 0.85}',
+            confidence=0.85,
+            determination="MAPPED",
+            control_id="sc-28",
+            framework="nist-800-53",
+        ),
+        AITrace(
+            operation="map",
+            input_text="We do security.",
+            prompt="Map this policy...",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output='{"confidence": 0.3}',
+            confidence=0.3,
+            determination="LOW_CONFIDENCE",
+            control_id="sa-11",
+            framework="nist-800-53",
+        ),
+    ]
+
+    for trace in traces:
+        trace_log.append(trace)
+
+    return traces
+
+
+class TestAuditCommand:
+    """Tests for the `lemma ai audit` CLI command."""
+
+    def test_audit_shows_all_traces(self, tmp_path: Path, monkeypatch):
+        """lemma ai audit lists all trace entries in a table."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        _seed_traces(tmp_path)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["ai", "audit", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        control_ids = [d["control_id"] for d in data]
+        assert "ac-7" in control_ids
+        assert "sc-28" in control_ids
+        assert "sa-11" in control_ids
+
+    def test_audit_filter_by_model(self, tmp_path: Path, monkeypatch):
+        """lemma ai audit --model filters to specific model traces."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        _seed_traces(tmp_path)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(
+            app, ["ai", "audit", "--model", "openai/gpt-4o-mini", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 1
+        assert data[0]["control_id"] == "sc-28"
+        # Should NOT contain ollama traces
+        model_ids = [d["model_id"] for d in data]
+        assert "ollama/llama3.2" not in model_ids
+
+    def test_audit_filter_by_status(self, tmp_path: Path, monkeypatch):
+        """lemma ai audit --status filters by review status."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        traces = _seed_traces(tmp_path)
+
+        # Accept the first trace
+        trace_log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        trace_log.review(
+            traces[0].trace_id,
+            status="ACCEPTED",
+            rationale="Verified manually.",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["ai", "audit", "--status", "ACCEPTED", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) >= 1
+        assert all(d["status"] == "ACCEPTED" for d in data)
+
+    def test_audit_json_format(self, tmp_path: Path, monkeypatch):
+        """lemma ai audit --format json outputs machine-readable JSON."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        _seed_traces(tmp_path)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["ai", "audit", "--format", "json"])
+        assert result.exit_code == 0
+
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) == 3
+        assert data[0]["control_id"] == "ac-7"
+
+    def test_audit_empty_log(self, tmp_path: Path, monkeypatch):
+        """lemma ai audit with no traces shows empty message."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["ai", "audit"])
+        assert result.exit_code == 0
+        assert "No trace" in result.stdout or "0 traces" in result.stdout
+
+    def test_audit_summary_flag(self, tmp_path: Path, monkeypatch):
+        """lemma ai audit --summary shows aggregate statistics."""
+        from lemma.cli import app
+
+        (tmp_path / ".lemma").mkdir()
+        _seed_traces(tmp_path)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["ai", "audit", "--summary"])
+        assert result.exit_code == 0
+        # Should contain counts
+        assert "3" in result.stdout  # total traces
+        assert "ollama/llama3.2" in result.stdout
+        assert "openai/gpt-4o-mini" in result.stdout


### PR DESCRIPTION
## Description

Adds the `lemma ai audit` subcommand to the existing `lemma ai` command group for querying the AI trace log — the auditor-facing interface to Lemma's AI transparency system.

**Commands:**
- `lemma ai audit` — Rich table of all trace entries with color-coded confidence and status
- `lemma ai audit --model ollama/llama3.2` — Filter by model ID
- `lemma ai audit --status PROPOSED` — Filter by review status
- `lemma ai audit --format json` — Machine-readable JSON for CI/scripting
- `lemma ai audit --summary` — Aggregate statistics (traces by model, by status, confidence min/avg/max)

This completes the Phase 2 Transparent AI Agent System. Remaining items (confidence-gated automation, AIBOM) have been deferred to Phase 3 as #80 and #81.

Closes #20

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `ruff check` with no errors
- [x] I have run `ruff format`
- [x] I have run `pytest` and all tests pass (190 passed, 90.69% coverage)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors