### PR TITLE
feat(models): Add OCSF event type models for evidence normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- OCSF (Open Cybersecurity Schema Framework) event type models at `src/lemma/models/ocsf.py`. Adds an `OcsfBaseEvent` and three concrete classes — `ComplianceFinding` (2003), `DetectionFinding` (2004), `AuthenticationEvent` (3002) — so future connectors can emit evidence in a vendor-agnostic wire format. Category consistency is enforced per class; enums use `IntEnum` to match OCSF's integer identifiers.
 - `lemma ai bom` CLI command exports an AI Bill of Materials in CycloneDX 1.6 JSON format, enumerating every model in the system card with name, version, provider, purpose, training data provenance, and optional SHA hash. Output is validated against a bundled CycloneDX 1.6 structural schema before it leaves the process.
 - Optional `model_hash` field on `ModelCard` for supply-chain integrity digests (e.g., `sha256:...`).
 - Confidence-gated automation for AI mapping. `ai.automation.thresholds.<operation>` in `lemma.config.yaml` auto-accepts AI outputs at or above the configured threshold; outputs below remain PROPOSED for human review. Auto-accepted trace entries are marked with `auto_accepted: true` and record the applied threshold in the review rationale.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -131,6 +131,42 @@ classDiagram
     Control --> Control : sub-controls
 ```
 
+## OCSF Evidence Models
+
+Lemma's Phase 3 connectors will collect compliance evidence from disparate sources — SIEM, CSPM, ITSM, identity providers. To avoid inventing a proprietary schema, Lemma adopts [**OCSF** (Open Cybersecurity Schema Framework)](https://schema.ocsf.io/) as the wire format for normalized evidence.
+
+OCSF provides a vendor-agnostic taxonomy of security telemetry maintained by a broad industry consortium and licensed Apache-2.0. Each event carries:
+
+- A numeric `class_uid` identifying the specific event class (e.g., `2003` = Compliance Finding).
+- A numeric `category_uid` identifying the high-level category (e.g., `2000` = Findings, `3000` = IAM).
+- Standardized fields for `time`, `severity_id`, `status_id`, `activity_id`, `metadata`, and a free-form `message`.
+
+### Classes modeled today
+
+This release ships the minimum lexicon needed to prove the schema and unblock connector work. All three classes live in `src/lemma/models/ocsf.py`.
+
+| Class | `class_uid` | Category | Why it's here |
+|---|---|---|---|
+| `ComplianceFinding` | 2003 | Findings (2000) | Direct representation of an evaluated compliance control outcome — the most natural OCSF class for GRC evidence. |
+| `DetectionFinding` | 2004 | Findings (2000) | The modern replacement for the deprecated Security Finding (2001) class in OCSF 1.1+. Used when a connector emits a generic detection result that still maps to a control. |
+| `AuthenticationEvent` | 3002 | IAM (3000) | Evidence of identity and access activity (MFA use, SSO logins, privilege escalations) — a common compliance signal. Also proves the base-class design generalizes across categories. |
+
+### Design notes
+
+- **Enums are `IntEnum`, not `StrEnum`.** OCSF serializes identifiers as integers on the wire; `StrEnum` would force lossy coercion. This is a deliberate divergence from the `StrEnum` pattern used by `TraceStatus` and `PolicyEventType`.
+- **Category consistency is enforced.** Each concrete class pins its `class_uid` via `Literal[...]` and validates that `category_uid` matches the expected category — so a misconfigured connector fails loudly on ingestion instead of silently polluting the graph.
+- **Nested OCSF objects (`Actor`, `Device`, full `Metadata`) are typed as `dict[str, Any]` for now.** Strongly-typed sub-schemas will arrive driven by connector demand rather than speculatively modeled.
+
+### What's deferred
+
+The following are intentionally out of scope for this release and will arrive with connector work:
+
+- An event normalization / ingestion service.
+- Connector adapters that emit these events.
+- OCSF-to-control mapping logic (belongs in the harmonization/mapping layer).
+- Additional OCSF event classes beyond the three above.
+- Per-class `activity_id` enums.
+
 ## Project Layout
 
 ```

