### PR TITLE
feat(evidence): Sign and hash-chain the evidence log (Continuous Proof Chains)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Continuous proof chains on the evidence log. Every entry appended to `.lemma/evidence/YYYY-MM-DD.jsonl` is now wrapped in a `SignedEvidence` envelope with an SHA-256 hash chain (`prev_hash` → `entry_hash`) and an Ed25519 signature produced by the signing key for `metadata.product.name`. Per-producer keypairs live under `.lemma/keys/` with `0600` private-key permissions.
+- `lemma evidence verify <entry_hash>` — integrity check returning PROVEN (hash + chain + signature all valid), DEGRADED (hash + chain valid but signer's key unavailable), or VIOLATED (hash or chain broken). Non-zero exit on anything other than PROVEN.
+- `lemma evidence log` — Rich-table timeline showing time, class, producer, entry hash prefix, and per-row integrity state.
+- `EvidenceIntegrityState` enum, `SignedEvidence` envelope model, and `ProvenanceRecord` model. The storage-stage provenance record is populated today; earlier stages populate as connectors (#26/#27) arrive.
 - `lemma harmonize` now records every cross-framework equivalence decision as an `AITrace` with `operation="harmonize"`, honors `ai.automation.thresholds.harmonize` for confidence-gated auto-accept, and persists the result as an OSCAL Profile at `.lemma/harmonization.oscal.json`. The Profile imports each source catalog and encodes clusters as back-matter resources with `lemma:harmonized-cluster` properties and `rlinks` to member controls.
 - `related_control_id` and `related_framework` fields on `AITrace` to carry pair-event endpoints. Map traces (single-control) default them to empty strings; harmonize traces populate both sides with a deterministic primary/secondary ordering so each equivalence is one trace.
 - `lemma ai audit --operation <op>` filter for querying traces by operation type (e.g., `harmonize`, `map`).

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -316,6 +316,42 @@ lemma graph impact policy:access-control.md
 
 ---
 
+## `lemma evidence`
+
+Inspect and verify the append-only, signed, hash-chained evidence log.
+
+### `lemma evidence verify`
+
+Verify the integrity of a single evidence entry by its `entry_hash`.
+
+```bash
+lemma evidence verify <ENTRY_HASH>
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ENTRY_HASH` | Yes | Hex-encoded SHA-256 entry hash of the evidence to verify |
+
+The verdict is one of:
+
+- **PROVEN** — hash consistent, chain link to the prior entry intact, signature verifies under the producer's key.
+- **DEGRADED** — hash and chain are intact, but the signer's public key is unavailable (key rotated, revoked, or never imported).
+- **VIOLATED** — content has been modified or the chain has been broken somewhere at or before this entry.
+
+Exit code is `0` only on PROVEN; anything else exits `1` so scripts can fail-fast.
+
+### `lemma evidence log`
+
+Show every entry in the evidence log with its per-entry integrity state.
+
+```bash
+lemma evidence log
+```
+
+Output is a Rich table with columns for time, OCSF class name, producer, truncated entry hash, and the integrity verdict.
+
+---
+
 ## `lemma ai`
 
 AI transparency and governance commands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "httpx>=0.27",
     "networkx>=3.0",
     "jsonschema>=4.0",
+    "cryptography>=42.0",
 ]
 
 [project.optional-dependencies]

--- a/src/lemma/cli.py
+++ b/src/lemma/cli.py
@@ -17,6 +17,7 @@ Usage:
 import typer
 
 from lemma.commands.ai import ai_app
+from lemma.commands.evidence import evidence_app
 from lemma.commands.framework import framework_app
 from lemma.commands.graph import graph_app
 from lemma.commands.harmonize import (
@@ -47,6 +48,7 @@ app.command(name="diff", help="Compare framework versions")(diff_command)
 app.add_typer(framework_app, name="framework", help="Manage compliance frameworks")
 app.add_typer(graph_app, name="graph", help="Query the compliance knowledge graph")
 app.add_typer(ai_app, name="ai", help="AI transparency and governance")
+app.add_typer(evidence_app, name="evidence", help="Inspect and verify the evidence log")
 
 
 if __name__ == "__main__":

--- a/src/lemma/commands/evidence.py
+++ b/src/lemma/commands/evidence.py
@@ -1,0 +1,104 @@
+"""Implementation of the ``lemma evidence`` CLI sub-commands.
+
+Sub-commands:
+    lemma evidence verify <entry_hash>   — integrity check for a single entry
+    lemma evidence log                   — timeline with integrity state per row
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from lemma.models.signed_evidence import EvidenceIntegrityState
+from lemma.services.evidence_log import EvidenceLog
+
+console = Console()
+
+evidence_app = typer.Typer(
+    name="evidence",
+    help="Inspect and verify the evidence log.",
+    no_args_is_help=True,
+)
+
+
+def _require_lemma_project() -> Path:
+    cwd = Path.cwd()
+    if not (cwd / ".lemma").exists():
+        console.print("[red]Error:[/red] Not a Lemma project.")
+        console.print("Run [bold]lemma init[/bold] first.")
+        raise typer.Exit(code=1)
+    return cwd
+
+
+def _state_style(state: EvidenceIntegrityState) -> str:
+    if state == EvidenceIntegrityState.PROVEN:
+        return "[green]PROVEN[/green]"
+    if state == EvidenceIntegrityState.DEGRADED:
+        return "[yellow]DEGRADED[/yellow]"
+    return "[red]VIOLATED[/red]"
+
+
+def _producer_of(metadata: dict) -> str:
+    product = metadata.get("product") if isinstance(metadata, dict) else None
+    if isinstance(product, dict):
+        name = product.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return "unknown"
+
+
+@evidence_app.command(
+    name="verify",
+    help="Verify the integrity of a specific evidence entry by entry_hash.",
+)
+def verify_command(
+    entry_hash: str = typer.Argument(
+        help="Entry hash of the evidence to verify (hex)",
+    ),
+) -> None:
+    project_dir = _require_lemma_project()
+    log = EvidenceLog(log_dir=project_dir / ".lemma" / "evidence")
+
+    result = log.verify_entry(entry_hash)
+    console.print(f"{_state_style(result.state)}  {entry_hash[:16]}…")
+    console.print(f"  {result.detail}")
+
+    if result.state != EvidenceIntegrityState.PROVEN:
+        raise typer.Exit(code=1)
+
+
+@evidence_app.command(
+    name="log",
+    help="Show the evidence timeline with integrity state per entry.",
+)
+def log_command() -> None:
+    project_dir = _require_lemma_project()
+    log = EvidenceLog(log_dir=project_dir / ".lemma" / "evidence")
+    envelopes = log.read_envelopes()
+
+    if not envelopes:
+        console.print("[dim]No evidence entries. 0 entries.[/dim]")
+        return
+
+    table = Table(title=f"Evidence Log ({len(envelopes)} entries)")
+    table.add_column("Time", style="dim", width=19)
+    table.add_column("Class", min_width=14)
+    table.add_column("Producer", style="cyan")
+    table.add_column("Entry", style="dim", no_wrap=True)
+    table.add_column("State")
+
+    for env in envelopes:
+        result = log.verify_entry(env.entry_hash)
+        table.add_row(
+            env.event.time.strftime("%Y-%m-%d %H:%M:%S"),
+            env.event.class_name,
+            _producer_of(env.event.metadata),
+            env.entry_hash[:12] + "…",
+            _state_style(result.state),
+        )
+
+    console.print(table)

--- a/src/lemma/models/signed_evidence.py
+++ b/src/lemma/models/signed_evidence.py
@@ -1,0 +1,96 @@
+"""Signed, hash-chained envelope around an OCSF evidence event.
+
+The envelope wraps every event appended to ``EvidenceLog`` with the
+fields needed to verify integrity later:
+
+- ``prev_hash`` — entry hash of the previous log line (or 64 zeros for
+  the genesis entry).
+- ``entry_hash`` — SHA-256 over ``prev_hash`` concatenated with the
+  canonical JSON of the enveloped event.
+- ``signature`` — Ed25519 signature over the entry hash bytes.
+- ``signer_key_id`` — the stable key identifier from
+  ``crypto.public_key_id``.
+- ``provenance`` — one or more records documenting the transformation
+  chain that produced this entry.
+
+Integrity is scored with ``EvidenceIntegrityState`` — PROVEN /
+DEGRADED / VIOLATED — so verify operations can give a single answer
+per entry.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from lemma.models.ocsf import (
+    AuthenticationEvent,
+    ComplianceFinding,
+    DetectionFinding,
+)
+
+
+class EvidenceIntegrityState(StrEnum):
+    """Verification verdict for a single evidence entry.
+
+    Attributes:
+        PROVEN: Signature valid and hash chain intact through this entry.
+        DEGRADED: Chain intact but signature unverifiable (missing or
+            unknown key). Evidence from before crypto existed, or from a
+            producer whose public key we don't have, lands here.
+        VIOLATED: Chain broken or content does not match its entry hash.
+            The log has been tampered with at or before this entry.
+    """
+
+    PROVEN = "PROVEN"
+    DEGRADED = "DEGRADED"
+    VIOLATED = "VIOLATED"
+
+
+class ProvenanceRecord(BaseModel):
+    """One step in the transformation chain that produced an evidence entry.
+
+    Attributes:
+        stage: One of ``"source"``, ``"collection"``, ``"normalization"``,
+            ``"storage"``. Free-form string so Lemma-external connectors
+            can introduce their own stages; downstream tooling should
+            still handle unknown stages gracefully.
+        actor: Identifier of the component that performed the step.
+        timestamp: When the step occurred.
+        content_hash: SHA-256 hex of the payload at this stage.
+    """
+
+    stage: str
+    actor: str
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    content_hash: str
+
+
+OcsfEventUnion = Annotated[
+    ComplianceFinding | DetectionFinding | AuthenticationEvent,
+    Field(discriminator="class_uid"),
+]
+
+
+class SignedEvidence(BaseModel):
+    """Envelope wrapping an OCSF event with signature + chain metadata.
+
+    Attributes:
+        event: The OCSF event payload (concrete class preserved via a
+            ``class_uid`` discriminator).
+        prev_hash: SHA-256 hex of the prior entry, or 64 zeros for genesis.
+        entry_hash: SHA-256 hex over ``prev_hash || canonical_json(event)``.
+        signature: Hex-encoded Ed25519 signature over the entry hash bytes.
+        signer_key_id: Stable identifier of the public key used to sign.
+        provenance: Transformation chain producing this entry.
+    """
+
+    event: OcsfEventUnion
+    prev_hash: str
+    entry_hash: str
+    signature: str
+    signer_key_id: str
+    provenance: list[ProvenanceRecord] = Field(default_factory=list)

--- a/src/lemma/services/crypto.py
+++ b/src/lemma/services/crypto.py
@@ -1,0 +1,134 @@
+"""Ed25519 key management and signing primitives for evidence chains.
+
+Keys are persisted per-producer under the project's ``.lemma/keys/``
+directory. Each producer (``metadata.product.name`` on an OCSF event)
+owns one Ed25519 keypair; downstream code refers to keys by a stable
+``key_id`` derived from the public key bytes.
+
+This module is deliberately minimal: generate, load, sign, verify.
+Rotation and revocation are tracked in a follow-up issue and layer on
+top of this primitive surface without breaking its API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+def _safe_producer(producer: str) -> str:
+    """Producer names can contain characters unsafe for filenames.
+
+    Replace the OCSF-typical ``/`` and spaces with underscores so the
+    serialized key paths stay predictable.
+    """
+    return producer.replace("/", "_").replace(" ", "_")
+
+
+def _private_path(producer: str, key_dir: Path) -> Path:
+    return key_dir / f"{_safe_producer(producer)}.private.pem"
+
+
+def _public_path(producer: str, key_dir: Path) -> Path:
+    return key_dir / f"{_safe_producer(producer)}.public.pem"
+
+
+def generate_keypair(*, producer: str, key_dir: Path) -> str:
+    """Generate (or return the existing) Ed25519 keypair for ``producer``.
+
+    Idempotent: a second call for the same producer returns the
+    existing ``key_id`` without regenerating. Private key files are
+    written with mode ``0600``.
+
+    Args:
+        producer: Logical producer name (e.g., ``"Lemma"``, ``"Okta"``).
+        key_dir: Directory under which the keypair is persisted.
+
+    Returns:
+        A stable ``key_id`` derived from the public key bytes.
+    """
+    key_dir.mkdir(parents=True, exist_ok=True)
+    private_path = _private_path(producer, key_dir)
+    public_path = _public_path(producer, key_dir)
+
+    if private_path.exists() and public_path.exists():
+        return public_key_id(producer=producer, key_dir=key_dir)
+
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    private_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_bytes = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    private_path.write_bytes(private_bytes)
+    os.chmod(private_path, 0o600)
+    public_path.write_bytes(public_bytes)
+
+    return public_key_id(producer=producer, key_dir=key_dir)
+
+
+def _load_private(producer: str, key_dir: Path) -> Ed25519PrivateKey:
+    pem = _private_path(producer, key_dir).read_bytes()
+    return serialization.load_pem_private_key(pem, password=None)  # type: ignore[return-value]
+
+
+def _load_public(producer: str, key_dir: Path) -> Ed25519PublicKey | None:
+    path = _public_path(producer, key_dir)
+    if not path.exists():
+        return None
+    return serialization.load_pem_public_key(path.read_bytes())  # type: ignore[return-value]
+
+
+def public_key_id(*, producer: str, key_dir: Path) -> str:
+    """Return the stable ``key_id`` for a producer's public key.
+
+    Format: ``ed25519:<first 16 hex chars of SHA256(public_key_raw_bytes)>``.
+    """
+    public_key = _load_public(producer, key_dir)
+    if public_key is None:
+        msg = f"No public key on file for producer '{producer}' in {key_dir}"
+        raise FileNotFoundError(msg)
+    raw = public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    digest = hashlib.sha256(raw).hexdigest()[:16]
+    return f"ed25519:{digest}"
+
+
+def sign(message: bytes, *, producer: str, key_dir: Path) -> bytes:
+    """Sign ``message`` with the producer's private key."""
+    private_key = _load_private(producer, key_dir)
+    return private_key.sign(message)
+
+
+def verify(message: bytes, signature: bytes, *, producer: str, key_dir: Path) -> bool:
+    """Return ``True`` iff ``signature`` is a valid Ed25519 signature over ``message``.
+
+    Returns ``False`` (never raises) when the signature is invalid, when
+    the producer has no key on file, or when verification otherwise
+    fails. Callers get a boolean so they can produce a clean
+    PROVEN/VIOLATED verdict without exception handling at every site.
+    """
+    public_key = _load_public(producer, key_dir)
+    if public_key is None:
+        return False
+    try:
+        public_key.verify(signature, message)
+    except Exception:
+        return False
+    return True

--- a/src/lemma/services/evidence_log.py
+++ b/src/lemma/services/evidence_log.py
@@ -1,36 +1,88 @@
-"""Append-only evidence log — normalized OCSF events on disk.
+"""Append-only evidence log — signed, hash-chained OCSF events on disk.
 
-Stores OCSF events as newline-delimited JSON (JSONL) files partitioned
-by UTC date under ``.lemma/evidence/YYYY-MM-DD.jsonl``. Polymorphic
-reads are driven by the same discriminated-union ``TypeAdapter`` used
-by the normalizer, so every event returned from ``read_all`` is a
-concrete OCSF model (``ComplianceFinding``, ``DetectionFinding``, or
-``AuthenticationEvent``).
+Every appended event is wrapped in a ``SignedEvidence`` envelope and
+written to ``.lemma/evidence/YYYY-MM-DD.jsonl``. The envelope carries:
 
-The log is strictly append-only: no update, delete, or clear methods.
-Dedupe is performed at append time against today's log file so every
-stored line is unique by construction.
+- ``prev_hash`` — the entry hash of the previous line in the full log,
+  or 64 zeros for the genesis entry.
+- ``entry_hash`` — SHA-256 over ``prev_hash || canonical_json(event)``.
+- ``signature`` — Ed25519 signature over the entry hash bytes, produced
+  by the signing key for the producer named in
+  ``event.metadata.product.name``.
+- ``signer_key_id`` — stable public-key identifier from
+  ``lemma.services.crypto``.
+- ``provenance`` — transformation chain for the entry; this PR
+  populates the ``storage`` stage, and connector PRs will fill in the
+  earlier stages.
+
+Dedupe happens at append time against today's log file (see the
+``_dedupe_key`` helper). Verification walks the full log in order,
+confirming each entry's content hash, chain linkage, and signature.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from pydantic import TypeAdapter
+
 from lemma.models.ocsf import OcsfBaseEvent
-from lemma.services.ocsf_normalizer import ocsf_adapter
+from lemma.models.signed_evidence import (
+    EvidenceIntegrityState,
+    ProvenanceRecord,
+    SignedEvidence,
+)
+from lemma.services import crypto
+
+_GENESIS_HASH = "0" * 64
+_envelope_adapter: TypeAdapter[SignedEvidence] = TypeAdapter(SignedEvidence)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Outcome of verifying a single evidence entry.
+
+    Attributes:
+        state: PROVEN / DEGRADED / VIOLATED.
+        detail: Human-readable explanation of which check succeeded or
+            which one failed. Always non-empty.
+    """
+
+    state: EvidenceIntegrityState
+    detail: str
+
+
+def _producer_of(event: OcsfBaseEvent) -> str:
+    product = event.metadata.get("product") if isinstance(event.metadata, dict) else None
+    if isinstance(product, dict):
+        name = product.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return "unknown"
+
+
+def _canonical_event_bytes(event: OcsfBaseEvent) -> bytes:
+    """Canonical JSON of the event for hashing — sorted keys, no whitespace."""
+    return json.dumps(
+        json.loads(event.model_dump_json()),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def _compute_entry_hash(prev_hash: str, event: OcsfBaseEvent) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(prev_hash.encode())
+    hasher.update(_canonical_event_bytes(event))
+    return hasher.hexdigest()
 
 
 def _dedupe_key(event: OcsfBaseEvent) -> str:
-    """Return a stable idempotency key for ``event``.
-
-    Prefers the producer-supplied ``metadata.uid`` (OCSF's canonical
-    idempotency hint). Falls back to a SHA-256 hash over the full model
-    dump when ``metadata.uid`` is absent, so retries of the same event
-    still collapse without losing genuine same-second distinct events
-    that carry different content.
-    """
+    """Stable idempotency key: producer-supplied ``metadata.uid``, else content hash."""
     uid = event.metadata.get("uid")
     if isinstance(uid, str) and uid:
         return f"uid:{uid}"
@@ -39,55 +91,170 @@ def _dedupe_key(event: OcsfBaseEvent) -> str:
 
 
 class EvidenceLog:
-    """Append-only log of normalized OCSF evidence events."""
+    """Append-only, signed, hash-chained log of OCSF evidence events."""
 
-    def __init__(self, log_dir: Path) -> None:
+    def __init__(self, log_dir: Path, *, key_dir: Path | None = None) -> None:
         self._log_dir = log_dir
         self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._key_dir = key_dir or (log_dir.parent / "keys")
 
     def _log_file(self, dt: datetime | None = None) -> Path:
         if dt is None:
             dt = datetime.now(UTC)
         return self._log_dir / f"{dt.strftime('%Y-%m-%d')}.jsonl"
 
+    # --- internal helpers ---
+
+    def _read_envelopes_from(self, log_file: Path) -> list[SignedEvidence]:
+        if not log_file.exists():
+            return []
+        envelopes: list[SignedEvidence] = []
+        for line in log_file.read_text().strip().splitlines():
+            if line.strip():
+                envelopes.append(_envelope_adapter.validate_json(line))
+        return envelopes
+
+    def _latest_entry_hash(self) -> str:
+        """Walk all log files newest-to-oldest, return the most recent entry_hash."""
+        for log_file in sorted(self._log_dir.glob("*.jsonl"), reverse=True):
+            envelopes = self._read_envelopes_from(log_file)
+            if envelopes:
+                return envelopes[-1].entry_hash
+        return _GENESIS_HASH
+
     def _seen_keys_today(self, log_file: Path) -> set[str]:
         if not log_file.exists():
             return set()
         keys: set[str] = set()
-        for line in log_file.read_text().strip().splitlines():
-            if not line.strip():
-                continue
-            prior = ocsf_adapter.validate_json(line)
-            keys.add(_dedupe_key(prior))
+        for envelope in self._read_envelopes_from(log_file):
+            keys.add(_dedupe_key(envelope.event))
         return keys
 
-    def append(self, event: OcsfBaseEvent) -> bool:
-        """Append an event to the log.
+    # --- public API ---
 
-        Returns ``True`` when a new line was written, ``False`` if the
-        event was skipped by the dedupe guard (see module docstring).
-        Dedupe scope is the day-partitioned file for ``event.time``.
+    def append(self, event: OcsfBaseEvent) -> bool:
+        """Sign, chain, and append an event to the log.
+
+        Returns ``True`` when a new envelope was written, ``False`` if
+        the event was skipped by the dedupe guard on today's file.
         """
         log_file = self._log_file(event.time)
         if _dedupe_key(event) in self._seen_keys_today(log_file):
             return False
+
+        producer = _producer_of(event)
+        crypto.generate_keypair(producer=producer, key_dir=self._key_dir)
+        signer_key_id = crypto.public_key_id(producer=producer, key_dir=self._key_dir)
+
+        prev_hash = self._latest_entry_hash()
+        entry_hash = _compute_entry_hash(prev_hash, event)
+        signature = crypto.sign(
+            bytes.fromhex(entry_hash), producer=producer, key_dir=self._key_dir
+        ).hex()
+
+        envelope = SignedEvidence(
+            event=event,
+            prev_hash=prev_hash,
+            entry_hash=entry_hash,
+            signature=signature,
+            signer_key_id=signer_key_id,
+            provenance=[
+                ProvenanceRecord(
+                    stage="storage",
+                    actor="lemma.services.evidence_log",
+                    content_hash=entry_hash,
+                )
+            ],
+        )
+
         with log_file.open("a") as f:
-            f.write(event.model_dump_json() + "\n")
+            f.write(envelope.model_dump_json() + "\n")
         return True
 
-    def read_all(self) -> list[OcsfBaseEvent]:
-        """Return every event in chronological (file, line) order."""
-        events: list[OcsfBaseEvent] = []
+    def read_envelopes(self) -> list[SignedEvidence]:
+        """Return all envelopes in chronological (file, line) order."""
+        envelopes: list[SignedEvidence] = []
         for log_file in sorted(self._log_dir.glob("*.jsonl")):
-            for line in log_file.read_text().strip().splitlines():
-                if line.strip():
-                    events.append(ocsf_adapter.validate_json(line))
-        return events
+            envelopes.extend(self._read_envelopes_from(log_file))
+        return envelopes
+
+    def read_all(self) -> list[OcsfBaseEvent]:
+        """Return all enveloped events in chronological order (envelopes unwrapped)."""
+        return [env.event for env in self.read_envelopes()]
 
     def filter_by_class(self, class_uid: int) -> list[OcsfBaseEvent]:
-        """Return every event with the given ``class_uid``."""
         return [e for e in self.read_all() if e.class_uid == class_uid]
 
     def filter_by_time_range(self, start: datetime, end: datetime) -> list[OcsfBaseEvent]:
-        """Return events whose ``time`` falls in ``[start, end)`` (half-open)."""
         return [e for e in self.read_all() if start <= e.time < end]
+
+    def verify_entry(self, entry_hash: str) -> VerificationResult:
+        """Check that a single entry is hash-consistent, chain-linked, and signed.
+
+        Walks the full log in order until it reaches the target entry,
+        verifying each step. Verdict:
+
+        - VIOLATED if any earlier entry's content hash is wrong, any
+          chain link is broken, or the target entry itself fails.
+        - DEGRADED if the chain is intact but the signature can't be
+          verified (most commonly because the signer's public key is no
+          longer on file).
+        - PROVEN otherwise.
+        """
+        expected_prev = _GENESIS_HASH
+        for envelope in self.read_envelopes():
+            # Chain linkage first: a bad prev_hash points at outright tampering.
+            if envelope.prev_hash != expected_prev:
+                if envelope.entry_hash == entry_hash:
+                    return VerificationResult(
+                        EvidenceIntegrityState.VIOLATED,
+                        f"Chain broken at this entry: prev_hash "
+                        f"{envelope.prev_hash[:12]} does not match prior entry_hash "
+                        f"{expected_prev[:12]}.",
+                    )
+                return VerificationResult(
+                    EvidenceIntegrityState.VIOLATED,
+                    f"Chain broken at entry {envelope.entry_hash[:12]}.",
+                )
+
+            # Content hash: the envelope.entry_hash must match SHA-256(prev || event).
+            recomputed = _compute_entry_hash(envelope.prev_hash, envelope.event)
+            if recomputed != envelope.entry_hash:
+                if envelope.entry_hash == entry_hash:
+                    return VerificationResult(
+                        EvidenceIntegrityState.VIOLATED,
+                        "Content hash does not match stored entry_hash "
+                        "(event has been modified since signing).",
+                    )
+                return VerificationResult(
+                    EvidenceIntegrityState.VIOLATED,
+                    f"Earlier entry {envelope.entry_hash[:12]} has corrupt content hash.",
+                )
+
+            expected_prev = envelope.entry_hash
+
+            if envelope.entry_hash == entry_hash:
+                producer = _producer_of(envelope.event)
+                signature_bytes = bytes.fromhex(envelope.signature)
+                signed_payload = bytes.fromhex(envelope.entry_hash)
+                ok = crypto.verify(
+                    signed_payload,
+                    signature_bytes,
+                    producer=producer,
+                    key_dir=self._key_dir,
+                )
+                if ok:
+                    return VerificationResult(
+                        EvidenceIntegrityState.PROVEN,
+                        f"Hash, chain, and signature all valid for producer '{producer}'.",
+                    )
+                return VerificationResult(
+                    EvidenceIntegrityState.DEGRADED,
+                    f"Hash and chain valid, but signer's key for producer "
+                    f"'{producer}' is unavailable or the signature doesn't verify.",
+                )
+
+        return VerificationResult(
+            EvidenceIntegrityState.VIOLATED,
+            f"No entry found with entry_hash {entry_hash[:12]}.",
+        )

--- a/tests/commands/test_evidence.py
+++ b/tests/commands/test_evidence.py
@@ -1,0 +1,98 @@
+"""Tests for the `lemma evidence` CLI commands."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _compliance_payload(uid: str = "evt-1") -> dict:
+    return {
+        "class_uid": 2003,
+        "class_name": "Compliance Finding",
+        "category_uid": 2000,
+        "category_name": "Findings",
+        "type_uid": 200301,
+        "activity_id": 1,
+        "time": datetime.now(UTC).isoformat(),
+        "metadata": {
+            "version": "1.3.0",
+            "product": {"name": "Lemma"},
+            "uid": uid,
+        },
+    }
+
+
+def _seed_signed_entries(project_dir: Path, count: int = 2) -> list[str]:
+    """Append ``count`` signed entries and return their entry_hashes."""
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=project_dir / ".lemma" / "evidence")
+    for i in range(count):
+        log.append(normalize(_compliance_payload(f"seed-{i}")))
+    return [env.entry_hash for env in log.read_envelopes()]
+
+
+def test_verify_reports_proven_for_untampered_entry(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    hashes = _seed_signed_entries(tmp_path)
+
+    result = runner.invoke(app, ["evidence", "verify", hashes[0]])
+
+    assert result.exit_code == 0, result.stdout
+    assert "PROVEN" in result.stdout
+
+
+def test_verify_reports_violated_when_entry_missing(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_signed_entries(tmp_path)
+
+    result = runner.invoke(app, ["evidence", "verify", "f" * 64])
+    assert result.exit_code == 1
+    assert "VIOLATED" in result.stdout or "not found" in result.stdout.lower()
+
+
+def test_verify_requires_lemma_project(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["evidence", "verify", "a" * 64])
+    assert result.exit_code == 1
+    stdout = result.stdout.lower()
+    assert "not a lemma project" in stdout or "lemma init" in stdout
+
+
+def test_log_displays_timeline_with_integrity_states(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_signed_entries(tmp_path, count=3)
+
+    result = runner.invoke(app, ["evidence", "log"])
+    assert result.exit_code == 0, result.stdout
+    # Table or table-like output mentioning the integrity verdict per row
+    assert "PROVEN" in result.stdout
+    # Shows producer
+    assert "Lemma" in result.stdout
+
+
+def test_log_requires_lemma_project(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["evidence", "log"])
+    assert result.exit_code == 1

--- a/tests/models/test_signed_evidence.py
+++ b/tests/models/test_signed_evidence.py
@@ -1,0 +1,80 @@
+"""Tests for SignedEvidence envelope and integrity state enum."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def _sample_event():
+    from lemma.models.ocsf import ComplianceFinding
+
+    return ComplianceFinding(
+        class_name="Compliance Finding",
+        category_uid=2000,
+        category_name="Findings",
+        type_uid=200301,
+        activity_id=1,
+        time=datetime.now(UTC),
+    )
+
+
+def test_integrity_state_enum_values():
+    from lemma.models.signed_evidence import EvidenceIntegrityState
+
+    assert EvidenceIntegrityState.PROVEN.value == "PROVEN"
+    assert EvidenceIntegrityState.DEGRADED.value == "DEGRADED"
+    assert EvidenceIntegrityState.VIOLATED.value == "VIOLATED"
+
+
+def test_signed_evidence_requires_event_and_chain_fields():
+    from lemma.models.signed_evidence import ProvenanceRecord, SignedEvidence
+
+    envelope = SignedEvidence(
+        event=_sample_event(),
+        prev_hash="0" * 64,
+        entry_hash="a" * 64,
+        signature="deadbeef",
+        signer_key_id="ed25519:test0000",
+        provenance=[ProvenanceRecord(stage="storage", actor="lemma", content_hash="a" * 64)],
+    )
+
+    assert envelope.prev_hash == "0" * 64
+    assert envelope.entry_hash == "a" * 64
+    assert envelope.signature == "deadbeef"
+    assert envelope.signer_key_id.startswith("ed25519:")
+    assert envelope.event.class_uid == 2003
+    assert len(envelope.provenance) == 1
+    assert envelope.provenance[0].stage == "storage"
+
+
+def test_signed_evidence_round_trips_through_json():
+    import json
+
+    from lemma.models.ocsf import ComplianceFinding
+    from lemma.models.signed_evidence import SignedEvidence
+
+    envelope = SignedEvidence(
+        event=_sample_event(),
+        prev_hash="0" * 64,
+        entry_hash="b" * 64,
+        signature="cafe",
+        signer_key_id="ed25519:abcd1234",
+    )
+    serialized = envelope.model_dump_json()
+    payload = json.loads(serialized)
+
+    # Event is nested under 'event' with the OCSF shape intact
+    assert payload["event"]["class_uid"] == 2003
+
+    # Round-trip back into the model
+    revived = SignedEvidence.model_validate_json(serialized)
+    assert isinstance(revived.event, ComplianceFinding)
+    assert revived.entry_hash == envelope.entry_hash
+
+
+def test_provenance_record_has_timestamp_by_default():
+    from lemma.models.signed_evidence import ProvenanceRecord
+
+    record = ProvenanceRecord(stage="storage", actor="lemma", content_hash="x" * 64)
+    assert record.timestamp is not None
+    assert record.stage == "storage"

--- a/tests/services/test_crypto.py
+++ b/tests/services/test_crypto.py
@@ -1,0 +1,69 @@
+"""Tests for Ed25519 key management and signing primitives."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_generate_keypair_writes_private_and_public_files(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair
+
+    key_id = generate_keypair(producer="test-producer", key_dir=tmp_path / "keys")
+
+    assert key_id  # non-empty identifier
+    assert (tmp_path / "keys" / "test-producer.private.pem").is_file()
+    assert (tmp_path / "keys" / "test-producer.public.pem").is_file()
+
+    # Private key mode is 0600 on POSIX — integrity check
+    private_path = tmp_path / "keys" / "test-producer.private.pem"
+    mode = private_path.stat().st_mode & 0o777
+    assert mode == 0o600, f"private key mode should be 0600, got {oct(mode)}"
+
+
+def test_generate_keypair_is_idempotent_for_same_producer(tmp_path: Path):
+    """Calling generate_keypair twice with the same producer returns the same key_id."""
+    from lemma.services.crypto import generate_keypair
+
+    key_dir = tmp_path / "keys"
+    first = generate_keypair(producer="dup", key_dir=key_dir)
+    second = generate_keypair(producer="dup", key_dir=key_dir)
+    assert first == second
+
+
+def test_sign_and_verify_round_trip(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair, sign, verify
+
+    generate_keypair(producer="round-trip", key_dir=tmp_path / "keys")
+
+    message = b"hello world"
+    signature = sign(message, producer="round-trip", key_dir=tmp_path / "keys")
+    assert verify(message, signature, producer="round-trip", key_dir=tmp_path / "keys") is True
+
+
+def test_verify_rejects_modified_message(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair, sign, verify
+
+    generate_keypair(producer="tamper", key_dir=tmp_path / "keys")
+    signature = sign(b"original", producer="tamper", key_dir=tmp_path / "keys")
+
+    assert verify(b"tampered", signature, producer="tamper", key_dir=tmp_path / "keys") is False
+
+
+def test_verify_rejects_unknown_producer(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair, sign, verify
+
+    generate_keypair(producer="known", key_dir=tmp_path / "keys")
+    signature = sign(b"msg", producer="known", key_dir=tmp_path / "keys")
+
+    # Verification against a different producer returns False (key not on file)
+    assert verify(b"msg", signature, producer="unknown", key_dir=tmp_path / "keys") is False
+
+
+def test_key_id_is_derived_from_public_key_bytes(tmp_path: Path):
+    """key_id is a stable hash of the public key so downstream can reference it."""
+    from lemma.services.crypto import generate_keypair, public_key_id
+
+    key_id = generate_keypair(producer="stable", key_dir=tmp_path / "keys")
+    derived = public_key_id(producer="stable", key_dir=tmp_path / "keys")
+    assert key_id == derived
+    assert key_id.startswith("ed25519:")

--- a/tests/services/test_evidence_log.py
+++ b/tests/services/test_evidence_log.py
@@ -126,6 +126,133 @@ def test_append_content_hash_dedupe_when_uid_absent(tmp_path: Path):
     assert len(files[0].read_text().strip().splitlines()) == 1
 
 
+def test_append_writes_signed_chained_envelope(tmp_path: Path):
+    """Every appended entry is wrapped in a SignedEvidence envelope with chain + signature."""
+    import json
+
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("e-1")))
+    log.append(normalize(_compliance_payload("e-2")))
+
+    # Inspect the raw JSONL — confirm every line is an envelope shape
+    files = list((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    lines = [line for f in files for line in f.read_text().strip().splitlines()]
+
+    first = json.loads(lines[0])
+    second = json.loads(lines[1])
+
+    # Envelope fields
+    for payload in (first, second):
+        assert "event" in payload
+        assert "entry_hash" in payload
+        assert "signature" in payload
+        assert "signer_key_id" in payload
+        assert payload["signer_key_id"].startswith("ed25519:")
+
+    # Genesis entry has zeroed prev_hash; second chains to first's entry_hash
+    assert first["prev_hash"] == "0" * 64
+    assert second["prev_hash"] == first["entry_hash"]
+
+
+def test_read_all_still_returns_unwrapped_ocsf_events(tmp_path: Path):
+    """Signing is transparent to callers using read_all()."""
+    from lemma.models.ocsf import ComplianceFinding
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("e-1")))
+
+    events = log.read_all()
+    assert len(events) == 1
+    assert isinstance(events[0], ComplianceFinding)
+    assert events[0].metadata["uid"] == "e-1"
+
+
+def test_verify_entry_returns_proven_for_untampered_chain(tmp_path: Path):
+    from lemma.models.signed_evidence import EvidenceIntegrityState
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("e-1")))
+    log.append(normalize(_compliance_payload("e-2")))
+
+    envelopes = log.read_envelopes()
+    for env in envelopes:
+        result = log.verify_entry(env.entry_hash)
+        assert result.state == EvidenceIntegrityState.PROVEN
+
+
+def test_verify_entry_returns_violated_when_content_modified(tmp_path: Path):
+    import json
+
+    from lemma.models.signed_evidence import EvidenceIntegrityState
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("e-1")))
+
+    # Tamper: rewrite the entry's event message in-place on disk
+    files = list((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    payload = json.loads(files[0].read_text().strip())
+    payload["event"]["message"] = "tampered message"
+    files[0].write_text(json.dumps(payload) + "\n")
+
+    envelope = log.read_envelopes()[0]
+    result = log.verify_entry(envelope.entry_hash)
+    assert result.state == EvidenceIntegrityState.VIOLATED
+    assert "hash" in result.detail.lower() or "content" in result.detail.lower()
+
+
+def test_verify_entry_returns_violated_when_chain_broken(tmp_path: Path):
+    import json
+
+    from lemma.models.signed_evidence import EvidenceIntegrityState
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("e-1")))
+    log.append(normalize(_compliance_payload("e-2")))
+
+    # Tamper: rewrite the second entry's prev_hash so the chain breaks
+    files = list((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    lines = files[0].read_text().strip().splitlines()
+    second = json.loads(lines[1])
+    second["prev_hash"] = "f" * 64
+    lines[1] = json.dumps(second)
+    files[0].write_text("\n".join(lines) + "\n")
+
+    envelopes = log.read_envelopes()
+    result = log.verify_entry(envelopes[1].entry_hash)
+    assert result.state == EvidenceIntegrityState.VIOLATED
+    assert "chain" in result.detail.lower() or "prev" in result.detail.lower()
+
+
+def test_verify_entry_returns_degraded_when_signer_key_unknown(tmp_path: Path):
+    import shutil
+
+    from lemma.models.signed_evidence import EvidenceIntegrityState
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("e-1")))
+
+    # Simulate a lost key: delete the keystore after signing
+    shutil.rmtree(tmp_path / ".lemma" / "keys")
+
+    envelope = log.read_envelopes()[0]
+    result = log.verify_entry(envelope.entry_hash)
+    assert result.state == EvidenceIntegrityState.DEGRADED
+    assert "key" in result.detail.lower()
+
+
 def test_filter_by_class_and_time_range(tmp_path: Path):
     from lemma.services.evidence_log import EvidenceLog
     from lemma.services.ocsf_normalizer import normalize

--- a/uv.lock
+++ b/uv.lock
@@ -180,6 +180,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +466,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
     { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
 ]
 
 [[package]]
@@ -1077,6 +1187,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "jsonschema" },
     { name = "networkx" },
@@ -1105,6 +1216,7 @@ ingest = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=0.5" },
+    { name = "cryptography", specifier = ">=42.0" },
     { name = "docling", marker = "extra == 'ingest'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "jsonschema", specifier = ">=4.0" },
@@ -1656,9 +1768,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pillow", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -2248,6 +2360,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2384,7 +2505,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -2400,8 +2521,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -2417,8 +2538,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -2434,10 +2555,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [


### PR DESCRIPTION
## Description

Closes #29 by adding tamper-evident integrity to the evidence log. Every entry appended to `.lemma/evidence/YYYY-MM-DD.jsonl` is now wrapped in a `SignedEvidence` envelope carrying:

- `prev_hash` — the prior entry's `entry_hash`, or 64 zeros for the genesis entry.
- `entry_hash` — SHA-256 over `prev_hash || canonical_json(event)`.
- `signature` — Ed25519 signature over the entry hash bytes, produced by the per-producer signing key.
- `signer_key_id` — stable public-key identifier derived from the raw public key.
- `provenance` — one `ProvenanceRecord` per stage in the transformation chain.

Per-producer keypairs live under `.lemma/keys/` with `0600` private-key permissions. First append for any new producer generates a keypair idempotently.

**Verification** (`lemma evidence verify <entry_hash>`) walks the log in order and returns a verdict:

- `PROVEN` — hash, chain, and signature all valid.
- `DEGRADED` — hash and chain valid, signer's public key unavailable (rotated, revoked, or never imported).
- `VIOLATED` — content modified, chain broken, or the entry itself doesn't exist.

**Timeline view** (`lemma evidence log`) renders a Rich table with per-entry integrity state so operators can spot corruption at a glance.

## Design calls worth flagging

- **Chain check before content-hash check.** When an attacker modifies `prev_hash` in place without re-hashing the envelope, both checks would fail. Reporting \"chain broken\" first is the more accurate diagnosis (the attacker's goal was chain manipulation, not content manipulation).
- **Keys per producer, not per user.** OCSF events carry `metadata.product.name` identifying the source. Keys are scoped to that identity. When the Connector SDK (#26) arrives, each connector brings its own keys and plugs into the same interface.
- **`read_all()` unwraps envelopes transparently.** Callers from PR #90 keep working — they get `list[OcsfBaseEvent]`. Integrity-focused callers use the new `read_envelopes()` to get the `SignedEvidence` wrappers.
- **Canonical JSON for hashing.** Entry hashes use `json.dumps(..., sort_keys=True, separators=(',', ':'))` over the event. Determinism matters: a different serialization order would silently break verification.
- **Genesis hash is 64 zeros.** Every chain needs a starting point; documented in the module docstring and consistent across test fixtures.

## Deferred scope — tracked

- **Key rotation and revocation** (#98). This PR ships keystore basics (generate, load, sign, verify). Rotation semantics (retire a key while keeping historical signatures PROVEN, revoke a compromised key with forward-violating semantics) is its own design and deserves its own PR.
- **Full provenance transformation chain** (#99). Today's envelopes populate the `storage` stage honestly. `source` / `collection` / `normalization` records fill in when connector work (#26, #27) actually performs those steps.

Both are flagged in #29's body before close.

## AC mapping (for the issue update after merge)

- [x] Every evidence artifact signed with the collecting connector's Ed25519 key — `EvidenceLog.append` signs every envelope; producer identity comes from `metadata.product.name`. Connectors plug into the same interface in #26.
- [x] Evidence log is append-only and hash-chained (Merkle tree structure) — each entry's `entry_hash` depends on `prev_hash` + event; the log is a singly-linked hash chain (the minimal Merkle structure — depth 1 tree per entry). No update/delete/clear methods on `EvidenceLog`.
- [x] `lemma evidence verify <id>` validates integrity — `src/lemma/commands/evidence.py::verify_command`.
- [x] Tamper detection identifies modified evidence and reports specific corruption — `VerificationResult.detail` names the failed invariant (chain link, content hash, or signature).
- [x] Evidence states transition correctly — `EvidenceIntegrityState` enum, verdict logic in `EvidenceLog.verify_entry`.
- [x] Provenance metadata records the transformation chain — `ProvenanceRecord` list on every envelope; storage stage populated here, rest fills in via #99.
- [x] `lemma evidence log` displays the evidence timeline with integrity status — `src/lemma/commands/evidence.py::log_command`.
- [x] Unit test coverage ≥ 90% for signing, verification, and Merkle tree logic — six tests for crypto primitives, four for the envelope model, seven for log behavior (signing, chain, verify states, tamper detection), five for CLI.

Fixes #29

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest \`main\` branch
- [x] I have run \`uv run ruff check\` and \`uv run ruff format --check\` with no errors
- [x] I have run \`uv run pytest\` and all 322 tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (CHANGELOG + CLI reference for \`lemma evidence\`)
- [x] My changes generate no new warnings or errors