### PR TITLE
feat(evidence): Add OCSF normalizer and append-only evidence log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- OCSF event ingestion. `normalize()` in `src/lemma/services/ocsf_normalizer.py` dispatches an incoming payload to the right concrete OCSF model via a Pydantic discriminated-union `TypeAdapter`, rejecting payloads with a missing/unknown `class_uid` or naive (tz-less) `time`. `EvidenceLog` in `src/lemma/services/evidence_log.py` persists normalized events to `.lemma/evidence/YYYY-MM-DD.jsonl`, with `append`/`read_all`/`filter_by_class`/`filter_by_time_range` and append-time dedupe keyed on `metadata.uid` (falling back to a content hash). The log is strictly append-only — no update/delete/clear.
 - OCSF (Open Cybersecurity Schema Framework) event type models at `src/lemma/models/ocsf.py`. Adds an `OcsfBaseEvent` and three concrete classes — `ComplianceFinding` (2003), `DetectionFinding` (2004), `AuthenticationEvent` (3002) — so future connectors can emit evidence in a vendor-agnostic wire format. Category consistency is enforced per class; enums use `IntEnum` to match OCSF's integer identifiers.
 - `lemma ai bom` CLI command exports an AI Bill of Materials in CycloneDX 1.6 JSON format, enumerating every model in the system card with name, version, provider, purpose, training data provenance, and optional SHA hash. Output is validated against a bundled CycloneDX 1.6 structural schema before it leaves the process.
 - Optional `model_hash` field on `ModelCard` for supply-chain integrity digests (e.g., `sha256:...`).

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -157,15 +157,21 @@ This release ships the minimum lexicon needed to prove the schema and unblock co
 - **Category consistency is enforced.** Each concrete class pins its `class_uid` via `Literal[...]` and validates that `category_uid` matches the expected category — so a misconfigured connector fails loudly on ingestion instead of silently polluting the graph.
 - **Nested OCSF objects (`Actor`, `Device`, full `Metadata`) are typed as `dict[str, Any]` for now.** Strongly-typed sub-schemas will arrive driven by connector demand rather than speculatively modeled.
 
+### Evidence log and ingestion
+
+Normalized OCSF events land in an append-only log at `.lemma/evidence/YYYY-MM-DD.jsonl`, the same pattern already proven by the AI trace log and policy event log.
+
+Two services drive ingestion:
+
+- **`normalize(payload)`** (`src/lemma/services/ocsf_normalizer.py`) — takes an OCSF-shaped dict and returns the correct concrete model (`ComplianceFinding`, `DetectionFinding`, `AuthenticationEvent`) via a Pydantic discriminated union. Rejects payloads with a missing or unknown `class_uid`, and rejects naive datetimes on `time` since OCSF is UTC on the wire.
+- **`EvidenceLog`** (`src/lemma/services/evidence_log.py`) — `append`, `read_all`, `filter_by_class`, `filter_by_time_range`. Dedupe happens at append time: if the event's `metadata.uid` (or, when absent, a content hash of the model) already appears in today's log file, the second `append` is a no-op and returns `False`. Dedupe scope is intentionally today's file only; cross-midnight duplicates are rare enough not to justify scanning the full log on every write.
+
 ### What's deferred
 