--- a/src/lemma/models/ocsf.py
+++ b/src/lemma/models/ocsf.py
@@ -1,0 +1,115 @@
+"""OCSF (Open Cybersecurity Schema Framework) event type models.
+
+Defines a minimal set of OCSF v1.x event classes used to normalize
+evidence collected by future connectors (SIEM, CSPM, ITSM, IdP) into a
+common, vendor-agnostic schema before it enters Lemma's compliance
+graph.
+
+Divergence from the repo's ``StrEnum`` convention: OCSF uses integer
+identifiers on the wire (``class_uid``, ``category_uid``,
+``severity_id`` are all ints), so the enums below are ``IntEnum`` to
+serialize correctly without coercion. See
+https://schema.ocsf.io/ for the authoritative schema.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import IntEnum
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class OcsfCategory(IntEnum):
+    """OCSF top-level event categories."""
+
+    FINDINGS = 2000
+    IAM = 3000
+
+
+class OcsfSeverity(IntEnum):
+    """OCSF severity levels (``severity_id`` field)."""
+
+    INFORMATIONAL = 1
+    LOW = 2
+    MEDIUM = 3
+    HIGH = 4
+    CRITICAL = 5
+    FATAL = 6
+
+
+class OcsfBaseEvent(BaseModel):
+    """Shared fields for every OCSF event.
+
+    Attributes:
+        class_uid: OCSF class identifier (e.g. 2003 for Compliance Finding).
+        class_name: Human-readable class name.
+        category_uid: Top-level category identifier (e.g. 2000 for Findings).
+        category_name: Human-readable category name.
+        type_uid: Specific type within the class (class-specific encoding).
+        time: Event occurrence time (defaults to now, UTC).
+        severity_id: OCSF severity level; defaults to INFORMATIONAL.
+        activity_id: Class-specific activity identifier.
+        metadata: OCSF metadata object (product, version, etc.).
+        status_id: Class-specific status code (0 = Unknown).
+        message: Free-form event message.
+    """
+
+    class_uid: int
+    class_name: str
+    category_uid: int
+    category_name: str
+    type_uid: int
+    time: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    severity_id: OcsfSeverity = OcsfSeverity.INFORMATIONAL
+    activity_id: int
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    status_id: int = 0
+    message: str = ""
+
+
+class _CategoryPinnedEvent(OcsfBaseEvent):
+    """Base for concrete classes that pin a specific OCSF category.
+
+    Subclasses declare ``_expected_category`` and a ``Literal`` default
+    on ``class_uid``; the validator below asserts ``category_uid``
+    matches the declared category so miswired producers fail loudly.
+    """
+
+    _expected_category: ClassVar[int]
+
+    @model_validator(mode="after")
+    def _enforce_category(self) -> _CategoryPinnedEvent:
+        if self.category_uid != self._expected_category:
+            msg = (
+                f"{type(self).__name__} requires category_uid="
+                f"{self._expected_category}, got {self.category_uid}."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class ComplianceFinding(_CategoryPinnedEvent):
+    """OCSF Compliance Finding (class_uid=2003, Findings category)."""
+
+    _expected_category: ClassVar[int] = OcsfCategory.FINDINGS
+    class_uid: Literal[2003] = 2003
+
+
+class DetectionFinding(_CategoryPinnedEvent):
+    """OCSF Detection Finding (class_uid=2004, Findings category).
+
+    Detection Finding replaces the deprecated Security Finding (2001)
+    in OCSF 1.1+ and is the preferred class for modern producers.
+    """
+
+    _expected_category: ClassVar[int] = OcsfCategory.FINDINGS
+    class_uid: Literal[2004] = 2004
+
+
+class AuthenticationEvent(_CategoryPinnedEvent):
+    """OCSF Authentication (class_uid=3002, IAM category)."""
+
+    _expected_category: ClassVar[int] = OcsfCategory.IAM
+    class_uid: Literal[3002] = 3002

--- a/tests/fixtures/ocsf/authentication_sample.json
+++ b/tests/fixtures/ocsf/authentication_sample.json
@@ -1,0 +1,19 @@
+{
+  "class_uid": 3002,
+  "class_name": "Authentication",
+  "category_uid": 3000,
+  "category_name": "IAM",
+  "type_uid": 300201,
+  "activity_id": 1,
+  "time": 1712345690000,
+  "severity_id": 1,
+  "status_id": 1,
+  "message": "User authenticated via SSO.",
+  "metadata": {
+    "version": "1.3.0",
+    "product": {
+      "name": "Okta",
+      "vendor_name": "Okta, Inc."
+    }
+  }
+}

--- a/tests/fixtures/ocsf/compliance_finding_sample.json
+++ b/tests/fixtures/ocsf/compliance_finding_sample.json
@@ -1,0 +1,20 @@
+{
+  "class_uid": 2003,
+  "class_name": "Compliance Finding",
+  "category_uid": 2000,
+  "category_name": "Findings",
+  "type_uid": 200301,
+  "activity_id": 1,
+  "time": 1712345678000,
+  "severity_id": 3,
+  "status_id": 1,
+  "message": "Policy requirement AC-7 evaluated.",
+  "metadata": {
+    "version": "1.3.0",
+    "product": {
+      "name": "Lemma",
+      "vendor_name": "Lemma GRC",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/tests/models/test_ocsf.py
+++ b/tests/models/test_ocsf.py
@@ -1,0 +1,169 @@
+"""Tests for OCSF (Open Cybersecurity Schema Framework) event type models.
+
+Event payloads used in the fixture-based tests are adapted from examples
+published at https://schema.ocsf.io/ (Apache-2.0).
+"""
+
+from __future__ import annotations
+
+
+def test_ocsf_category_enum_has_canonical_ids():
+    from lemma.models.ocsf import OcsfCategory
+
+    assert int(OcsfCategory.FINDINGS) == 2000
+    assert int(OcsfCategory.IAM) == 3000
+
+
+def test_ocsf_severity_enum_matches_ocsf_spec():
+    from lemma.models.ocsf import OcsfSeverity
+
+    assert int(OcsfSeverity.INFORMATIONAL) == 1
+    assert int(OcsfSeverity.LOW) == 2
+    assert int(OcsfSeverity.MEDIUM) == 3
+    assert int(OcsfSeverity.HIGH) == 4
+    assert int(OcsfSeverity.CRITICAL) == 5
+    assert int(OcsfSeverity.FATAL) == 6
+
+
+def test_ocsf_base_event_requires_core_fields():
+    from lemma.models.ocsf import OcsfBaseEvent
+
+    event = OcsfBaseEvent(
+        class_uid=2003,
+        class_name="Compliance Finding",
+        category_uid=2000,
+        category_name="Findings",
+        type_uid=200301,
+        activity_id=1,
+    )
+    # time auto-populates; metadata defaults to empty mapping
+    assert event.class_uid == 2003
+    assert event.time is not None
+    assert event.metadata == {}
+    assert event.message == ""
+
+
+def test_ocsf_base_event_rejects_missing_class_uid():
+    import pytest
+    from pydantic import ValidationError
+
+    from lemma.models.ocsf import OcsfBaseEvent
+
+    with pytest.raises(ValidationError):
+        OcsfBaseEvent(
+            class_name="X",
+            category_uid=2000,
+            category_name="Findings",
+            type_uid=1,
+            activity_id=1,
+        )
+
+
+def test_compliance_finding_pins_class_uid_2003():
+    from lemma.models.ocsf import ComplianceFinding
+
+    finding = ComplianceFinding(
+        class_name="Compliance Finding",
+        category_uid=2000,
+        category_name="Findings",
+        type_uid=200301,
+        activity_id=1,
+    )
+    assert finding.class_uid == 2003
+    assert finding.category_uid == 2000
+
+
+def test_compliance_finding_validates_category_consistency():
+    import pytest
+    from pydantic import ValidationError
+
+    from lemma.models.ocsf import ComplianceFinding
+
+    with pytest.raises(ValidationError):
+        ComplianceFinding(
+            class_name="Compliance Finding",
+            category_uid=3000,  # IAM — wrong category for a Finding
+            category_name="IAM",
+            type_uid=200301,
+            activity_id=1,
+        )
+
+
+def test_detection_finding_pins_class_uid_2004():
+    from lemma.models.ocsf import DetectionFinding
+
+    finding = DetectionFinding(
+        class_name="Detection Finding",
+        category_uid=2000,
+        category_name="Findings",
+        type_uid=200401,
+        activity_id=1,
+    )
+    assert finding.class_uid == 2004
+    assert finding.category_uid == 2000
+
+
+def test_authentication_event_pins_class_uid_3002_and_category_3000():
+    from lemma.models.ocsf import AuthenticationEvent
+
+    event = AuthenticationEvent(
+        class_name="Authentication",
+        category_uid=3000,
+        category_name="IAM",
+        type_uid=300201,
+        activity_id=1,
+    )
+    assert event.class_uid == 3002
+    assert event.category_uid == 3000
+
+
+def _load_fixture(name: str) -> dict:
+    import json
+    from pathlib import Path
+
+    return json.loads((Path(__file__).parent.parent / "fixtures" / "ocsf" / name).read_text())
+
+
+def test_compliance_finding_parses_sample_ocsf_payload():
+    """Sample payload adapted from https://schema.ocsf.io/ (Apache-2.0)."""
+    from lemma.models.ocsf import ComplianceFinding
+
+    payload = _load_fixture("compliance_finding_sample.json")
+    finding = ComplianceFinding.model_validate(payload)
+
+    assert finding.class_uid == 2003
+    assert finding.category_uid == 2000
+    assert finding.metadata["product"]["name"]
+
+
+def test_authentication_event_parses_sample_ocsf_payload():
+    """Sample payload adapted from https://schema.ocsf.io/ (Apache-2.0)."""
+    from lemma.models.ocsf import AuthenticationEvent
+
+    payload = _load_fixture("authentication_sample.json")
+    event = AuthenticationEvent.model_validate(payload)
+
+    assert event.class_uid == 3002
+    assert event.category_uid == 3000
+    assert event.metadata["version"]
+
+
+def test_ocsf_event_serializes_to_json_with_snake_case_keys():
+    import json
+
+    from lemma.models.ocsf import ComplianceFinding
+
+    finding = ComplianceFinding(
+        class_name="Compliance Finding",
+        category_uid=2000,
+        category_name="Findings",
+        type_uid=200301,
+        activity_id=1,
+    )
+    data = json.loads(finding.model_dump_json())
+
+    assert data["class_uid"] == 2003
+    assert data["category_uid"] == 2000
+    assert data["severity_id"] == 1  # default INFORMATIONAL
+    assert "time" in data
+    assert "metadata" in data


