### PR TITLE
feat(automation): Add confidence-gated auto-accept for AI mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ Thumbs.db
 .env.local
 .env.*.local
 
+# Claude Code local settings
+.claude/
+
 # Lemma local state
 .lemma/cache/
 .lemma/index/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Confidence-gated automation for AI mapping. `ai.automation.thresholds.<operation>` in `lemma.config.yaml` auto-accepts AI outputs at or above the configured threshold; outputs below remain PROPOSED for human review. Auto-accepted trace entries are marked with `auto_accepted: true` and record the applied threshold in the review rationale.
+- `auto_accepted` field on `AITrace` distinguishes gate-driven acceptances from human-driven ones.
 - Initial project scaffolding and repository structure.
 - `README.md` containing the project vision, principles, and high-level architecture.
 - Core governance documents including `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, and `GOVERNANCE.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Confidence-gated automation for AI mapping. `ai.automation.thresholds.<operation>` in `lemma.config.yaml` auto-accepts AI outputs at or above the configured threshold; outputs below remain PROPOSED for human review. Auto-accepted trace entries are marked with `auto_accepted: true` and record the applied threshold in the review rationale.
 - `auto_accepted` field on `AITrace` distinguishes gate-driven acceptances from human-driven ones.
+- Policy event audit log at `.lemma/policy-events/YYYY-MM-DD.jsonl`. Each `lemma map` run diffs `ai.automation.thresholds` against the prior state and appends `threshold_set`, `threshold_changed`, or `threshold_removed` events — so governance-relevant config changes are independently auditable from AI decision traces.
 - Initial project scaffolding and repository structure.
 - `README.md` containing the project vision, principles, and high-level architecture.
 - Core governance documents including `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, and `GOVERNANCE.md`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -186,6 +186,10 @@ ai:
 
 Thresholds must be in the range `0.0`–`1.0`. Operations without a configured threshold are never auto-accepted. Review-status transitions (including auto-accepts) are visible via `lemma ai audit --status ACCEPTED`.
 
+#### Policy event audit trail
+
+Every time `lemma map` loads the automation config, it diffs the current thresholds against the last recorded state and appends any changes as policy events to `.lemma/policy-events/YYYY-MM-DD.jsonl`. Events carry one of three types — `threshold_set`, `threshold_changed`, or `threshold_removed` — plus the previous and new values, the operation affected, and the config file path that triggered the change. The log is append-only so the history of governance changes is independently auditable from AI decision traces.
+
 ---
 
 ## `lemma harmonize`

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -172,6 +172,20 @@ lemma map --framework nist-800-53 --output csv > mapping.csv
 lemma map --framework nist-800-53 --threshold 0.5
 ```
 
+### Confidence-gated automation
+
+`lemma map` honors per-operation auto-accept thresholds defined in `lemma.config.yaml`. When an AI output's confidence is at or above the configured threshold, its trace entry is automatically promoted from `PROPOSED` to `ACCEPTED` with `auto_accepted: true`. Outputs below the threshold remain `PROPOSED` for human review.
+
+```yaml
+# lemma.config.yaml
+ai:
+  automation:
+    thresholds:
+      map: 0.85
+```
+
+Thresholds must be in the range `0.0`–`1.0`. Operations without a configured threshold are never auto-accepted. Review-status transitions (including auto-accepts) are visible via `lemma ai audit --status ACCEPTED`.
+
 ---
 
 ## `lemma harmonize`

--- a/src/lemma/commands/init.py
+++ b/src/lemma/commands/init.py
@@ -18,6 +18,12 @@ _DEFAULT_CONFIG = {
         "provider": "ollama",
         "model": "llama3.2",
         "temperature": 0.1,
+        # Confidence-gated automation. Outputs at or above the per-operation
+        # threshold are auto-accepted; outputs below remain PROPOSED for
+        # human review. Omit or leave empty to require human review on all.
+        "automation": {
+            "thresholds": {},
+        },
     },
     "connectors": [],
 }

--- a/src/lemma/commands/map.py
+++ b/src/lemma/commands/map.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import typer
 import yaml
 
+from lemma.services.config import load_automation_config
 from lemma.services.formatters import get_formatter
 from lemma.services.llm import get_llm_client
 from lemma.services.mapper import map_policies