-The following are intentionally out of scope for this release and will arrive with connector work:
-
-- An event normalization / ingestion service.
-- Connector adapters that emit these events.
-- OCSF-to-control mapping logic (belongs in the harmonization/mapping layer).
-- Additional OCSF event classes beyond the three above.
-- Per-class `activity_id` enums.
+- Connector adapters that emit these events (#26 SDK, #27 first-party).
+- Linking evidence to controls in the compliance graph (#88).
+- Additional OCSF event classes and per-class `activity_id` enums (#89).
+- CLI surface (`lemma evidence ingest`) — open an issue first if wanted.
 
 ## Project Layout
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -171,7 +171,7 @@ Two services drive ingestion:
 - Connector adapters that emit these events (#26 SDK, #27 first-party).
 - Linking evidence to controls in the compliance graph (#88).
 - Additional OCSF event classes and per-class `activity_id` enums (#89).
-- CLI surface (`lemma evidence ingest`) — open an issue first if wanted.
+- `lemma evidence ingest <file>` CLI for manual / operator ingestion (#91).
 
 ## Project Layout
 

--- a/src/lemma/services/evidence_log.py
+++ b/src/lemma/services/evidence_log.py
@@ -1,0 +1,93 @@
+"""Append-only evidence log — normalized OCSF events on disk.
+
+Stores OCSF events as newline-delimited JSON (JSONL) files partitioned
+by UTC date under ``.lemma/evidence/YYYY-MM-DD.jsonl``. Polymorphic
+reads are driven by the same discriminated-union ``TypeAdapter`` used
+by the normalizer, so every event returned from ``read_all`` is a
+concrete OCSF model (``ComplianceFinding``, ``DetectionFinding``, or
+``AuthenticationEvent``).
+
+The log is strictly append-only: no update, delete, or clear methods.
+Dedupe is performed at append time against today's log file so every
+stored line is unique by construction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lemma.models.ocsf import OcsfBaseEvent
+from lemma.services.ocsf_normalizer import ocsf_adapter
+
+
+def _dedupe_key(event: OcsfBaseEvent) -> str:
+    """Return a stable idempotency key for ``event``.
+
+    Prefers the producer-supplied ``metadata.uid`` (OCSF's canonical
+    idempotency hint). Falls back to a SHA-256 hash over the full model
+    dump when ``metadata.uid`` is absent, so retries of the same event
+    still collapse without losing genuine same-second distinct events
+    that carry different content.
+    """
+    uid = event.metadata.get("uid")
+    if isinstance(uid, str) and uid:
+        return f"uid:{uid}"
+    digest = hashlib.sha256(event.model_dump_json().encode()).hexdigest()
+    return f"hash:{digest}"
+
+
+class EvidenceLog:
+    """Append-only log of normalized OCSF evidence events."""
+
+    def __init__(self, log_dir: Path) -> None:
+        self._log_dir = log_dir
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+
+    def _log_file(self, dt: datetime | None = None) -> Path:
+        if dt is None:
+            dt = datetime.now(UTC)
+        return self._log_dir / f"{dt.strftime('%Y-%m-%d')}.jsonl"
+
+    def _seen_keys_today(self, log_file: Path) -> set[str]:
+        if not log_file.exists():
+            return set()
+        keys: set[str] = set()
+        for line in log_file.read_text().strip().splitlines():
+            if not line.strip():
+                continue
+            prior = ocsf_adapter.validate_json(line)
+            keys.add(_dedupe_key(prior))
+        return keys
+
+    def append(self, event: OcsfBaseEvent) -> bool:
+        """Append an event to the log.
+
+        Returns ``True`` when a new line was written, ``False`` if the
+        event was skipped by the dedupe guard (see module docstring).
+        Dedupe scope is the day-partitioned file for ``event.time``.
+        """
+        log_file = self._log_file(event.time)
+        if _dedupe_key(event) in self._seen_keys_today(log_file):
+            return False
+        with log_file.open("a") as f:
+            f.write(event.model_dump_json() + "\n")
+        return True
+
+    def read_all(self) -> list[OcsfBaseEvent]:
+        """Return every event in chronological (file, line) order."""
+        events: list[OcsfBaseEvent] = []
+        for log_file in sorted(self._log_dir.glob("*.jsonl")):
+            for line in log_file.read_text().strip().splitlines():
+                if line.strip():
+                    events.append(ocsf_adapter.validate_json(line))
+        return events
+
+    def filter_by_class(self, class_uid: int) -> list[OcsfBaseEvent]:
+        """Return every event with the given ``class_uid``."""
+        return [e for e in self.read_all() if e.class_uid == class_uid]
+
+    def filter_by_time_range(self, start: datetime, end: datetime) -> list[OcsfBaseEvent]:
+        """Return events whose ``time`` falls in ``[start, end)`` (half-open)."""
+        return [e for e in self.read_all() if start <= e.time < end]

--- a/src/lemma/services/ocsf_normalizer.py
+++ b/src/lemma/services/ocsf_normalizer.py
@@ -1,0 +1,55 @@
+"""OCSF event normalization.
+
+Accepts raw OCSF payloads (as dicts or JSON strings) and returns the
+matching concrete Pydantic model from ``lemma.models.ocsf``. A single
+Pydantic discriminated-union ``TypeAdapter`` drives dispatch: the
+``class_uid`` field on every OCSF event is the sole discriminator.
+
+The same adapter is exported as ``ocsf_adapter`` for reuse by the
+evidence log when reading JSONL lines back into typed events.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field, TypeAdapter
+
+from lemma.models.ocsf import (
+    AuthenticationEvent,
+    ComplianceFinding,
+    DetectionFinding,
+    OcsfBaseEvent,
+)
+
+OcsfEvent = Annotated[
+    ComplianceFinding | DetectionFinding | AuthenticationEvent,
+    Field(discriminator="class_uid"),
+]
+
+ocsf_adapter: TypeAdapter[OcsfEvent] = TypeAdapter(OcsfEvent)
+
+
+def normalize(payload: dict) -> OcsfBaseEvent:
+    """Validate and dispatch an OCSF payload to its concrete model.
+
+    Args:
+        payload: OCSF-shaped dict. Must include ``class_uid``.
+
+    Returns:
+        The concrete event model keyed by ``class_uid``.
+
+    Raises:
+        ValueError: On missing/unknown ``class_uid``, validation errors
+            from the discriminated union, or a naive (tz-less) ``time``
+            value — OCSF is UTC on the wire, so a naive datetime at the
+            ingest boundary is almost certainly a producer bug.
+    """
+    event = ocsf_adapter.validate_python(payload)
+    if event.time.tzinfo is None:
+        msg = (
+            "OCSF event 'time' must carry tzinfo (UTC). Got a naive datetime "
+            f"for {type(event).__name__} (class_uid={event.class_uid})."
+        )
+        raise ValueError(msg)
+    return event

--- a/tests/services/test_evidence_log.py
+++ b/tests/services/test_evidence_log.py
@@ -1,0 +1,151 @@
+"""Tests for the append-only EvidenceLog."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+def _compliance_payload(uid: str = "evt-1", when: datetime | None = None) -> dict:
+    when = when or datetime.now(UTC)
+    return {
+        "class_uid": 2003,
+        "class_name": "Compliance Finding",
+        "category_uid": 2000,
+        "category_name": "Findings",
+        "type_uid": 200301,
+        "activity_id": 1,
+        "time": when.isoformat(),
+        "metadata": {
+            "version": "1.3.0",
+            "product": {"name": "Lemma"},
+            "uid": uid,
+        },
+    }
+
+
+def _auth_payload(uid: str = "auth-1", when: datetime | None = None) -> dict:
+    when = when or datetime.now(UTC)
+    return {
+        "class_uid": 3002,
+        "class_name": "Authentication",
+        "category_uid": 3000,
+        "category_name": "IAM",
+        "type_uid": 300201,
+        "activity_id": 1,
+        "time": when.isoformat(),
+        "metadata": {
+            "version": "1.3.0",
+            "product": {"name": "Okta"},
+            "uid": uid,
+        },
+    }
+
+
+def test_append_writes_one_line_and_read_all_round_trips(tmp_path: Path):
+    from lemma.models.ocsf import ComplianceFinding
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    event = normalize(_compliance_payload())
+
+    wrote = log.append(event)
+
+    assert wrote is True
+    files = list((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    assert len(files) == 1
+    assert len(files[0].read_text().strip().splitlines()) == 1
+
+    out = log.read_all()
+    assert len(out) == 1
+    assert isinstance(out[0], ComplianceFinding)
+    assert out[0].metadata["uid"] == "evt-1"
+
+
+def test_evidence_log_is_append_only(tmp_path: Path):
+    from lemma.services.evidence_log import EvidenceLog
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    assert not hasattr(log, "update")
+    assert not hasattr(log, "delete")
+    assert not hasattr(log, "clear")
+
+
+def test_read_all_returns_events_across_files_in_chronological_order(tmp_path: Path):
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    yesterday = datetime.now(UTC) - timedelta(days=1)
+    today = datetime.now(UTC)
+
+    event_yesterday = normalize(_compliance_payload("y-1", when=yesterday))
+    event_today = normalize(_compliance_payload("t-1", when=today))
+
+    # Append out-of-order to prove sort is by file name, not insertion order
+    log.append(event_today)
+    log.append(event_yesterday)
+
+    files = sorted((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    assert len(files) == 2  # one file per UTC date
+
+    out = log.read_all()
+    assert [e.metadata["uid"] for e in out] == ["y-1", "t-1"]
+
+
+def test_append_dedupes_by_metadata_uid(tmp_path: Path):
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    event = normalize(_compliance_payload("dup-1"))
+
+    assert log.append(event) is True
+    assert log.append(event) is False  # second call is a no-op
+
+    files = list((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    assert len(files[0].read_text().strip().splitlines()) == 1
+
+
+def test_append_content_hash_dedupe_when_uid_absent(tmp_path: Path):
+    """Producers that don't set metadata.uid fall back to content-hash dedupe."""
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    payload = _compliance_payload()
+    del payload["metadata"]["uid"]
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    event = normalize(payload)
+
+    assert log.append(event) is True
+    assert log.append(event) is False
+
+    files = list((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    assert len(files[0].read_text().strip().splitlines()) == 1
+
+
+def test_filter_by_class_and_time_range(tmp_path: Path):
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    t_early = datetime(2026, 4, 20, 12, 0, 0, tzinfo=UTC)
+    t_mid = datetime(2026, 4, 21, 12, 0, 0, tzinfo=UTC)
+    t_late = datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+
+    log.append(normalize(_compliance_payload("c-early", when=t_early)))
+    log.append(normalize(_compliance_payload("c-late", when=t_late)))
+    log.append(normalize(_auth_payload("a-mid", when=t_mid)))
+
+    # filter_by_class
+    compliance = log.filter_by_class(2003)
+    assert {e.metadata["uid"] for e in compliance} == {"c-early", "c-late"}
+    auth = log.filter_by_class(3002)
+    assert {e.metadata["uid"] for e in auth} == {"a-mid"}
+    assert log.filter_by_class(9999) == []
+
+    # filter_by_time_range — half-open [start, end)
+    window = log.filter_by_time_range(t_early, t_late)
+    assert {e.metadata["uid"] for e in window} == {"c-early", "a-mid"}

--- a/tests/services/test_ocsf_normalizer.py
+++ b/tests/services/test_ocsf_normalizer.py
@@ -1,0 +1,83 @@
+"""Tests for the OCSF ingestion normalizer."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def _base_payload(class_uid: int, class_name: str, category_uid: int, category_name: str) -> dict:
+    return {
+        "class_uid": class_uid,
+        "class_name": class_name,
+        "category_uid": category_uid,
+        "category_name": category_name,
+        "type_uid": class_uid * 100 + 1,
+        "activity_id": 1,
+        "time": datetime.now(UTC).isoformat(),
+        "metadata": {"version": "1.3.0", "product": {"name": "Lemma"}},
+    }
+
+
+def test_normalize_dispatches_compliance_finding():
+    from lemma.models.ocsf import ComplianceFinding
+    from lemma.services.ocsf_normalizer import normalize
+
+    event = normalize(_base_payload(2003, "Compliance Finding", 2000, "Findings"))
+
+    assert isinstance(event, ComplianceFinding)
+    assert event.class_uid == 2003
+
+
+def test_normalize_dispatches_detection_finding():
+    from lemma.models.ocsf import DetectionFinding
+    from lemma.services.ocsf_normalizer import normalize
+
+    event = normalize(_base_payload(2004, "Detection Finding", 2000, "Findings"))
+
+    assert isinstance(event, DetectionFinding)
+    assert event.class_uid == 2004
+
+
+def test_normalize_dispatches_authentication_event():
+    from lemma.models.ocsf import AuthenticationEvent
+    from lemma.services.ocsf_normalizer import normalize
+
+    event = normalize(_base_payload(3002, "Authentication", 3000, "IAM"))
+
+    assert isinstance(event, AuthenticationEvent)
+    assert event.class_uid == 3002
+
+
+def test_normalize_rejects_missing_class_uid():
+    import pytest
+
+    from lemma.services.ocsf_normalizer import normalize
+
+    payload = _base_payload(2003, "Compliance Finding", 2000, "Findings")
+    del payload["class_uid"]
+
+    with pytest.raises(ValueError, match="class_uid"):
+        normalize(payload)
+
+
+def test_normalize_rejects_unknown_class_uid():
+    import pytest
+
+    from lemma.services.ocsf_normalizer import normalize
+
+    payload = _base_payload(9999, "Made Up", 9000, "Unknown")
+
+    with pytest.raises(ValueError, match="class_uid"):
+        normalize(payload)
+
+
+def test_normalize_rejects_naive_time():
+    import pytest
+
+    from lemma.services.ocsf_normalizer import normalize
+
+    payload = _base_payload(2003, "Compliance Finding", 2000, "Findings")
+    payload["time"] = datetime(2026, 4, 21, 12, 0, 0).isoformat()  # no tzinfo
+
+    with pytest.raises(ValueError, match=r"time.*tzinfo|tzinfo.*time|timezone"):
+        normalize(payload)


### PR DESCRIPTION
## Description

Wires the OCSF event type models from PR #86 into a runtime path. Connectors (#26, #27) and downstream graph consumers (#88) now have a canonical ingestion surface that validates, dispatches, dedupes, and persists events.

**Two new services:**

- **`normalize(payload)`** (`src/lemma/services/ocsf_normalizer.py`) dispatches an incoming OCSF-shaped dict to the correct concrete model (`ComplianceFinding`, `DetectionFinding`, `AuthenticationEvent`) via a Pydantic discriminated-union `TypeAdapter` keyed on `class_uid`. Rejects payloads with a missing or unknown `class_uid`, and rejects naive (tz-less) `time` values — OCSF is UTC on the wire, so a naive datetime at the ingest boundary is almost always a producer bug.
- **`EvidenceLog`** (`src/lemma/services/evidence_log.py`) persists normalized events to `.lemma/evidence/YYYY-MM-DD.jsonl`. Methods: `append`, `read_all`, `filter_by_class`, `filter_by_time_range`. No update/delete/clear — append-only by construction, like `TraceLog` and `PolicyEventLog`.

**Design calls worth flagging:**

- **One source of truth for dispatch.** The same discriminated-union `TypeAdapter` is exported as `ocsf_adapter` and reused by `EvidenceLog.read_all` to rehydrate JSONL lines into the correct concrete model. Drift-proof by construction.
- **Dedupe key is stronger than what the issue AC literally listed.** The issue said `(class_uid, type_uid, time, source)`. That key collapses two distinct events from the same producer in the same second — a real concern for IAM events (rapid-fire SSO tries) and for CSPM (scan-frame bursts). The implemented key prefers `metadata.uid` when present (OCSF's canonical idempotency hint) and falls back to a SHA-256 hash over the full model dump. It's a strict superset of the tuple, not a replacement.
- **Dedupe scope is today's file only.** Cross-midnight duplicates are rare enough not to justify scanning the full log on every write. Documented in the module docstring. If exactness is ever needed, a sidecar `seen-uids` store can be added without breaking the public API.
- **`TypeAdapter.validate_json(line)` not `model_validate_json`** — the former is the `TypeAdapter` method; the latter is a `BaseModel` class method. Discriminated-union reads need the adapter.
- **UTC enforcement at the ingest boundary**, not at the model layer. Keeps the model surface from PR #86 stable and puts the defensive check where external data actually arrives.

**Deferred scope — tracked in follow-up issues:**

- `lemma evidence ingest <file>` CLI for manual/operator ingestion → #91
- Connector adapters that produce events → #26 (SDK), #27 (first-party)
- Graph edges from evidence → control → #88
- Additional OCSF event classes and per-class `activity_id` enums → #89

Fixes #87

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run `uv run ruff check` and `uv run ruff format --check` with no errors
- [x] I have run `uv run pytest` and all 278 tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (CHANGELOG + concepts guide)
- [x] My changes generate no new warnings or errors