### PR DESCRIPTION
## Description

Adds OCSF (Open Cybersecurity Schema Framework) v1.x base event types as Pydantic models in `src/lemma/models/ocsf.py`. This is the wire schema Phase 3 connectors (#26, #27) will emit so every piece of collected compliance evidence has a consistent shape regardless of source (SIEM, CSPM, ITSM, IdP).

**Why OCSF and not a proprietary schema:** OCSF is a vendor-agnostic taxonomy of security telemetry maintained by a broad industry consortium and licensed Apache-2.0. Adopting it now — before any connectors ship — avoids inventing a proprietary evidence schema we'd later have to migrate off of. Modern OCSF producers (Splunk, Palo Alto, AWS Security Hub, Okta) already emit events in this format.

**What's in this PR:**

- `OcsfBaseEvent` with the shared fields required by every OCSF class (`class_uid`, `category_uid`, `type_uid`, `time`, `severity_id`, `activity_id`, `metadata`, `status_id`, `message`).
- Three concrete classes — the minimum lexicon that satisfies the issue's AC of validating ≥ 2 event categories while proving the base design generalizes:
  - `ComplianceFinding` (`class_uid=2003`, Findings) — direct representation of an evaluated compliance control outcome, the most natural class for GRC evidence.
  - `DetectionFinding` (`class_uid=2004`, Findings) — the modern replacement for the deprecated Security Finding (2001) class in OCSF 1.1+.
  - `AuthenticationEvent` (`class_uid=3002`, IAM) — identity and access telemetry (MFA, SSO, privilege escalation). Second category satisfies the AC.
- Unit tests covering enum shape, base construction, `Literal` class_uid pinning, category consistency validation, and fixture round-trips for both categories.
- Sample payloads in `tests/fixtures/ocsf/` adapted from the [OCSF schema browser](https://schema.ocsf.io/) (Apache-2.0).
- New "OCSF Evidence Models" section in `docs/concepts/index.md` covering adoption rationale, class selection, and deferred scope.

**Design calls worth flagging:**

- **Enums are `IntEnum`, not `StrEnum`.** Deliberate divergence from the `TraceStatus` / `PolicyEventType` pattern: OCSF serializes identifiers as integers on the wire, so `StrEnum` would force lossy coercion. Documented in the module docstring.
- **Category consistency is enforced via a `model_validator` on a private `_CategoryPinnedEvent` base.** Each concrete class declares its expected category as a `ClassVar` and pins `class_uid` with `Literal[...]`. Misconfigured producers fail at validation rather than silently polluting the graph.
- **Nested OCSF objects (`Actor`, `Device`, full `Metadata`) are typed as `dict[str, Any]`.** Strongly-typed sub-schemas will arrive driven by connector demand, not speculatively.

**Deferred scope — tracked in follow-up issues:**

- Event ingestion and normalization service → #87
- OCSF-to-control mapping in the compliance graph → #88
- Additional OCSF event classes and per-class `activity_id` enums → #89
- Connector adapters that emit these events → #26 (SDK), #27 (first-party)

Fixes #68

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `uv run ruff check` and `uv run ruff format --check` with no errors
- [x] I have run `uv run pytest` and all 266 tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (CHANGELOG + concepts guide)
- [x] My changes generate no new warnings or errors