@@ -59,6 +60,12 @@ def map_command(
     except ImportError as e:
         _error(str(e))
 
+    # Load confidence-gated automation config (thresholds per operation).
+    try:
+        automation = load_automation_config(config_file)
+    except ValueError as e:
+        _error(str(e))
+
     # Run mapping
     try:
         report = map_policies(
@@ -66,6 +73,7 @@ def map_command(
             project_dir=cwd,
             llm_client=llm_client,
             threshold=threshold,
+            automation=automation,
         )
     except ValueError as e:
         _error(str(e))

--- a/src/lemma/commands/map.py
+++ b/src/lemma/commands/map.py
@@ -9,10 +9,11 @@ from pathlib import Path
 import typer
 import yaml
 
-from lemma.services.config import load_automation_config
+from lemma.services.config import load_automation_config, record_threshold_changes
 from lemma.services.formatters import get_formatter
 from lemma.services.llm import get_llm_client
 from lemma.services.mapper import map_policies
+from lemma.services.policy_log import PolicyEventLog
 
 
 def _error(message: str) -> None:
@@ -65,6 +66,10 @@ def map_command(
         automation = load_automation_config(config_file)
     except ValueError as e:
         _error(str(e))
+
+    # Record any threshold changes as auditable policy events before running.
+    policy_log = PolicyEventLog(log_dir=cwd / ".lemma" / "policy-events")
+    record_threshold_changes(automation, policy_log, source=str(config_file))
 
     # Run mapping
     try:

--- a/src/lemma/models/policy.py
+++ b/src/lemma/models/policy.py
@@ -1,0 +1,45 @@
+"""Policy event model — auditable record of policy configuration changes.
+
+Policy events capture changes to governance-relevant configuration (e.g.,
+confidence-gated automation thresholds) so that changes in automation
+behavior are independently reviewable, separate from individual AI
+decision traces.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class PolicyEventType(StrEnum):
+    """Discriminator for the kind of policy change recorded."""
+
+    THRESHOLD_SET = "threshold_set"
+    THRESHOLD_CHANGED = "threshold_changed"
+    THRESHOLD_REMOVED = "threshold_removed"
+
+
+class PolicyEvent(BaseModel):
+    """A single auditable policy configuration change.
+
+    Attributes:
+        event_id: Unique identifier.
+        timestamp: UTC timestamp of when the change was recorded.
+        event_type: The kind of change (set, changed, removed).
+        operation: The operation whose policy changed (e.g., ``"map"``).
+        previous_value: Prior threshold, or None if newly set.
+        new_value: New threshold, or None if removed.
+        source: Free-form origin indicator (e.g., config file path).
+    """
+
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    event_type: PolicyEventType
+    operation: str
+    previous_value: float | None = None
+    new_value: float | None = None
+    source: str = ""

--- a/src/lemma/models/trace.py
+++ b/src/lemma/models/trace.py
@@ -55,6 +55,8 @@ class AITrace(BaseModel):
         status: Human review status (PROPOSED, ACCEPTED, REJECTED).
         review_rationale: Rationale for acceptance/rejection (required for REJECTED).
         parent_trace_id: For review entries, the trace_id of the original trace.
+        auto_accepted: True if the review entry was produced by confidence-gated
+            automation rather than a human reviewer.
     """
 
     trace_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
@@ -72,3 +74,4 @@ class AITrace(BaseModel):
     status: TraceStatus = TraceStatus.PROPOSED
     review_rationale: str = ""
     parent_trace_id: str = ""
+    auto_accepted: bool = False

--- a/src/lemma/services/config.py
+++ b/src/lemma/services/config.py
@@ -1,0 +1,68 @@
+"""Lemma project configuration loader and schema.
+
+Parses ``lemma.config.yaml`` and exposes validated config objects
+for use by the CLI commands and services.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class AutomationConfig(BaseModel):
+    """Confidence-gated automation configuration.
+
+    Per-operation confidence thresholds. When an AI operation emits a
+    trace with confidence greater than or equal to the configured
+    threshold, the mapper auto-accepts it (status promoted to ACCEPTED
+    with ``auto_accepted=True``). Operations without a threshold entry
+    are never auto-accepted and remain PROPOSED for human review.
+
+    Attributes:
+        thresholds: Mapping of operation name (e.g., ``"map"``) to the
+            confidence threshold in the range 0.0-1.0.
+    """
+
+    thresholds: dict[str, float] = Field(default_factory=dict)
+
+    @field_validator("thresholds")
+    @classmethod
+    def _validate_thresholds(cls, value: dict[str, float]) -> dict[str, float]:
+        for operation, threshold in value.items():
+            if not 0.0 <= threshold <= 1.0:
+                msg = (
+                    f"Automation threshold for operation '{operation}' must be "
+                    f"between 0.0 and 1.0 (got {threshold})."
+                )
+                raise ValueError(msg)
+        return value
+
+    def threshold_for(self, operation: str) -> float | None:
+        """Return the configured threshold for an operation, or None if unset."""
+        return self.thresholds.get(operation)
+
+
+def load_automation_config(config_file: Path) -> AutomationConfig:
+    """Load and validate the automation config block from ``lemma.config.yaml``.
+
+    Returns an empty ``AutomationConfig`` (no auto-accept) if the file
+    does not exist or if the ``ai.automation`` block is absent.
+
+    Args:
+        config_file: Path to ``lemma.config.yaml``.
+
+    Returns:
+        A validated ``AutomationConfig``.
+
+    Raises:
+        ValueError: If any threshold is outside the 0.0-1.0 range.
+    """
+    if not config_file.exists():
+        return AutomationConfig()
+
+    raw = yaml.safe_load(config_file.read_text()) or {}
+    automation_block = raw.get("ai", {}).get("automation", {}) or {}
+    return AutomationConfig(**automation_block)

--- a/src/lemma/services/config.py
+++ b/src/lemma/services/config.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
+from lemma.models.policy import PolicyEvent, PolicyEventType
+from lemma.services.policy_log import PolicyEventLog
+
 
 class AutomationConfig(BaseModel):
     """Confidence-gated automation configuration.
@@ -66,3 +69,57 @@ def load_automation_config(config_file: Path) -> AutomationConfig:
     raw = yaml.safe_load(config_file.read_text()) or {}
     automation_block = raw.get("ai", {}).get("automation", {}) or {}
     return AutomationConfig(**automation_block)
+
+
+def record_threshold_changes(
+    config: AutomationConfig,
+    policy_log: PolicyEventLog,
+    source: str = "",
+) -> list[PolicyEvent]:
+    """Diff ``config`` against the most recent recorded thresholds and append events.
+
+    For each operation currently configured, emits ``THRESHOLD_SET`` if there
+    is no prior recorded value or ``THRESHOLD_CHANGED`` if the value differs.
+    For each operation with a prior non-None recorded value that is no longer
+    configured, emits ``THRESHOLD_REMOVED``. Operations whose current and prior
+    values match produce no event.
+
+    Args:
+        config: The currently-loaded automation configuration.
+        policy_log: Append-only log to write change events to.
+        source: Optional provenance string (e.g. the config file path) recorded
+            on every emitted event.
+
+    Returns:
+        The list of events appended this call, in the order they were written.
+    """
+    emitted: list[PolicyEvent] = []
+    current = config.thresholds
+
+    # Operations previously recorded but absent now, so we can flag removals.
+    prior_ops = {event.operation for event in policy_log.read_all()}
+    for operation in sorted(set(current) | prior_ops):
+        previous = policy_log.latest_threshold(operation)
+        new = current.get(operation)
+
+        if previous == new:
+            continue
+
+        if previous is None:
+            event_type = PolicyEventType.THRESHOLD_SET
+        elif new is None:
+            event_type = PolicyEventType.THRESHOLD_REMOVED
+        else:
+            event_type = PolicyEventType.THRESHOLD_CHANGED
+
+        event = PolicyEvent(
+            event_type=event_type,
+            operation=operation,
+            previous_value=previous,
+            new_value=new,
+            source=source,
+        )
+        policy_log.append(event)
+        emitted.append(event)
+
+    return emitted

--- a/src/lemma/services/mapper.py
+++ b/src/lemma/services/mapper.py
@@ -111,9 +111,7 @@ def map_policies(
     model_id = _get_model_id(llm_client)
 
     # Resolve auto-accept threshold for the map operation (None = no gating)
-    auto_accept_threshold = (
-        automation.threshold_for("map") if automation is not None else None
-    )
+    auto_accept_threshold = automation.threshold_for("map") if automation is not None else None
 
     # Map each chunk to controls
     results: list[MappingResult] = []
@@ -158,10 +156,7 @@ def map_policies(
             trace_log.append(proposed_trace)
 
             # Confidence-gated automation: auto-accept at/above configured threshold.
-            if (
-                auto_accept_threshold is not None
-                and confidence >= auto_accept_threshold
-            ):
+            if auto_accept_threshold is not None and confidence >= auto_accept_threshold:
                 trace_log.auto_accept(proposed_trace, threshold=auto_accept_threshold)
 
             results.append(

--- a/src/lemma/services/mapper.py
+++ b/src/lemma/services/mapper.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from lemma.models.mapping import MappingReport, MappingResult
 from lemma.models.trace import AITrace
 from lemma.services.chunker import chunk_policies
+from lemma.services.config import AutomationConfig
 from lemma.services.indexer import ControlIndexer
 from lemma.services.knowledge_graph import ComplianceGraph
 from lemma.services.llm import LLMClient
@@ -66,6 +67,7 @@ def map_policies(
     threshold: float = 0.6,
     top_k: int = 3,
     output_format: str = "json",
+    automation: AutomationConfig | None = None,
 ) -> MappingReport:
     """Run the full control mapping pipeline.
 
@@ -79,6 +81,10 @@ def map_policies(
         threshold: Confidence threshold for LOW_CONFIDENCE flagging.
         top_k: Number of candidate controls per chunk.
         output_format: Output format name (for future use).
+        automation: Optional confidence-gated automation config. When a
+            threshold is configured for the ``map`` operation, outputs
+            at or above the threshold are auto-accepted; outputs below
+            remain PROPOSED for human review.
 
     Returns:
         MappingReport with all mapping results.
@@ -103,6 +109,11 @@ def map_policies(
     # Initialize trace log
     trace_log = TraceLog(log_dir=project_dir / ".lemma" / "traces")
     model_id = _get_model_id(llm_client)
+
+    # Resolve auto-accept threshold for the map operation (None = no gating)
+    auto_accept_threshold = (
+        automation.threshold_for("map") if automation is not None else None
+    )
 
     # Map each chunk to controls
     results: list[MappingResult] = []
@@ -132,20 +143,26 @@ def map_policies(
             status = "MAPPED" if confidence >= threshold else "LOW_CONFIDENCE"
 
             # Log trace entry for this AI decision
-            trace_log.append(
-                AITrace(
-                    operation="map",
-                    input_text=chunk["text"][:500],
-                    prompt=prompt,
-                    model_id=model_id,
-                    model_version="",
-                    raw_output=raw_response,
-                    confidence=confidence,
-                    determination=status,
-                    control_id=candidate["control_id"],
-                    framework=framework,
-                )
+            proposed_trace = AITrace(
+                operation="map",
+                input_text=chunk["text"][:500],
+                prompt=prompt,
+                model_id=model_id,
+                model_version="",
+                raw_output=raw_response,
+                confidence=confidence,
+                determination=status,
+                control_id=candidate["control_id"],
+                framework=framework,
             )
+            trace_log.append(proposed_trace)
+
+            # Confidence-gated automation: auto-accept at/above configured threshold.
+            if (
+                auto_accept_threshold is not None
+                and confidence >= auto_accept_threshold
+            ):
+                trace_log.auto_accept(proposed_trace, threshold=auto_accept_threshold)
 
             results.append(
                 MappingResult(

--- a/src/lemma/services/policy_log.py
+++ b/src/lemma/services/policy_log.py
@@ -1,0 +1,53 @@
+"""Append-only policy event log — tamper-evident record of config changes.
+
+Mirrors the shape of the AI trace log: strictly append-only JSONL files
+partitioned by UTC date. Stored at ``.lemma/policy-events/YYYY-MM-DD.jsonl``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lemma.models.policy import PolicyEvent
+
+
+class PolicyEventLog:
+    """Append-only log of policy configuration events."""
+
+    def __init__(self, log_dir: Path) -> None:
+        self._log_dir = log_dir
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+
+    def _log_file(self, dt: datetime | None = None) -> Path:
+        if dt is None:
+            dt = datetime.now(UTC)
+        return self._log_dir / f"{dt.strftime('%Y-%m-%d')}.jsonl"
+
+    def append(self, event: PolicyEvent) -> None:
+        """Append a policy event to the log."""
+        log_file = self._log_file(event.timestamp)
+        with log_file.open("a") as f:
+            f.write(event.model_dump_json() + "\n")
+
+    def read_all(self) -> list[PolicyEvent]:
+        """Return every event in chronological (file, line) order."""
+        events: list[PolicyEvent] = []
+        for log_file in sorted(self._log_dir.glob("*.jsonl")):
+            for line in log_file.read_text().strip().splitlines():
+                if line.strip():
+                    events.append(PolicyEvent.model_validate_json(line))
+        return events
+
+    def latest_threshold(self, operation: str) -> float | None:
+        """Return the most recently recorded threshold for ``operation``.
+
+        Scans events newest-to-oldest and returns the ``new_value`` of the
+        first matching entry (which may be ``None`` if the threshold was
+        most recently removed). If the operation has no recorded events,
+        returns ``None``.
+        """
+        for event in reversed(self.read_all()):
+            if event.operation == operation:
+                return event.new_value
+        return None

--- a/src/lemma/services/trace_log.py
+++ b/src/lemma/services/trace_log.py
@@ -146,3 +146,44 @@ class TraceLog:
         )
 
         self.append(review_entry)
+
+    def auto_accept(self, original: AITrace, *, threshold: float) -> AITrace:
+        """Append an ACCEPTED review entry produced by confidence gating.
+
+        Used by confidence-gated automation: when an AI output's confidence
+        is at or above a configured threshold, the mapper calls this to
+        promote the original PROPOSED trace to ACCEPTED without human review.
+        The review entry records the threshold that was applied and carries
+        ``auto_accepted=True`` so it is auditable as policy-driven rather
+        than human-driven.
+
+        Args:
+            original: The PROPOSED trace being auto-accepted.
+            threshold: The configured threshold that was met.
+
+        Returns:
+            The appended review entry.
+        """
+        rationale = (
+            f"Auto-accepted by confidence gate: "
+            f"confidence {original.confidence:.3f} >= threshold {threshold:.3f} "
+            f"for operation '{original.operation}'."
+        )
+        review_entry = AITrace(
+            operation=original.operation,
+            input_text=original.input_text,
+            prompt=original.prompt,
+            model_id=original.model_id,
+            model_version=original.model_version,
+            raw_output=original.raw_output,
+            confidence=original.confidence,
+            determination=original.determination,
+            control_id=original.control_id,
+            framework=original.framework,
+            status=TraceStatus.ACCEPTED,
+            review_rationale=rationale,
+            parent_trace_id=original.trace_id,
+            auto_accepted=True,
+        )
+        self.append(review_entry)
+        return review_entry

--- a/tests/commands/test_map.py
+++ b/tests/commands/test_map.py
@@ -123,3 +123,61 @@ class TestMapCommand:
             )
         assert result.exit_code == 0
         assert "ac-2" in result.stdout or "nist-800-53" in result.stdout
+
+    def test_map_records_policy_event_when_threshold_changes(self, tmp_path, monkeypatch):
+        """Editing ai.automation.thresholds between runs emits a policy event."""
+        from lemma.cli import app
+        from lemma.services.indexer import ControlIndexer
+        from lemma.services.policy_log import PolicyEventLog
+
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps({"confidence": 0.85, "rationale": "Match."})
+
+        monkeypatch.chdir(tmp_path)
+        runner.invoke(app, ["init"])
+
+        Path("policies/access.md").write_text("# Access Control\n\nAll users use MFA.\n")
+
+        index_dir = (tmp_path / ".lemma" / "index").resolve()
+        indexer = ControlIndexer(index_dir=index_dir)
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-2",
+                    "title": "Account Management",
+                    "prose": "Manage system accounts.",
+                    "family": "AC",
+                },
+            ],
+        )
+        del indexer
+
+        config_path = Path("lemma.config.yaml")
+
+        def _run_with_threshold(threshold: float) -> None:
+            config_path.write_text(
+                "ai:\n"
+                "  provider: ollama\n"
+                "  model: llama3.2\n"
+                "  temperature: 0.1\n"
+                "  automation:\n"
+                "    thresholds:\n"
+                f"      map: {threshold}\n"
+                "frameworks: []\n"
+                "connectors: []\n"
+            )
+            with patch("lemma.commands.map.get_llm_client", return_value=mock_llm):
+                runner.invoke(app, ["map", "--framework", "nist-800-53"])
+
+        _run_with_threshold(0.80)
+        _run_with_threshold(0.95)
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        events = log.read_all()
+        assert len(events) == 2
+        assert events[0].event_type.value == "threshold_set"
+        assert events[0].new_value == 0.80
+        assert events[1].event_type.value == "threshold_changed"
+        assert events[1].previous_value == 0.80
+        assert events[1].new_value == 0.95

--- a/tests/models/test_policy.py
+++ b/tests/models/test_policy.py
@@ -1,0 +1,50 @@
+"""Tests for the PolicyEvent model — auditable record of policy config changes."""
+
+from __future__ import annotations
+
+import json
+
+
+def test_policy_event_requires_event_type_and_operation():
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+
+    event = PolicyEvent(
+        event_type=PolicyEventType.THRESHOLD_SET,
+        operation="map",
+        previous_value=None,
+        new_value=0.85,
+    )
+
+    assert event.event_type == PolicyEventType.THRESHOLD_SET
+    assert event.operation == "map"
+    assert event.previous_value is None
+    assert event.new_value == 0.85
+    assert event.event_id
+    assert event.timestamp is not None
+
+
+def test_policy_event_serializes_to_json():
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+
+    event = PolicyEvent(
+        event_type=PolicyEventType.THRESHOLD_CHANGED,
+        operation="map",
+        previous_value=0.80,
+        new_value=0.95,
+    )
+    data = json.loads(event.model_dump_json())
+
+    assert data["event_type"] == "threshold_changed"
+    assert data["operation"] == "map"
+    assert data["previous_value"] == 0.80
+    assert data["new_value"] == 0.95
+    assert "event_id" in data
+    assert "timestamp" in data
+
+
+def test_policy_event_type_enum_has_three_transitions():
+    from lemma.models.policy import PolicyEventType
+
+    assert PolicyEventType.THRESHOLD_SET.value == "threshold_set"
+    assert PolicyEventType.THRESHOLD_CHANGED.value == "threshold_changed"
+    assert PolicyEventType.THRESHOLD_REMOVED.value == "threshold_removed"

--- a/tests/services/test_config.py
+++ b/tests/services/test_config.py
@@ -29,11 +29,11 @@ class TestAutomationConfig:
         AutomationConfig(thresholds={"map": 1.0})
 
     def test_threshold_above_one_rejected(self):
-        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        with pytest.raises(ValueError, match=r"between 0\.0 and 1\.0"):
             AutomationConfig(thresholds={"map": 1.5})
 
     def test_threshold_below_zero_rejected(self):
-        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        with pytest.raises(ValueError, match=r"between 0\.0 and 1\.0"):
             AutomationConfig(thresholds={"map": -0.1})
 
     def test_operation_name_is_preserved_in_error(self):
@@ -75,9 +75,7 @@ class TestLoadAutomationConfig:
 
     def test_invalid_threshold_raises_on_load(self, tmp_path: Path):
         config_file = tmp_path / "lemma.config.yaml"
-        config_file.write_text(
-            yaml.dump({"ai": {"automation": {"thresholds": {"map": 1.7}}}})
-        )
+        config_file.write_text(yaml.dump({"ai": {"automation": {"thresholds": {"map": 1.7}}}}))
 
-        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        with pytest.raises(ValueError, match=r"between 0\.0 and 1\.0"):
             load_automation_config(config_file)

--- a/tests/services/test_config.py
+++ b/tests/services/test_config.py
@@ -1,0 +1,83 @@
+"""Tests for the project config loader and automation schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lemma.services.config import AutomationConfig, load_automation_config
+
+
+class TestAutomationConfig:
+    """Tests for the AutomationConfig Pydantic model."""
+
+    def test_empty_config_has_no_thresholds(self):
+        config = AutomationConfig()
+        assert config.thresholds == {}
+        assert config.threshold_for("map") is None
+
+    def test_threshold_for_returns_configured_value(self):
+        config = AutomationConfig(thresholds={"map": 0.8, "harmonize": 0.9})
+        assert config.threshold_for("map") == 0.8
+        assert config.threshold_for("harmonize") == 0.9
+        assert config.threshold_for("unknown") is None
+
+    def test_threshold_boundaries_are_inclusive(self):
+        AutomationConfig(thresholds={"map": 0.0})
+        AutomationConfig(thresholds={"map": 1.0})
+
+    def test_threshold_above_one_rejected(self):
+        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+            AutomationConfig(thresholds={"map": 1.5})
+
+    def test_threshold_below_zero_rejected(self):
+        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+            AutomationConfig(thresholds={"map": -0.1})
+
+    def test_operation_name_is_preserved_in_error(self):
+        with pytest.raises(ValueError, match="harmonize"):
+            AutomationConfig(thresholds={"harmonize": 2.0})
+
+
+class TestLoadAutomationConfig:
+    """Tests for loading automation config from lemma.config.yaml."""
+
+    def test_missing_file_returns_empty_config(self, tmp_path: Path):
+        config = load_automation_config(tmp_path / "missing.yaml")
+        assert config.thresholds == {}
+
+    def test_missing_automation_block_returns_empty_config(self, tmp_path: Path):
+        config_file = tmp_path / "lemma.config.yaml"
+        config_file.write_text(yaml.dump({"ai": {"provider": "ollama"}}))
+
+        config = load_automation_config(config_file)
+        assert config.thresholds == {}
+
+    def test_loads_per_operation_thresholds(self, tmp_path: Path):
+        config_file = tmp_path / "lemma.config.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "ai": {
+                        "automation": {
+                            "thresholds": {"map": 0.85, "harmonize": 0.95},
+                        }
+                    }
+                }
+            )
+        )
+
+        config = load_automation_config(config_file)
+        assert config.threshold_for("map") == 0.85
+        assert config.threshold_for("harmonize") == 0.95
+
+    def test_invalid_threshold_raises_on_load(self, tmp_path: Path):
+        config_file = tmp_path / "lemma.config.yaml"
+        config_file.write_text(
+            yaml.dump({"ai": {"automation": {"thresholds": {"map": 1.7}}}})
+        )
+
+        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+            load_automation_config(config_file)

--- a/tests/services/test_config.py
+++ b/tests/services/test_config.py
@@ -79,3 +79,93 @@ class TestLoadAutomationConfig:
 
         with pytest.raises(ValueError, match=r"between 0\.0 and 1\.0"):
             load_automation_config(config_file)
+
+
+class TestRecordThresholdChanges:
+    """Tests for the automation-config → policy-event diff function."""
+
+    def test_first_configured_threshold_emits_threshold_set(self, tmp_path: Path):
+        from lemma.services.config import AutomationConfig, record_threshold_changes
+        from lemma.services.policy_log import PolicyEventLog
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        emitted = record_threshold_changes(AutomationConfig(thresholds={"map": 0.85}), log)
+
+        assert len(emitted) == 1
+        event = emitted[0]
+        assert event.event_type.value == "threshold_set"
+        assert event.operation == "map"
+        assert event.previous_value is None
+        assert event.new_value == 0.85
+        assert log.latest_threshold("map") == 0.85
+
+    def test_unchanged_threshold_emits_nothing(self, tmp_path: Path):
+        from lemma.services.config import AutomationConfig, record_threshold_changes
+        from lemma.services.policy_log import PolicyEventLog
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        record_threshold_changes(AutomationConfig(thresholds={"map": 0.85}), log)
+        emitted = record_threshold_changes(AutomationConfig(thresholds={"map": 0.85}), log)
+
+        assert emitted == []
+        assert len(log.read_all()) == 1
+
+    def test_changed_threshold_emits_threshold_changed(self, tmp_path: Path):
+        from lemma.services.config import AutomationConfig, record_threshold_changes
+        from lemma.services.policy_log import PolicyEventLog
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        record_threshold_changes(AutomationConfig(thresholds={"map": 0.85}), log)
+        emitted = record_threshold_changes(AutomationConfig(thresholds={"map": 0.95}), log)
+
+        assert len(emitted) == 1
+        event = emitted[0]
+        assert event.event_type.value == "threshold_changed"
+        assert event.operation == "map"
+        assert event.previous_value == 0.85
+        assert event.new_value == 0.95
+
+    def test_removed_threshold_emits_threshold_removed(self, tmp_path: Path):
+        from lemma.services.config import AutomationConfig, record_threshold_changes
+        from lemma.services.policy_log import PolicyEventLog
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        record_threshold_changes(AutomationConfig(thresholds={"map": 0.85}), log)
+        emitted = record_threshold_changes(AutomationConfig(), log)
+
+        assert len(emitted) == 1
+        event = emitted[0]
+        assert event.event_type.value == "threshold_removed"
+        assert event.operation == "map"
+        assert event.previous_value == 0.85
+        assert event.new_value is None
+
+    def test_source_is_recorded_on_emitted_events(self, tmp_path: Path):
+        from lemma.services.config import AutomationConfig, record_threshold_changes
+        from lemma.services.policy_log import PolicyEventLog
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        emitted = record_threshold_changes(
+            AutomationConfig(thresholds={"map": 0.85}),
+            log,
+            source="lemma.config.yaml",
+        )
+        assert emitted[0].source == "lemma.config.yaml"
+
+    def test_multiple_ops_diffed_independently(self, tmp_path: Path):
+        from lemma.services.config import AutomationConfig, record_threshold_changes
+        from lemma.services.policy_log import PolicyEventLog
+
+        log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+        record_threshold_changes(
+            AutomationConfig(thresholds={"map": 0.80, "harmonize": 0.90}),
+            log,
+        )
+        emitted = record_threshold_changes(
+            AutomationConfig(thresholds={"map": 0.85, "harmonize": 0.90}),
+            log,
+        )
+
+        assert len(emitted) == 1
+        assert emitted[0].operation == "map"
+        assert emitted[0].event_type.value == "threshold_changed"

--- a/tests/services/test_mapper.py
+++ b/tests/services/test_mapper.py
@@ -322,3 +322,150 @@ class TestMapperTraceIntegration:
         trace = traces[0]
         assert trace.confidence == 0.0
         assert trace.raw_output == "NOT VALID JSON"
+
+
+class TestMapperConfidenceGate:
+    """Tests for confidence-gated automation in the mapping pipeline."""
+
+    def _setup_project(self, tmp_path):
+        from lemma.services.indexer import ControlIndexer
+
+        (tmp_path / ".lemma").mkdir()
+        policies_dir = tmp_path / "policies"
+        policies_dir.mkdir()
+        (policies_dir / "access.md").write_text(
+            "# Access Control\n\nAll users must use MFA to authenticate.\n"
+        )
+
+        indexer = ControlIndexer(index_dir=tmp_path / ".lemma" / "index")
+        indexer.index_controls(
+            "nist-800-53",
+            [
+                {
+                    "id": "ac-7",
+                    "title": "Unsuccessful Logon Attempts",
+                    "prose": "Enforce lockout after failed logon attempts.",
+                    "family": "AC",
+                },
+            ],
+        )
+
+    def test_high_confidence_is_auto_accepted(self, tmp_path):
+        from lemma.services.config import AutomationConfig
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        self._setup_project(tmp_path)
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.92, "rationale": "Strong match."}
+        )
+
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+            automation=AutomationConfig(thresholds={"map": 0.85}),
+        )
+
+        traces = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+        # One PROPOSED plus one auto-accepted review per candidate
+        accepted = [t for t in traces if t.status.value == "ACCEPTED"]
+        assert len(accepted) >= 1
+        review = accepted[0]
+        assert review.auto_accepted is True
+        assert review.parent_trace_id != ""
+
+    def test_below_threshold_remains_proposed(self, tmp_path):
+        from lemma.services.config import AutomationConfig
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        self._setup_project(tmp_path)
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.70, "rationale": "Moderate match."}
+        )
+
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+            automation=AutomationConfig(thresholds={"map": 0.95}),
+        )
+
+        traces = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+        accepted = [t for t in traces if t.status.value == "ACCEPTED"]
+        proposed = [t for t in traces if t.status.value == "PROPOSED"]
+        assert accepted == []
+        assert len(proposed) >= 1
+
+    def test_without_automation_config_never_auto_accepts(self, tmp_path):
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        self._setup_project(tmp_path)
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.99, "rationale": "Very strong."}
+        )
+
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+        )
+
+        traces = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+        assert all(t.status.value == "PROPOSED" for t in traces)
+
+    def test_missing_operation_threshold_never_auto_accepts(self, tmp_path):
+        """Thresholds for other operations must not affect 'map'."""
+        from lemma.services.config import AutomationConfig
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        self._setup_project(tmp_path)
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.99, "rationale": "Very strong."}
+        )
+
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+            automation=AutomationConfig(thresholds={"harmonize": 0.5}),
+        )
+
+        traces = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+        assert all(t.status.value == "PROPOSED" for t in traces)
+
+    def test_threshold_boundary_auto_accepts(self, tmp_path):
+        """Confidence exactly at the threshold auto-accepts (inclusive)."""
+        from lemma.services.config import AutomationConfig
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        self._setup_project(tmp_path)
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps(
+            {"confidence": 0.8, "rationale": "Exact threshold."}
+        )
+
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+            automation=AutomationConfig(thresholds={"map": 0.8}),
+        )
+
+        traces = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+        accepted = [t for t in traces if t.status.value == "ACCEPTED"]
+        assert len(accepted) >= 1
+        assert accepted[0].auto_accepted is True

--- a/tests/services/test_mapper.py
+++ b/tests/services/test_mapper.py
@@ -469,3 +469,41 @@ class TestMapperConfidenceGate:
         accepted = [t for t in traces if t.status.value == "ACCEPTED"]
         assert len(accepted) >= 1
         assert accepted[0].auto_accepted is True
+
+    def test_threshold_change_does_not_affect_existing_traces(self, tmp_path):
+        """Raising the threshold on a later run must not alter prior trace entries."""
+        from lemma.services.config import AutomationConfig
+        from lemma.services.mapper import map_policies
+        from lemma.services.trace_log import TraceLog
+
+        self._setup_project(tmp_path)
+        mock_llm = MagicMock()
+        mock_llm.generate.return_value = json.dumps({"confidence": 0.9, "rationale": "Match."})
+
+        # First run: threshold 0.8, confidence 0.9 => auto-accept
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+            automation=AutomationConfig(thresholds={"map": 0.8}),
+        )
+        first_run = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+        first_snapshot = [(t.trace_id, t.status.value, t.auto_accepted) for t in first_run]
+
+        # Second run: threshold raised to 0.95. Must not rewrite first run entries.
+        map_policies(
+            framework="nist-800-53",
+            project_dir=tmp_path,
+            llm_client=mock_llm,
+            threshold=0.5,
+            automation=AutomationConfig(thresholds={"map": 0.95}),
+        )
+        second_run = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+
+        # Every original trace_id must be present with identical status and flag.
+        second_by_id = {t.trace_id: t for t in second_run}
+        for trace_id, status, auto in first_snapshot:
+            assert trace_id in second_by_id
+            assert second_by_id[trace_id].status.value == status
+            assert second_by_id[trace_id].auto_accepted is auto

--- a/tests/services/test_policy_log.py
+++ b/tests/services/test_policy_log.py
@@ -1,0 +1,147 @@
+"""Tests for the append-only PolicyEventLog."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_append_writes_event_to_file(tmp_path: Path):
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+    event = PolicyEvent(
+        event_type=PolicyEventType.THRESHOLD_SET,
+        operation="map",
+        new_value=0.85,
+    )
+    log.append(event)
+
+    files = list((tmp_path / ".lemma" / "policy-events").glob("*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text().strip().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["operation"] == "map"
+    assert entry["event_type"] == "threshold_set"
+
+
+def test_read_all_returns_events_in_order(tmp_path: Path):
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_SET,
+            operation="map",
+            new_value=0.80,
+        )
+    )
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_CHANGED,
+            operation="map",
+            previous_value=0.80,
+            new_value=0.95,
+        )
+    )
+
+    events = log.read_all()
+    assert len(events) == 2
+    assert events[0].event_type.value == "threshold_set"
+    assert events[1].event_type.value == "threshold_changed"
+
+
+def test_policy_log_is_append_only(tmp_path: Path):
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+    assert not hasattr(log, "update")
+    assert not hasattr(log, "delete")
+    assert not hasattr(log, "clear")
+
+
+def test_latest_threshold_returns_none_when_no_events(tmp_path: Path):
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+    assert log.latest_threshold("map") is None
+
+
+def test_latest_threshold_returns_new_value_of_most_recent_event(tmp_path: Path):
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_SET,
+            operation="map",
+            new_value=0.80,
+        )
+    )
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_CHANGED,
+            operation="map",
+            previous_value=0.80,
+            new_value=0.95,
+        )
+    )
+
+    assert log.latest_threshold("map") == 0.95
+
+
+def test_latest_threshold_after_removal_is_none(tmp_path: Path):
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_SET,
+            operation="map",
+            new_value=0.80,
+        )
+    )
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_REMOVED,
+            operation="map",
+            previous_value=0.80,
+            new_value=None,
+        )
+    )
+
+    assert log.latest_threshold("map") is None
+
+
+def test_latest_threshold_isolated_by_operation(tmp_path: Path):
+    from lemma.models.policy import PolicyEvent, PolicyEventType
+    from lemma.services.policy_log import PolicyEventLog
+
+    log = PolicyEventLog(log_dir=tmp_path / ".lemma" / "policy-events")
+
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_SET,
+            operation="map",
+            new_value=0.80,
+        )
+    )
+    log.append(
+        PolicyEvent(
+            event_type=PolicyEventType.THRESHOLD_SET,
+            operation="harmonize",
+            new_value=0.90,
+        )
+    )
+
+    assert log.latest_threshold("map") == 0.80
+    assert log.latest_threshold("harmonize") == 0.90
+    assert log.latest_threshold("nonexistent") is None

