### PR TITLE
feat(evidence): Key rotation and revocation with lifecycle-aware verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Key lifecycle for evidence signing. Per-producer keys now live under `.lemma/keys/<producer>/<key_id>.*.pem` with a sibling `meta.json` tracking every key the producer has held. Status is one of `ACTIVE`, `RETIRED`, or `REVOKED`. Flat pre-lifecycle layouts are auto-migrated to the versioned layout on first access.
+- `lemma evidence rotate-key --producer <name>` retires the producer's active signing key and generates a fresh one. Pre-rotation entries keep verifying PROVEN under the retired key; new entries use the successor.
+- `lemma evidence revoke-key --producer <name> --key-id <id> --reason <str>` marks a key REVOKED. Verification now returns VIOLATED for entries signed at or after `revoked_at` under a revoked key, and stays PROVEN for signatures made before the revocation.
+- `lemma evidence keys` lists every signing key with its lifecycle state, activation timestamp, retirement/revocation timestamp, and revocation reason.
+- `SignedEvidence` gains a `signed_at` field so key-lifecycle checks can compare the signing timestamp (not `event.time`) against `revoked_at`.
 - Continuous proof chains on the evidence log. Every entry appended to `.lemma/evidence/YYYY-MM-DD.jsonl` is now wrapped in a `SignedEvidence` envelope with an SHA-256 hash chain (`prev_hash` → `entry_hash`) and an Ed25519 signature produced by the signing key for `metadata.product.name`. Per-producer keypairs live under `.lemma/keys/` with `0600` private-key permissions.
 - `lemma evidence verify <entry_hash>` — integrity check returning PROVEN (hash + chain + signature all valid), DEGRADED (hash + chain valid but signer's key unavailable), or VIOLATED (hash or chain broken). Non-zero exit on anything other than PROVEN.
 - `lemma evidence log` — Rich-table timeline showing time, class, producer, entry hash prefix, and per-row integrity state.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -350,6 +350,40 @@ lemma evidence log
 
 Output is a Rich table with columns for time, OCSF class name, producer, truncated entry hash, and the integrity verdict.
 
+### `lemma evidence rotate-key`
+
+Retire the producer's active signing key and generate a new one. Pre-rotation entries keep verifying PROVEN under the retired key; new entries are signed with the successor.
+
+```bash
+lemma evidence rotate-key --producer <NAME>
+```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--producer` | Yes | Producer name (e.g. `Lemma`, `Okta`, `AWS`) |
+
+### `lemma evidence revoke-key`
+
+Mark a specific signing key as revoked with a required reason. Signatures made at or after `revoked_at` under a revoked key verify as `VIOLATED`; signatures made before revocation remain `PROVEN`.
+
+```bash
+lemma evidence revoke-key --producer <NAME> --key-id <ID> --reason <TEXT>
+```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--producer` | Yes | Producer name whose key is being revoked |
+| `--key-id` | Yes | Exact key identifier (e.g. `ed25519:abcd1234`) to revoke |
+| `--reason` | Yes | Why this key is being revoked (operator note) |
+
+### `lemma evidence keys`
+
+List every signing key on file with its lifecycle state, activation timestamp, retirement/revocation timestamp, and revocation reason.
+
+```bash
+lemma evidence keys
+```
+
 ---
 
 ## `lemma ai`

--- a/src/lemma/commands/evidence.py
+++ b/src/lemma/commands/evidence.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from rich.table import Table
 
 from lemma.models.signed_evidence import EvidenceIntegrityState
+from lemma.services import crypto
 from lemma.services.evidence_log import EvidenceLog
 
 console = Console()
@@ -102,3 +103,96 @@ def log_command() -> None:
         )
 
     console.print(table)
+
+
+def _key_status_style(status_value: str) -> str:
+    if status_value == "ACTIVE":
+        return "[green]ACTIVE[/green]"
+    if status_value == "RETIRED":
+        return "[yellow]RETIRED[/yellow]"
+    return "[red]REVOKED[/red]"
+
+
+@evidence_app.command(
+    name="rotate-key",
+    help="Retire the producer's active signing key and generate a new one.",
+)
+def rotate_key_command(
+    producer: str = typer.Option(..., "--producer", help="Producer name (e.g. Lemma, Okta, AWS)"),
+) -> None:
+    project_dir = _require_lemma_project()
+    key_dir = project_dir / ".lemma" / "keys"
+    try:
+        new_key_id = crypto.rotate_key(producer=producer, key_dir=key_dir)
+    except FileNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1) from e
+
+    console.print(
+        f"Rotated signing key for [cyan]{producer}[/cyan]. "
+        f"Prior key marked RETIRED; new active key [green]{new_key_id}[/green]."
+    )
+
+
+@evidence_app.command(
+    name="revoke-key",
+    help="Revoke a specific signing key with a required reason.",
+)
+def revoke_key_command(
+    producer: str = typer.Option(
+        ..., "--producer", help="Producer name whose key is being revoked"
+    ),
+    key_id: str = typer.Option(
+        ..., "--key-id", help="Exact key_id (e.g. ed25519:abcd1234) to revoke"
+    ),
+    reason: str = typer.Option(..., "--reason", help="Why this key is being revoked (required)"),
+) -> None:
+    project_dir = _require_lemma_project()
+    key_dir = project_dir / ".lemma" / "keys"
+
+    try:
+        record = crypto.revoke_key(producer=producer, key_id=key_id, reason=reason, key_dir=key_dir)
+    except (FileNotFoundError, ValueError) as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1) from e
+
+    console.print(
+        f"Key [cyan]{record.key_id}[/cyan] for producer [cyan]{producer}[/cyan] "
+        f"is now [red]REVOKED[/red] (reason: {record.revoked_reason})."
+    )
+
+
+@evidence_app.command(
+    name="keys",
+    help="List every signing key with its lifecycle state.",
+)
+def keys_command() -> None:
+    project_dir = _require_lemma_project()
+    key_dir = project_dir / ".lemma" / "keys"
+
+    if not key_dir.exists():
+        console.print("[dim]No keys on file. 0 producers.[/dim]")
+        return
+
+    producers: list[str] = sorted([p.name for p in key_dir.iterdir() if p.is_dir()])
+    if not producers:
+        console.print("[dim]No keys on file. 0 producers.[/dim]")
+        return
+
+    # Plain-text output — Rich tables truncate in narrow terminals.
+    console.print("[bold]Evidence Signing Keys[/bold]")
+    for producer in producers:
+        lifecycle = crypto.read_lifecycle(producer, key_dir=key_dir)
+        for record in lifecycle.keys:
+            lifecycle_ts = record.revoked_at or record.retired_at
+            timestamp_suffix = (
+                f"  (→ {lifecycle_ts.strftime('%Y-%m-%d %H:%M:%S')})" if lifecycle_ts else ""
+            )
+            reason_suffix = f"  reason: {record.revoked_reason}" if record.revoked_reason else ""
+            console.print(
+                f"  [cyan]{producer}[/cyan]  "
+                f"{_key_status_style(record.status.value)}  "
+                f"{record.key_id}  "
+                f"activated {record.activated_at.strftime('%Y-%m-%d %H:%M:%S')}"
+                f"{timestamp_suffix}{reason_suffix}"
+            )

