### PR TITLE
ci(docs): Grant contents:write so gh-deploy can push to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
   build-docs:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       


### PR DESCRIPTION
## Description

The Documentation workflow has been failing on \`main\` with a 403 from \`github-actions[bot]\` when \`mkdocs gh-deploy\` tries to push the built site to the \`gh-pages\` branch:

\`\`\`
remote: Permission to JoshDoesIT/Lemma.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/JoshDoesIT/Lemma/': The requested URL returned error: 403
subprocess.CalledProcessError: Command '['git', 'push', 'origin', 'gh-pages', '--force']' returned non-zero exit status 128.
\`\`\`

GitHub made the default \`GITHUB_TOKEN\` read-only a while back, so workflows that push to \`gh-pages\` now need an explicit \`permissions: contents: write\` block. This adds that block to the \`build-docs\` job only — no other permissions are elevated and the blast radius is a single job.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Pre-Submission Checklist

- [x] I have rebased on the latest \`main\` branch
- [x] I have performed a self-review of my code