--- a/tests/services/test_trace_log.py
+++ b/tests/services/test_trace_log.py
@@ -323,3 +323,59 @@ class TestTraceLog:
         rejection = all_traces[-1]
         assert rejection.status == TraceStatus.REJECTED
         assert "not relevant" in rejection.review_rationale
+
+
+class TestAutoAccept:
+    """Tests for confidence-gated automatic acceptance."""
+
+    def _proposed(self, confidence: float = 0.9) -> AITrace:
+        return AITrace(
+            operation="map",
+            input_text="text",
+            prompt="p",
+            model_id="ollama/llama3.2",
+            model_version="3.2",
+            raw_output="o",
+            confidence=confidence,
+            determination="MAPPED",
+            control_id="ac-1",
+            framework="nist-800-53",
+        )
+
+    def test_auto_accept_appends_accepted_review_entry(self, tmp_path: Path):
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        original = self._proposed(confidence=0.92)
+        log.append(original)
+
+        log.auto_accept(original, threshold=0.85)
+
+        all_traces = log.read_all()
+        assert len(all_traces) == 2
+        review = all_traces[-1]
+        assert review.status == TraceStatus.ACCEPTED
+        assert review.auto_accepted is True
+        assert review.parent_trace_id == original.trace_id
+
+    def test_auto_accept_rationale_records_threshold(self, tmp_path: Path):
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        original = self._proposed(confidence=0.97)
+        log.append(original)
+
+        log.auto_accept(original, threshold=0.95)
+
+        review = log.read_all()[-1]
+        assert "0.970" in review.review_rationale
+        assert "0.950" in review.review_rationale
+        assert "map" in review.review_rationale
+
+    def test_human_reviews_default_to_not_auto_accepted(self, tmp_path: Path):
+        """Manual review() entries must not carry auto_accepted=True."""
+        log = TraceLog(log_dir=tmp_path / ".lemma" / "traces")
+        original = self._proposed(confidence=0.5)
+        log.append(original)
+
+        log.review(original.trace_id, status=TraceStatus.ACCEPTED)
+
+        review = log.read_all()[-1]
+        assert review.status == TraceStatus.ACCEPTED
+        assert review.auto_accepted is False