--- a/src/lemma/models/key_metadata.py
+++ b/src/lemma/models/key_metadata.py
@@ -1,0 +1,53 @@
+"""Evidence-signing key lifecycle metadata.
+
+Each producer maintains a rolling history of signing keys. Every key
+the producer has ever held is represented as a ``KeyRecord``. The
+records live alongside the key material under
+``.lemma/keys/<producer>/meta.json`` and drive the verification
+verdict in ``EvidenceLog.verify_entry``:
+
+- ACTIVE — currently signing new entries.
+- RETIRED — superseded by rotation. Historical signatures from this
+  key remain PROVEN for entries signed during its active window.
+- REVOKED — compromised. Signatures from this key are VIOLATED for
+  entries signed at or after ``revoked_at`` and PROVEN before.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class KeyStatus(StrEnum):
+    """Lifecycle state for a signing key."""
+
+    ACTIVE = "ACTIVE"
+    RETIRED = "RETIRED"
+    REVOKED = "REVOKED"
+
+
+class KeyRecord(BaseModel):
+    """Lifecycle metadata for one signing key.
+
+    Attributes:
+        key_id: Stable identifier derived from the public key bytes.
+        status: Current lifecycle state.
+        activated_at: When the key entered ACTIVE status.
+        retired_at: When the key was retired, or None if still active /
+            already revoked without prior retirement.
+        revoked_at: When the key was revoked, or None if not revoked.
+        revoked_reason: Free-form operator note accompanying revocation.
+        successor_key_id: Key that replaced this one on rotation, or
+            empty string if none.
+    """
+
+    key_id: str
+    status: KeyStatus
+    activated_at: datetime
+    retired_at: datetime | None = None
+    revoked_at: datetime | None = None
+    revoked_reason: str = ""
+    successor_key_id: str = ""

--- a/src/lemma/models/signed_evidence.py
+++ b/src/lemma/models/signed_evidence.py
@@ -85,6 +85,12 @@ class SignedEvidence(BaseModel):
         entry_hash: SHA-256 hex over ``prev_hash || canonical_json(event)``.
         signature: Hex-encoded Ed25519 signature over the entry hash bytes.
         signer_key_id: Stable identifier of the public key used to sign.
+        signed_at: When the envelope was produced. Distinct from
+            ``event.time`` (which is when the thing happened in the
+            outside world). Key-lifecycle verification uses this
+            timestamp — revocation semantics say "signatures made at
+            or after ``revoked_at`` are VIOLATED," and that's about
+            when the signing happened, not when the event did.
         provenance: Transformation chain producing this entry.
     """
 
@@ -93,4 +99,5 @@ class SignedEvidence(BaseModel):
     entry_hash: str
     signature: str
     signer_key_id: str
+    signed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     provenance: list[ProvenanceRecord] = Field(default_factory=list)

--- a/src/lemma/services/crypto.py
+++ b/src/lemma/services/crypto.py
@@ -1,19 +1,27 @@
-"""Ed25519 key management and signing primitives for evidence chains.
+"""Ed25519 key management, signing, and lifecycle for evidence chains.
 
-Keys are persisted per-producer under the project's ``.lemma/keys/``
-directory. Each producer (``metadata.product.name`` on an OCSF event)
-owns one Ed25519 keypair; downstream code refers to keys by a stable
-``key_id`` derived from the public key bytes.
+Keys are organized under the project's ``.lemma/keys/`` directory:
 
-This module is deliberately minimal: generate, load, sign, verify.
-Rotation and revocation are tracked in a follow-up issue and layer on
-top of this primitive surface without breaking its API.
+    .lemma/keys/<producer>/<key_id>.private.pem   (mode 0600)
+    .lemma/keys/<producer>/<key_id>.public.pem
+    .lemma/keys/<producer>/meta.json              (KeyLifecycle)
+
+``meta.json`` records every key the producer has ever held and its
+lifecycle state (ACTIVE / RETIRED / REVOKED). Verification consults
+this file to decide whether a historical signature is still trusted.
+
+Flat pre-#98 layouts (``<producer>.private.pem`` next to
+``<producer>.public.pem``) are auto-migrated on first access so
+existing projects don't lose their keys when the versioned layout
+ships.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+from datetime import UTC, datetime
 from pathlib import Path
 
 from cryptography.hazmat.primitives import serialization
@@ -21,110 +29,257 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
     Ed25519PublicKey,
 )
+from pydantic import BaseModel, Field
+
+from lemma.models.key_metadata import KeyRecord, KeyStatus
 
 
 def _safe_producer(producer: str) -> str:
-    """Producer names can contain characters unsafe for filenames.
-
-    Replace the OCSF-typical ``/`` and spaces with underscores so the
-    serialized key paths stay predictable.
-    """
+    """Producer names can contain characters unsafe for filenames."""
     return producer.replace("/", "_").replace(" ", "_")
 
 