### PR DESCRIPTION
## Description

Adds confidence-gated automation for AI mapping outputs. Introduces per-operation confidence thresholds in `lemma.config.yaml` under `ai.automation.thresholds`. When a `map` output's confidence is at or above the configured threshold, its trace entry is auto-promoted from `PROPOSED` to `ACCEPTED` with `auto_accepted: true`, and the applied threshold is recorded in the review rationale. Outputs below the threshold stay `PROPOSED`, preserving the existing human-in-the-loop flow.

**Why:** Phase 2 of the roadmap calls for confidence-gated automation on top of the transparency layer (#72, #74, #78, #79). With the HITL primitives already landed, this closes out the automation half so trusted mappings can flow without review while uncertain ones still queue.

**Design notes:**

- `AITrace` gains an `auto_accepted: bool` field defaulting to `false`, so existing manual `review()` calls remain clearly distinguishable from gate-driven acceptances in the audit log.
- `TraceLog.auto_accept(original, threshold=...)` is a new helper that skips the `read_all()` lookup in `review()` since the mapper already holds the original trace — avoids O(n²) over a mapping run.
- `AutomationConfig` validates every threshold is in `[0.0, 1.0]` at load time; invalid config surfaces as a `ValueError` from the `map` command.
- Operations without a configured threshold are never auto-accepted (absence = human-review-required).
- `.claude/` is added to `.gitignore` as an unrelated housekeeping change.

**Deferred from this PR:** the AC also mentions "threshold changes logged as auditable policy events." I interpreted this as recording the applied threshold on each auto-accept trace (which it does). A dedicated config-change policy event log would require state tracking across runs — happy to add in a follow-up if that's the intended reading.

Fixes #80

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest \`main\` branch
- [x] I have run \`npm run test\` (or equivalent) and all tests pass (215 passed)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (CHANGELOG + CLI reference)
- [x] My changes generate no new warnings or errors