-def _private_path(producer: str, key_dir: Path) -> Path:
-    return key_dir / f"{_safe_producer(producer)}.private.pem"
+def _producer_dir(producer: str, key_dir: Path) -> Path:
+    return key_dir / _safe_producer(producer)
 
 
-def _public_path(producer: str, key_dir: Path) -> Path:
-    return key_dir / f"{_safe_producer(producer)}.public.pem"
+def _meta_path(producer: str, key_dir: Path) -> Path:
+    return _producer_dir(producer, key_dir) / "meta.json"
+
+
+def _key_path(producer: str, key_id: str, key_dir: Path, *, kind: str) -> Path:
+    return _producer_dir(producer, key_dir) / f"{key_id}.{kind}.pem"
+
+
+def _compute_key_id_from_public_bytes(raw_public: bytes) -> str:
+    digest = hashlib.sha256(raw_public).hexdigest()[:16]
+    return f"ed25519:{digest}"
+
+
+def _public_raw(public_key: Ed25519PublicKey) -> bytes:
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+class KeyLifecycle(BaseModel):
+    """Persisted lifecycle record for all of a producer's keys."""
+
+    keys: list[KeyRecord] = Field(default_factory=list)
+
+    def active(self) -> KeyRecord | None:
+        for record in self.keys:
+            if record.status == KeyStatus.ACTIVE:
+                return record
+        return None
+
+    def find(self, key_id: str) -> KeyRecord | None:
+        for record in self.keys:
+            if record.key_id == key_id:
+                return record
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Migration from the pre-#98 flat layout
+# ---------------------------------------------------------------------------
+
+
+def _legacy_flat_paths(producer: str, key_dir: Path) -> tuple[Path, Path]:
+    safe = _safe_producer(producer)
+    return key_dir / f"{safe}.private.pem", key_dir / f"{safe}.public.pem"
+
+
+def _migrate_flat_layout_if_present(producer: str, key_dir: Path) -> None:
+    """If the pre-#98 flat layout exists for ``producer``, migrate to the versioned one."""
+    legacy_priv, legacy_pub = _legacy_flat_paths(producer, key_dir)
+    if not legacy_priv.exists() or not legacy_pub.exists():
+        return
+
+    public_key = serialization.load_pem_public_key(legacy_pub.read_bytes())  # type: ignore[assignment]
+    key_id = _compute_key_id_from_public_bytes(_public_raw(public_key))
+
+    producer_dir = _producer_dir(producer, key_dir)
+    producer_dir.mkdir(parents=True, exist_ok=True)
+
+    new_priv = _key_path(producer, key_id, key_dir, kind="private")
+    new_pub = _key_path(producer, key_id, key_dir, kind="public")
+    legacy_priv.rename(new_priv)
+    legacy_pub.rename(new_pub)
+    os.chmod(new_priv, 0o600)
+
+    _write_lifecycle(
+        producer,
+        key_dir,
+        KeyLifecycle(
+            keys=[
+                KeyRecord(
+                    key_id=key_id,
+                    status=KeyStatus.ACTIVE,
+                    activated_at=datetime.now(UTC),
+                )
+            ]
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle persistence
+# ---------------------------------------------------------------------------
+
+
+def _read_lifecycle(producer: str, key_dir: Path) -> KeyLifecycle:
+    path = _meta_path(producer, key_dir)
+    if not path.exists():
+        return KeyLifecycle()
+    return KeyLifecycle.model_validate_json(path.read_text())
+
+
+def _write_lifecycle(producer: str, key_dir: Path, lifecycle: KeyLifecycle) -> None:
+    producer_dir = _producer_dir(producer, key_dir)
+    producer_dir.mkdir(parents=True, exist_ok=True)
+    _meta_path(producer, key_dir).write_text(
+        json.dumps(json.loads(lifecycle.model_dump_json()), indent=2)
+    )
+
+
+def read_lifecycle(producer: str, *, key_dir: Path) -> KeyLifecycle:
+    """Return the full lifecycle record for ``producer`` (public accessor)."""
+    _migrate_flat_layout_if_present(producer, key_dir)
+    return _read_lifecycle(producer, key_dir)
+
+
+# ---------------------------------------------------------------------------
+# Key generation
+# ---------------------------------------------------------------------------
+
+
+def _write_new_keypair(producer: str, key_dir: Path) -> tuple[str, Ed25519PrivateKey]:
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    key_id = _compute_key_id_from_public_bytes(_public_raw(public_key))
+
+    _producer_dir(producer, key_dir).mkdir(parents=True, exist_ok=True)
+
+    priv_path = _key_path(producer, key_id, key_dir, kind="private")
+    pub_path = _key_path(producer, key_id, key_dir, kind="public")
+
+    priv_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    os.chmod(priv_path, 0o600)
+    pub_path.write_bytes(
+        public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    return key_id, private_key
 
 
 def generate_keypair(*, producer: str, key_dir: Path) -> str:
     """Generate (or return the existing) Ed25519 keypair for ``producer``.
 
-    Idempotent: a second call for the same producer returns the
-    existing ``key_id`` without regenerating. Private key files are
-    written with mode ``0600``.
-
-    Args:
-        producer: Logical producer name (e.g., ``"Lemma"``, ``"Okta"``).
-        key_dir: Directory under which the keypair is persisted.
-
-    Returns:
-        A stable ``key_id`` derived from the public key bytes.
+    Idempotent with respect to an existing ACTIVE key: a second call
+    returns the active key's ``key_id`` without creating a new one. If
+    the pre-#98 flat layout exists for the producer, it's migrated to
+    the versioned layout before anything else happens.
     """
     key_dir.mkdir(parents=True, exist_ok=True)
-    private_path = _private_path(producer, key_dir)
-    public_path = _public_path(producer, key_dir)
+    _migrate_flat_layout_if_present(producer, key_dir)
 
-    if private_path.exists() and public_path.exists():
-        return public_key_id(producer=producer, key_dir=key_dir)
+    lifecycle = _read_lifecycle(producer, key_dir)
+    active = lifecycle.active()
+    if active is not None:
+        return active.key_id
 
-    private_key = Ed25519PrivateKey.generate()
-    public_key = private_key.public_key()
-
-    private_bytes = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
+    key_id, _ = _write_new_keypair(producer, key_dir)
+    lifecycle.keys.append(
+        KeyRecord(
+            key_id=key_id,
+            status=KeyStatus.ACTIVE,
+            activated_at=datetime.now(UTC),
+        )
     )
-    public_bytes = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    private_path.write_bytes(private_bytes)
-    os.chmod(private_path, 0o600)
-    public_path.write_bytes(public_bytes)
-
-    return public_key_id(producer=producer, key_dir=key_dir)
+    _write_lifecycle(producer, key_dir, lifecycle)
+    return key_id
 
 
-def _load_private(producer: str, key_dir: Path) -> Ed25519PrivateKey:
-    pem = _private_path(producer, key_dir).read_bytes()
+def public_key_id(*, producer: str, key_dir: Path) -> str:
+    """Return the ACTIVE ``key_id`` for ``producer``, migrating if needed."""
+    _migrate_flat_layout_if_present(producer, key_dir)
+    lifecycle = _read_lifecycle(producer, key_dir)
+    active = lifecycle.active()
+    if active is None:
+        msg = f"No active key on file for producer '{producer}' in {key_dir}"
+        raise FileNotFoundError(msg)
+    return active.key_id
+
+
+# ---------------------------------------------------------------------------
+# Signing
+# ---------------------------------------------------------------------------
+
+
+def _load_private_by_key_id(producer: str, key_id: str, key_dir: Path) -> Ed25519PrivateKey:
+    pem = _key_path(producer, key_id, key_dir, kind="private").read_bytes()
     return serialization.load_pem_private_key(pem, password=None)  # type: ignore[return-value]
 
 
-def _load_public(producer: str, key_dir: Path) -> Ed25519PublicKey | None:
-    path = _public_path(producer, key_dir)
+def _load_public_by_key_id(producer: str, key_id: str, key_dir: Path) -> Ed25519PublicKey | None:
+    path = _key_path(producer, key_id, key_dir, kind="public")
     if not path.exists():
         return None
     return serialization.load_pem_public_key(path.read_bytes())  # type: ignore[return-value]
 
 
-def public_key_id(*, producer: str, key_dir: Path) -> str:
-    """Return the stable ``key_id`` for a producer's public key.
-
-    Format: ``ed25519:<first 16 hex chars of SHA256(public_key_raw_bytes)>``.
-    """
-    public_key = _load_public(producer, key_dir)
-    if public_key is None:
-        msg = f"No public key on file for producer '{producer}' in {key_dir}"
-        raise FileNotFoundError(msg)
-    raw = public_key.public_bytes(
-        encoding=serialization.Encoding.Raw,
-        format=serialization.PublicFormat.Raw,
-    )
-    digest = hashlib.sha256(raw).hexdigest()[:16]
-    return f"ed25519:{digest}"
-
-
 def sign(message: bytes, *, producer: str, key_dir: Path) -> bytes:
-    """Sign ``message`` with the producer's private key."""
-    private_key = _load_private(producer, key_dir)
+    """Sign ``message`` with the producer's currently ACTIVE key."""
+    _migrate_flat_layout_if_present(producer, key_dir)
+    lifecycle = _read_lifecycle(producer, key_dir)
+    active = lifecycle.active()
+    if active is None:
+        msg = f"No active key on file for producer '{producer}' in {key_dir}"
+        raise FileNotFoundError(msg)
+    private_key = _load_private_by_key_id(producer, active.key_id, key_dir)
     return private_key.sign(message)
 
 
-def verify(message: bytes, signature: bytes, *, producer: str, key_dir: Path) -> bool:
+def verify(
+    message: bytes,
+    signature: bytes,
+    *,
+    producer: str,
+    key_dir: Path,
+    key_id: str | None = None,
+) -> bool:
     """Return ``True`` iff ``signature`` is a valid Ed25519 signature over ``message``.
 
-    Returns ``False`` (never raises) when the signature is invalid, when
-    the producer has no key on file, or when verification otherwise
-    fails. Callers get a boolean so they can produce a clean
-    PROVEN/VIOLATED verdict without exception handling at every site.
+    Args:
+        message: Payload that was signed.
+        signature: Signature bytes to verify.
+        producer: Producer identifier used to locate the keystore.
+        key_dir: Base keystore directory.
+        key_id: Optional specific key to verify against. When omitted,
+            the producer's ACTIVE key is used.
+
+    Returns False (never raises) on any failure, so callers get a clean
+    boolean for lifecycle verdicts.
     """
-    public_key = _load_public(producer, key_dir)
+    _migrate_flat_layout_if_present(producer, key_dir)
+    if key_id is None:
+        lifecycle = _read_lifecycle(producer, key_dir)
+        active = lifecycle.active()
+        if active is None:
+            return False
+        key_id = active.key_id
+
+    public_key = _load_public_by_key_id(producer, key_id, key_dir)
     if public_key is None:
         return False
     try:
@@ -132,3 +287,60 @@ def verify(message: bytes, signature: bytes, *, producer: str, key_dir: Path) ->
     except Exception:
         return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Rotation and revocation
+# ---------------------------------------------------------------------------
+
+
+def rotate_key(*, producer: str, key_dir: Path) -> str:
+    """Retire the producer's current ACTIVE key and generate a fresh one.
+
+    Returns the new active ``key_id``. Raises if no ACTIVE key exists
+    (there is nothing to rotate from).
+    """
+    _migrate_flat_layout_if_present(producer, key_dir)
+    lifecycle = _read_lifecycle(producer, key_dir)
+    active = lifecycle.active()
+    if active is None:
+        msg = f"No active key on file for producer '{producer}' — nothing to rotate."
+        raise FileNotFoundError(msg)
+
+    now = datetime.now(UTC)
+    new_key_id, _ = _write_new_keypair(producer, key_dir)
+
+    # Update prior record.
+    active.status = KeyStatus.RETIRED
+    active.retired_at = now
+    active.successor_key_id = new_key_id
+
+    lifecycle.keys.append(
+        KeyRecord(
+            key_id=new_key_id,
+            status=KeyStatus.ACTIVE,
+            activated_at=now,
+        )
+    )
+    _write_lifecycle(producer, key_dir, lifecycle)
+    return new_key_id
+
+
+def revoke_key(*, producer: str, key_id: str, reason: str, key_dir: Path) -> KeyRecord:
+    """Mark a specific key as REVOKED with a timestamp and reason."""
+    if not reason:
+        msg = "revoke_key requires a non-empty reason."
+        raise ValueError(msg)
+
+    _migrate_flat_layout_if_present(producer, key_dir)
+    lifecycle = _read_lifecycle(producer, key_dir)
+    record = lifecycle.find(key_id)
+    if record is None:
+        msg = f"Key '{key_id}' not found in lifecycle for producer '{producer}'."
+        raise FileNotFoundError(msg)
+
+    record.status = KeyStatus.REVOKED
+    record.revoked_at = datetime.now(UTC)
+    record.revoked_reason = reason
+    _write_lifecycle(producer, key_dir, lifecycle)
+    return record

--- a/src/lemma/services/evidence_log.py
+++ b/src/lemma/services/evidence_log.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from pydantic import TypeAdapter
 
+from lemma.models.key_metadata import KeyStatus
 from lemma.models.ocsf import OcsfBaseEvent
 from lemma.models.signed_evidence import (
     EvidenceIntegrityState,
@@ -242,16 +243,38 @@ class EvidenceLog:
                     signature_bytes,
                     producer=producer,
                     key_dir=self._key_dir,
+                    key_id=envelope.signer_key_id,
                 )
-                if ok:
+                if not ok:
                     return VerificationResult(
-                        EvidenceIntegrityState.PROVEN,
-                        f"Hash, chain, and signature all valid for producer '{producer}'.",
+                        EvidenceIntegrityState.DEGRADED,
+                        f"Hash and chain valid, but signer's key "
+                        f"{envelope.signer_key_id} for producer "
+                        f"'{producer}' is unavailable or the signature doesn't verify.",
+                    )
+
+                # Signature verifies. Now check the key's lifecycle for
+                # revocation — a signature made before the key was
+                # revoked is still PROVEN; one made at or after the
+                # revocation timestamp is VIOLATED.
+                lifecycle = crypto.read_lifecycle(producer, key_dir=self._key_dir)
+                record = lifecycle.find(envelope.signer_key_id)
+                if (
+                    record is not None
+                    and record.status == KeyStatus.REVOKED
+                    and record.revoked_at is not None
+                    and envelope.signed_at >= record.revoked_at
+                ):
+                    return VerificationResult(
+                        EvidenceIntegrityState.VIOLATED,
+                        f"Signer key {envelope.signer_key_id} was revoked at "
+                        f"{record.revoked_at.isoformat()} "
+                        f"({record.revoked_reason or 'no reason given'}); "
+                        f"this entry was signed at or after revocation.",
                     )
                 return VerificationResult(
-                    EvidenceIntegrityState.DEGRADED,
-                    f"Hash and chain valid, but signer's key for producer "
-                    f"'{producer}' is unavailable or the signature doesn't verify.",
+                    EvidenceIntegrityState.PROVEN,
+                    f"Hash, chain, and signature all valid for producer '{producer}'.",
                 )
 
         return VerificationResult(

--- a/tests/commands/test_evidence.py
+++ b/tests/commands/test_evidence.py
@@ -96,3 +96,97 @@ def test_log_requires_lemma_project(tmp_path: Path, monkeypatch):
 
     result = runner.invoke(app, ["evidence", "log"])
     assert result.exit_code == 1
+
+
+def test_rotate_key_command_retires_active_and_prints_new_id(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+    from lemma.services.crypto import read_lifecycle
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_signed_entries(tmp_path, count=1)
+
+    result = runner.invoke(app, ["evidence", "rotate-key", "--producer", "Lemma"])
+    assert result.exit_code == 0, result.stdout
+    assert "ed25519:" in result.stdout  # printed new key_id
+    assert "RETIRED" in result.stdout or "rotated" in result.stdout.lower()
+
+    lifecycle = read_lifecycle("Lemma", key_dir=tmp_path / ".lemma" / "keys")
+    statuses = [r.status.value for r in lifecycle.keys]
+    assert statuses.count("ACTIVE") == 1
+    assert statuses.count("RETIRED") == 1
+
+
+def test_rotate_key_requires_lemma_project(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["evidence", "rotate-key", "--producer", "Lemma"])
+    assert result.exit_code == 1
+
+
+def test_revoke_key_requires_reason(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_signed_entries(tmp_path, count=1)
+
+    # Grab the active key_id.
+    from lemma.services.crypto import read_lifecycle
+
+    active_key_id = read_lifecycle("Lemma", key_dir=tmp_path / ".lemma" / "keys").active().key_id
+
+    # Missing --reason should fail with a non-zero exit.
+    result = runner.invoke(
+        app, ["evidence", "revoke-key", "--producer", "Lemma", "--key-id", active_key_id]
+    )
+    assert result.exit_code != 0
+
+
+def test_revoke_key_marks_record_and_prints_confirmation(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+    from lemma.services.crypto import read_lifecycle
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_signed_entries(tmp_path, count=1)
+
+    active_key_id = read_lifecycle("Lemma", key_dir=tmp_path / ".lemma" / "keys").active().key_id
+
+    result = runner.invoke(
+        app,
+        [
+            "evidence",
+            "revoke-key",
+            "--producer",
+            "Lemma",
+            "--key-id",
+            active_key_id,
+            "--reason",
+            "test compromise",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "REVOKED" in result.stdout
+
+    lifecycle = read_lifecycle("Lemma", key_dir=tmp_path / ".lemma" / "keys")
+    assert lifecycle.find(active_key_id).status.value == "REVOKED"
+
+
+def test_keys_command_lists_all_keys_with_lifecycle(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+    from lemma.services.crypto import rotate_key
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_signed_entries(tmp_path, count=1)
+    rotate_key(producer="Lemma", key_dir=tmp_path / ".lemma" / "keys")
+
+    result = runner.invoke(app, ["evidence", "keys"])
+    assert result.exit_code == 0, result.stdout
+    # Both the retired and active key should surface.
+    assert "ACTIVE" in result.stdout
+    assert "RETIRED" in result.stdout
+    assert "Lemma" in result.stdout

--- a/tests/models/test_key_metadata.py
+++ b/tests/models/test_key_metadata.py
@@ -1,0 +1,55 @@
+"""Tests for evidence-signing key lifecycle metadata."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def test_key_status_enum_values():
+    from lemma.models.key_metadata import KeyStatus
+
+    assert KeyStatus.ACTIVE.value == "ACTIVE"
+    assert KeyStatus.RETIRED.value == "RETIRED"
+    assert KeyStatus.REVOKED.value == "REVOKED"
+
+
+def test_key_record_active_defaults():
+    from lemma.models.key_metadata import KeyRecord, KeyStatus
+
+    activated = datetime.now(UTC)
+    record = KeyRecord(
+        key_id="ed25519:abcd1234",
+        status=KeyStatus.ACTIVE,
+        activated_at=activated,
+    )
+
+    assert record.status == KeyStatus.ACTIVE
+    assert record.retired_at is None
+    assert record.revoked_at is None
+    assert record.revoked_reason == ""
+    assert record.successor_key_id == ""
+
+
+def test_key_record_json_round_trip():
+    import json
+
+    from lemma.models.key_metadata import KeyRecord, KeyStatus
+
+    activated = datetime.now(UTC)
+    revoked = datetime.now(UTC)
+    record = KeyRecord(
+        key_id="ed25519:revoked0",
+        status=KeyStatus.REVOKED,
+        activated_at=activated,
+        revoked_at=revoked,
+        revoked_reason="private key exposed in commit abc123",
+        successor_key_id="ed25519:successor",
+    )
+
+    data = json.loads(record.model_dump_json())
+    assert data["status"] == "REVOKED"
+    assert data["revoked_reason"] == "private key exposed in commit abc123"
+
+    revived = KeyRecord.model_validate_json(record.model_dump_json())
+    assert revived.status == KeyStatus.REVOKED
+    assert revived.successor_key_id == "ed25519:successor"

--- a/tests/models/test_signed_evidence.py
+++ b/tests/models/test_signed_evidence.py
@@ -78,3 +78,19 @@ def test_provenance_record_has_timestamp_by_default():
     record = ProvenanceRecord(stage="storage", actor="lemma", content_hash="x" * 64)
     assert record.timestamp is not None
     assert record.stage == "storage"
+
+
+def test_signed_evidence_has_signed_at_timestamp():
+    """signed_at records when the envelope was written, distinct from event.time."""
+    from lemma.models.signed_evidence import SignedEvidence
+
+    envelope = SignedEvidence(
+        event=_sample_event(),
+        prev_hash="0" * 64,
+        entry_hash="c" * 64,
+        signature="sig",
+        signer_key_id="ed25519:sample00",
+    )
+    assert envelope.signed_at is not None
+    # Default is UTC-aware
+    assert envelope.signed_at.tzinfo is not None

--- a/tests/services/test_crypto.py
+++ b/tests/services/test_crypto.py
@@ -11,11 +11,12 @@ def test_generate_keypair_writes_private_and_public_files(tmp_path: Path):
     key_id = generate_keypair(producer="test-producer", key_dir=tmp_path / "keys")
 
     assert key_id  # non-empty identifier
-    assert (tmp_path / "keys" / "test-producer.private.pem").is_file()
-    assert (tmp_path / "keys" / "test-producer.public.pem").is_file()
+    producer_dir = tmp_path / "keys" / "test-producer"
+    assert (producer_dir / f"{key_id}.private.pem").is_file()
+    assert (producer_dir / f"{key_id}.public.pem").is_file()
 
     # Private key mode is 0600 on POSIX — integrity check
-    private_path = tmp_path / "keys" / "test-producer.private.pem"
+    private_path = producer_dir / f"{key_id}.private.pem"
     mode = private_path.stat().st_mode & 0o777
     assert mode == 0o600, f"private key mode should be 0600, got {oct(mode)}"
 
@@ -67,3 +68,154 @@ def test_key_id_is_derived_from_public_key_bytes(tmp_path: Path):
     derived = public_key_id(producer="stable", key_dir=tmp_path / "keys")
     assert key_id == derived
     assert key_id.startswith("ed25519:")
+
+
+def test_versioned_keystore_layout_on_fresh_generate(tmp_path: Path):
+    """New-layout keystore writes keys under <producer>/<key_id>.*.pem."""
+    from lemma.services.crypto import generate_keypair
+
+    key_id = generate_keypair(producer="fresh", key_dir=tmp_path / "keys")
+    producer_dir = tmp_path / "keys" / "fresh"
+
+    assert producer_dir.is_dir()
+    assert (producer_dir / f"{key_id}.private.pem").is_file()
+    assert (producer_dir / f"{key_id}.public.pem").is_file()
+    assert (producer_dir / "meta.json").is_file()
+
+
+def test_migrate_flat_keystore_preserves_key_id(tmp_path: Path):
+    """A keystore in the old flat layout (pre-#98) is auto-migrated on access."""
+    import json
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from lemma.services.crypto import public_key_id
+
+    # Simulate the pre-#98 flat layout.
+    key_dir = tmp_path / "keys"
+    key_dir.mkdir()
+    legacy_priv = Ed25519PrivateKey.generate()
+    (key_dir / "legacy.private.pem").write_bytes(
+        legacy_priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    (key_dir / "legacy.public.pem").write_bytes(
+        legacy_priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+
+    # Access triggers migration.
+    key_id = public_key_id(producer="legacy", key_dir=key_dir)
+    assert key_id.startswith("ed25519:")
+
+    # New layout exists; old flat files are gone.
+    producer_dir = key_dir / "legacy"
+    assert producer_dir.is_dir()
+    assert (producer_dir / f"{key_id}.private.pem").is_file()
+    assert (producer_dir / "meta.json").is_file()
+    assert not (key_dir / "legacy.private.pem").exists()
+
+    # Meta records the migrated key as ACTIVE.
+    meta = json.loads((producer_dir / "meta.json").read_text())
+    assert len(meta["keys"]) == 1
+    assert meta["keys"][0]["key_id"] == key_id
+    assert meta["keys"][0]["status"] == "ACTIVE"
+
+
+def test_rotate_key_retires_active_and_generates_new(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair, read_lifecycle, rotate_key
+
+    original = generate_keypair(producer="rot", key_dir=tmp_path / "keys")
+    successor = rotate_key(producer="rot", key_dir=tmp_path / "keys")
+
+    assert successor != original
+
+    lifecycle = read_lifecycle("rot", key_dir=tmp_path / "keys")
+    by_id = {r.key_id: r for r in lifecycle.keys}
+
+    assert by_id[original].status.value == "RETIRED"
+    assert by_id[original].retired_at is not None
+    assert by_id[original].successor_key_id == successor
+
+    assert by_id[successor].status.value == "ACTIVE"
+    assert by_id[successor].retired_at is None
+
+
+def test_rotate_key_without_active_key_raises(tmp_path: Path):
+    import pytest
+
+    from lemma.services.crypto import rotate_key
+
+    with pytest.raises(FileNotFoundError):
+        rotate_key(producer="never-generated", key_dir=tmp_path / "keys")
+
+
+def test_rotated_retired_key_can_still_verify_historical_signatures(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair, rotate_key, sign, verify
+
+    original = generate_keypair(producer="hist", key_dir=tmp_path / "keys")
+    historical_signature = sign(b"old message", producer="hist", key_dir=tmp_path / "keys")
+
+    rotate_key(producer="hist", key_dir=tmp_path / "keys")
+
+    # The retired key's material is still on disk and verifiable by key_id.
+    assert verify(
+        b"old message",
+        historical_signature,
+        producer="hist",
+        key_dir=tmp_path / "keys",
+        key_id=original,
+    )
+
+
+def test_revoke_key_requires_reason(tmp_path: Path):
+    import pytest
+
+    from lemma.services.crypto import generate_keypair, revoke_key
+
+    key_id = generate_keypair(producer="rev", key_dir=tmp_path / "keys")
+
+    with pytest.raises(ValueError, match="reason"):
+        revoke_key(producer="rev", key_id=key_id, reason="", key_dir=tmp_path / "keys")
+
+
+def test_revoke_key_marks_record(tmp_path: Path):
+    from lemma.services.crypto import generate_keypair, read_lifecycle, revoke_key
+
+    key_id = generate_keypair(producer="rev", key_dir=tmp_path / "keys")
+
+    record = revoke_key(
+        producer="rev",
+        key_id=key_id,
+        reason="leaked in private repo",
+        key_dir=tmp_path / "keys",
+    )
+
+    assert record.status.value == "REVOKED"
+    assert record.revoked_at is not None
+    assert record.revoked_reason == "leaked in private repo"
+
+    lifecycle = read_lifecycle("rev", key_dir=tmp_path / "keys")
+    assert lifecycle.find(key_id).status.value == "REVOKED"
+
+
+def test_revoke_key_with_unknown_key_id_raises(tmp_path: Path):
+    import pytest
+
+    from lemma.services.crypto import generate_keypair, revoke_key
+
+    generate_keypair(producer="rev", key_dir=tmp_path / "keys")
+
+    with pytest.raises(FileNotFoundError):
+        revoke_key(
+            producer="rev",
+            key_id="ed25519:doesnotexist",
+            reason="test",
+            key_dir=tmp_path / "keys",
+        )

--- a/tests/services/test_evidence_log.py
+++ b/tests/services/test_evidence_log.py
@@ -253,6 +253,96 @@ def test_verify_entry_returns_degraded_when_signer_key_unknown(tmp_path: Path):
     assert "key" in result.detail.lower()
 
 
+def test_rotation_leaves_prior_entries_proven(tmp_path: Path):
+    """Pre-rotation entries stay PROVEN after the signing key is rotated."""
+    from lemma.models.signed_evidence import EvidenceIntegrityState
+    from lemma.services.crypto import rotate_key
+    from lemma.services.evidence_log import EvidenceLog
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    log.append(normalize(_compliance_payload("rot-before")))
+
+    rotate_key(producer="Lemma", key_dir=tmp_path / ".lemma" / "keys")
+    log.append(normalize(_compliance_payload("rot-after")))
+
+    envelopes = log.read_envelopes()
+    for env in envelopes:
+        result = log.verify_entry(env.entry_hash)
+        assert result.state == EvidenceIntegrityState.PROVEN, (
+            f"expected PROVEN, got {result.state}: {result.detail}"
+        )
+
+
+def test_revocation_violates_entries_signed_at_or_after_revoked_at(tmp_path: Path):
+    """REVOKED signer → VIOLATED for entries signed at/after revoked_at, PROVEN before.
+
+    Models the adversarial scenario the revocation check exists to catch: an
+    attacker with a stolen-but-now-revoked key signs new entries after the
+    revocation timestamp. The honest verifier must refuse those entries even
+    though the signature itself is cryptographically valid.
+    """
+    from datetime import timedelta
+
+    from lemma.models.signed_evidence import EvidenceIntegrityState, SignedEvidence
+    from lemma.services import crypto
+    from lemma.services.evidence_log import (
+        EvidenceLog,
+        _compute_entry_hash,
+    )
+    from lemma.services.ocsf_normalizer import normalize
+
+    log = EvidenceLog(log_dir=tmp_path / ".lemma" / "evidence")
+    key_dir = tmp_path / ".lemma" / "keys"
+
+    # A legitimate pre-revoke entry signed by the currently-active key.
+    log.append(normalize(_compliance_payload("pre-revoke")))
+    pre_envelope = log.read_envelopes()[0]
+    active_key_id = pre_envelope.signer_key_id
+
+    # Revoke the signing key.
+    crypto.revoke_key(
+        producer="Lemma",
+        key_id=active_key_id,
+        reason="test: simulated compromise",
+        key_dir=key_dir,
+    )
+
+    # Manually craft a "malicious" post-revocation entry that still uses the
+    # revoked key. This is the whole point of the revocation check — the
+    # signature is cryptographically valid, but policy says ignore it.
+    malicious_event = normalize(_compliance_payload("post-revoke"))
+    prev_hash = pre_envelope.entry_hash
+    entry_hash = _compute_entry_hash(prev_hash, malicious_event)
+    # Use the signing primitive directly with the revoked key's private material.
+    private_key = crypto._load_private_by_key_id("Lemma", active_key_id, key_dir)  # type: ignore[attr-defined]
+    signature = private_key.sign(bytes.fromhex(entry_hash)).hex()
+
+    revoked_record = crypto.read_lifecycle("Lemma", key_dir=key_dir).find(active_key_id)
+    malicious_envelope = SignedEvidence(
+        event=malicious_event,
+        prev_hash=prev_hash,
+        entry_hash=entry_hash,
+        signature=signature,
+        signer_key_id=active_key_id,
+        signed_at=revoked_record.revoked_at + timedelta(milliseconds=1),
+    )
+    log_file = next((tmp_path / ".lemma" / "evidence").glob("*.jsonl"))
+    with log_file.open("a") as f:
+        f.write(malicious_envelope.model_dump_json() + "\n")
+
+    pre_result = log.verify_entry(pre_envelope.entry_hash)
+    post_result = log.verify_entry(malicious_envelope.entry_hash)
+
+    assert pre_result.state == EvidenceIntegrityState.PROVEN, (
+        f"pre-revoke entry should be PROVEN, got {pre_result.state}: {pre_result.detail}"
+    )
+    assert post_result.state == EvidenceIntegrityState.VIOLATED, (
+        f"post-revoke entry should be VIOLATED, got {post_result.state}: {post_result.detail}"
+    )
+    assert "revoked" in post_result.detail.lower()
+
+
 def test_filter_by_class_and_time_range(tmp_path: Path):
     from lemma.services.evidence_log import EvidenceLog
     from lemma.services.ocsf_normalizer import normalize


### PR DESCRIPTION
## Description

Closes #98. Extends PR #100's crypto layer with a full key lifecycle so leaked keys have a remediation path and rotated keys don't orphan historical signatures.

## What changed

**Keystore layout**

| Before | After |
|---|---|
| `.lemma/keys/<producer>.private.pem` | `.lemma/keys/<producer>/<key_id>.private.pem` |
| `.lemma/keys/<producer>.public.pem` | `.lemma/keys/<producer>/<key_id>.public.pem` |
| — | `.lemma/keys/<producer>/meta.json` (KeyLifecycle) |

Flat pre-lifecycle keystores are auto-migrated on first access. Existing projects keep their keys; the migrated key lands as `ACTIVE`.

**Lifecycle semantics**

- `rotate_key` retires the current ACTIVE key, generates a fresh one, links `successor_key_id` on the retired record. Historical signatures under the retired key keep verifying PROVEN — key material stays on disk and `crypto.verify` now accepts an explicit `key_id` to target a specific historical key.
- `revoke_key` marks a specific key REVOKED with a timestamp and required reason. Verification consults the lifecycle: before `revoked_at` → PROVEN, at/after → VIOLATED with a detail naming the revocation and reason.

**New field on `SignedEvidence`**

`signed_at` records when the envelope was produced, distinct from `event.time` (when the thing happened in the outside world). The lifecycle check needs to compare against signing time, not event time — events can be replayed long after they happened, and we don't want a replay to change the revocation verdict.

**CLI**

- `lemma evidence rotate-key --producer <name>`
- `lemma evidence revoke-key --producer <name> --key-id <id> --reason <text>`
- `lemma evidence keys` — lists every signing key with lifecycle state

## Design calls worth flagging

- **Key IDs stay the join key.** Envelopes from PR #100 already carry `signer_key_id`. The versioned keystore indexes keys by that same ID, so verification looks up specific historical keys without any envelope schema change.
- **Flat-layout migration on read, not a dedicated command.** Simpler for operators (no one-shot step) and safer (idempotent, runs every time; if migration already happened the code is a no-op).
- **Revocation is forward-permissive on purpose.** Revoking doesn't invalidate signatures made before the compromise was discovered — that matches every real-world PKI (Sigstore, Let's Encrypt, CRLs). What's being revoked is future trust in the key, not past judgements.
- **`keys` uses plain-text output, not a Rich `Table`.** Rich tables truncate in narrow terminals, including CliRunner's default width. A single formatted line per key stays readable everywhere without column-dropping.

## Deferred scope — tracked

- **Distributed revocation lists (CRLs)** so external verifiers honor revocations done here → #101.
- **Hardware-backed key storage (HSM / YubiKey / TPM)** for enterprise deployments → #102.

Both exist as real issues before this PR opens, per the deferred-scope rule.

## AC mapping (for the issue update after merge)

- [x] **Key metadata schema** — `KeyRecord` with `status`, `activated_at`, `retired_at`, `revoked_at`, `revoked_reason`, `successor_key_id` in `src/lemma/models/key_metadata.py`.
- [x] **`lemma evidence rotate-key --producer <name>` CLI** — `src/lemma/commands/evidence.py::rotate_key_command`.
- [x] **`lemma evidence revoke-key --producer <name> --reason <string>` CLI** — `src/lemma/commands/evidence.py::revoke_key_command` (additionally requires `--key-id` so operators can target a specific historical key, not just the active one).
- [x] **Verification accepts historical signatures from retired keys, refuses revoked-key signatures post-revocation** — `EvidenceLog.verify_entry` walks `crypto.read_lifecycle` and compares `envelope.signed_at` against `revoked_at`.
- [x] **Rotation leaves previously-signed entries PROVEN** — `test_rotation_leaves_prior_entries_proven`.
- [x] **Revocation flags entries signed after the revocation timestamp as VIOLATED** — `test_revocation_violates_entries_signed_at_or_after_revoked_at`.
- [x] **Pre-retirement entries under a retired key remain PROVEN** — rotation test covers both retired and new active.
- [x] **`lemma evidence verify` surfaces the signing key status** — `VerificationResult.detail` names the revoked key and the reason when verdict is VIOLATED due to revocation.

Fixes #98

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest \`main\` branch
- [x] I have run \`uv run ruff check\` and \`uv run ruff format --check\` with no errors
- [x] I have run \`uv run pytest\` and all 341 tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (CHANGELOG + CLI reference)
- [x] My changes generate no new warnings or errors