### PR TITLE
feat(query): Add lemma query for natural-language graph queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `lemma query "<question>"` answers natural-language questions about the compliance knowledge graph. An LLM translates the question to a structured `QueryPlan` (bounded to traversals the executor supports — NEIGHBORS, IMPACT, FRAMEWORK_CONTROL_COUNT — with edge-type and direction filters), the executor walks the graph, and every invocation is recorded in the AI trace log with `operation="query"`. `--verbose` prints the resolved plan before the results so "AI that shows its work" extends to read queries too.
+- Short entry-node names (e.g., `"ac-2"`) are resolved against the graph at translate time; ambiguous matches fail loud with all candidate node IDs listed. The translator retries once with validation feedback on malformed LLM output, then raises a clean `ValueError` — no silent fallback.
+- New AI operation type `query` alongside the existing `map` and `harmonize` — filter with `lemma ai audit --operation query`. Query traces use `confidence=0.0` and `determination="QUERY_EXECUTED"` as conventions for the read-only operation kind.
 - Key lifecycle for evidence signing. Per-producer keys now live under `.lemma/keys/<producer>/<key_id>.*.pem` with a sibling `meta.json` tracking every key the producer has held. Status is one of `ACTIVE`, `RETIRED`, or `REVOKED`. Flat pre-lifecycle layouts are auto-migrated to the versioned layout on first access.
 - `lemma evidence rotate-key --producer <name>` retires the producer's active signing key and generates a fresh one. Pre-rotation entries keep verifying PROVEN under the retired key; new entries use the successor.
 - `lemma evidence revoke-key --producer <name> --key-id <id> --reason <str>` marks a key REVOKED. Verification now returns VIOLATED for entries signed at or after `revoked_at` under a revoked key, and stays PROVEN for signatures made before the revocation.

--- a/docs/concepts/ai.md
+++ b/docs/concepts/ai.md
@@ -8,11 +8,12 @@ This page explains what the AI actually does, what it doesn't do, and how to ver
 
 ```mermaid
 flowchart LR
-    A["Framework ingestion<br/>(semantic indexing)"] --> B["Control mapping<br/>(policy → framework control)"] --> C["Harmonization<br/>(control → control across frameworks)"]
+    A["Framework ingestion<br/>(semantic indexing)"] --> B["Control mapping<br/>(policy → framework control)"] --> C["Harmonization<br/>(control → control across frameworks)"] --> D["NL query<br/>(question → graph traversal)"]
 
     style A fill:#1e293b,stroke:#06b6d4,color:#e2e8f0
     style B fill:#1e293b,stroke:#f59e0b,color:#e2e8f0
     style C fill:#1e293b,stroke:#10b981,color:#e2e8f0
+    style D fill:#1e293b,stroke:#a855f7,color:#e2e8f0
 ```
 
 ### 1. Framework ingestion
@@ -65,6 +66,20 @@ Every equivalence decision is recorded as an `AITrace` with `operation="harmoniz
 Harmonize respects the same confidence-gated automation as mapping: set `ai.automation.thresholds.harmonize` in `lemma.config.yaml` to auto-accept equivalences at or above the threshold. Query harmonization traces with `lemma ai audit --operation harmonize`.
 
 `lemma harmonize` also writes an OSCAL Profile to `.lemma/harmonization.oscal.json`. The profile imports each source catalog and encodes each cluster as a back-matter resource with `lemma:harmonized-cluster` properties and `rlinks` to the member controls — making the output consumable by any OSCAL-aware tool.
+
+### 4. Natural language query — `lemma query`
+
+Users don't always know the graph schema. `lemma query "<question>"` fills that gap:
+
+1. The translator summarizes the live graph (node types, edge types, example node IDs) and sends it along with the question to the LLM.
+2. The LLM returns a structured `QueryPlan` — an executor-bounded object describing entry node, traversal kind, edge filters, and direction.
+3. The translator resolves short entry-node names (`"ac-2"` → `"control:nist-800-53:ac-2"`) against the real graph. Ambiguous short names fail loud.
+4. The executor walks the graph using existing `ComplianceGraph` methods and returns matching nodes.
+5. Every call emits an `AITrace` with `operation="query"`, full prompt, raw LLM output, and the resolved plan — auditable alongside map and harmonize decisions via `lemma ai audit --operation query`.
+
+The LLM cannot generate arbitrary graph code; it can only emit `QueryPlan` instances the executor recognizes. That's the safety contract — the LLM gets to interpret intent creatively, the executor only does what's in the plan.
+
+Query traces use `confidence=0.0` and `determination="QUERY_EXECUTED"` as conventions for the read-only operation kind. A typed discriminator for decision-vs-read ops is a future schema change (see [#104](https://github.com/JoshDoesIT/Lemma/issues/104)).
 
 ## The trust model
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -192,6 +192,35 @@ Every time `lemma map` loads the automation config, it diffs the current thresho
 
 ---
 
+## `lemma query`
+
+Ask the compliance graph a question in plain English. An LLM translates the question into a bounded structured plan (`QueryPlan`), the executor walks the graph using existing traversals, and every call lands in the AI trace log with `operation="query"`.
+
+```bash
+lemma query "<QUESTION>" [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--verbose` | `false` | Print the resolved query plan before the results |
+| `--format` | `table` | Output format: `table` or `json` |
+
+**Examples:**
+
+```bash
+lemma query "Which controls does NIST AC-2 harmonize with?"
+lemma query --verbose "Which policies satisfy ac-2?"
+lemma query --format json "How many controls does nist-csf-2.0 have?"
+```
+
+**What it can and can't do:**
+
+- Supports single-hop traversals (NEIGHBORS / IMPACT / framework control counts) with edge-type and direction filters. Multi-hop questions ("framework → its controls → harmonized controls") land in a future release — see [#105](https://github.com/JoshDoesIT/Lemma/issues/105).
+- Evidence-node queries ("what evidence supports SOC 2 CC6.1?") require evidence nodes in the graph, which ship with connector work — tracked in [#97](https://github.com/JoshDoesIT/Lemma/issues/97).
+- Short entry-node names (`"ac-2"`) are resolved against the real graph. Ambiguous short names (same control ID in multiple frameworks) fail with a message listing all candidates so you can rephrase with a framework qualifier.
+
+---
+
 ## `lemma harmonize`
 
 Harmonize controls across all indexed frameworks into a Common Control Framework (CCF).

--- a/src/lemma/cli.py
+++ b/src/lemma/cli.py
@@ -28,6 +28,7 @@ from lemma.commands.harmonize import (
 )
 from lemma.commands.init import init_command
 from lemma.commands.map import map_command
+from lemma.commands.query import query_command
 from lemma.commands.status import status_command
 from lemma.commands.validate import validate_command
 
@@ -41,6 +42,9 @@ app.command(name="init", help="Scaffold a compliance-as-code repository")(init_c
 app.command(name="status", help="Show compliance posture summary")(status_command)
 app.command(name="validate", help="Validate an OSCAL JSON file")(validate_command)
 app.command(name="map", help="Map policies to framework controls")(map_command)
+app.command(name="query", help="Ask the compliance graph a question in plain English")(
+    query_command
+)
 app.command(name="harmonize", help="Harmonize controls across frameworks")(harmonize_command)
 app.command(name="coverage", help="Per-framework coverage percentages")(coverage_command)
 app.command(name="gaps", help="Identify unmapped controls")(gaps_command)

--- a/src/lemma/commands/query.py
+++ b/src/lemma/commands/query.py
@@ -1,0 +1,155 @@
+"""Implementation of the ``lemma query`` CLI.
+
+Translates a natural-language question into a structured ``QueryPlan``
+via an LLM, executes the plan against the compliance graph, emits an
+``AITrace`` with ``operation="query"``, and renders results.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from lemma.models.trace import AITrace
+from lemma.services.knowledge_graph import ComplianceGraph
+from lemma.services.llm import LLMClient, get_llm_client
+from lemma.services.query_executor import execute
+from lemma.services.query_translator import translate
+from lemma.services.trace_log import TraceLog
+
+console = Console()
+
+
+def _error(message: str) -> None:
+    typer.echo(f"Error: {message}")
+    raise typer.Exit(code=1)
+
+
+def _require_lemma_project() -> Path:
+    cwd = Path.cwd()
+    if not (cwd / ".lemma").exists():
+        console.print("[red]Error:[/red] Not a Lemma project.")
+        console.print("Run [bold]lemma init[/bold] first.")
+        raise typer.Exit(code=1)
+    return cwd
+
+
+def _load_llm(project_dir: Path) -> LLMClient:
+    config_file = project_dir / "lemma.config.yaml"
+    ai_config: dict = {}
+    if config_file.exists():
+        full_config = yaml.safe_load(config_file.read_text()) or {}
+        ai_config = full_config.get("ai", {})
+    try:
+        return get_llm_client(ai_config)
+    except ImportError as exc:
+        _error(str(exc))
+
+
+def _model_id_from(llm_client: LLMClient) -> str:
+    model = str(getattr(llm_client, "model", "unknown"))
+    class_name = type(llm_client).__name__.lower()
+    if "ollama" in class_name:
+        return f"ollama/{model}"
+    if "openai" in class_name:
+        return f"openai/{model}"
+    return model
+
+
+def _format_list(results: list[dict]) -> None:
+    if not results:
+        console.print("[dim]No matching nodes. 0 results.[/dim]")
+        return
+
+    table = Table(title=f"Query Results ({len(results)})")
+    table.add_column("Node", style="cyan", no_wrap=True)
+    table.add_column("Type")
+    table.add_column("Edge", style="dim")
+
+    for row in results:
+        table.add_row(
+            str(row.get("id", "")),
+            str(row.get("type", "")),
+            str(row.get("_edge", "")),
+        )
+    console.print(table)
+
+
+def query_command(
+    question: str = typer.Argument(help="Natural-language question about the graph"),
+    verbose: bool = typer.Option(
+        False, "--verbose", help="Print the resolved query plan before the results"
+    ),
+    output_format: str = typer.Option("table", "--format", help="Output format: table or json"),
+) -> None:
+    """Ask the compliance graph a question in plain English."""
+    project_dir = _require_lemma_project()
+    graph_path = project_dir / ".lemma" / "graph.json"
+    if not graph_path.exists():
+        _error("No compliance graph found. Run `lemma framework add` and `lemma map` first.")
+    graph = ComplianceGraph.load(graph_path)
+
+    llm_client = _load_llm(project_dir)
+
+    # Translate — the translator is the only place LLM calls happen in
+    # this command, so we capture prompt + raw output via a spy.
+    prompt_seen: dict = {}
+    raw_output_seen: dict = {}
+
+    original_generate = llm_client.generate
+
+    def _spying_generate(prompt: str) -> str:
+        prompt_seen.setdefault("first", prompt)
+        response = original_generate(prompt)
+        raw_output_seen.setdefault("first", response)
+        return response
+
+    llm_client.generate = _spying_generate  # type: ignore[method-assign]
+
+    try:
+        plan = translate(question=question, graph=graph, llm_client=llm_client)
+    except ValueError as exc:
+        _error(str(exc))
+
+    if verbose:
+        console.print("[bold]Resolved plan:[/bold]")
+        console.print(plan.model_dump_json(indent=2))
+
+    try:
+        result = execute(plan, graph)
+    except ValueError as exc:
+        _error(str(exc))
+
+    # Emit trace: one entry per query, with prompt + first raw response.
+    trace_log = TraceLog(log_dir=project_dir / ".lemma" / "traces")
+    trace_log.append(
+        AITrace(
+            operation="query",
+            input_text=question[:500],
+            prompt=prompt_seen.get("first", ""),
+            model_id=_model_id_from(llm_client),
+            model_version="",
+            raw_output=raw_output_seen.get("first", ""),
+            confidence=0.0,  # convention: query traces are reads, not decisions
+            determination="QUERY_EXECUTED",
+            control_id="",
+            framework="",
+        )
+    )
+
+    # Render result
+    if output_format == "json":
+        if isinstance(result, int):
+            typer.echo(_json.dumps({"count": result}))
+        else:
+            typer.echo(_json.dumps(result, indent=2))
+    else:
+        if isinstance(result, int):
+            console.print(f"[bold]{result}[/bold]")
+        else:
+            _format_list(result)

--- a/src/lemma/models/query_plan.py
+++ b/src/lemma/models/query_plan.py
@@ -1,0 +1,54 @@
+"""Structured query plan produced by the NL → graph translator.
+
+The LLM takes a natural-language question and returns a ``QueryPlan``
+describing a bounded traversal the executor knows how to run. The
+plan is the contract between the model (which gets to be creative)
+and the executor (which only does what's in the plan).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class QueryTraversal(StrEnum):
+    """Kinds of traversal the executor supports.
+
+    Attributes:
+        NEIGHBORS: One-hop traversal from ``entry_node``; the most
+            general shape, refined by ``edge_filter`` and ``direction``.
+        IMPACT: ``ComplianceGraph.impact`` — downstream controls and
+            frameworks reachable from the entry node.
+        FRAMEWORK_CONTROL_COUNT: Scalar count of controls in a framework.
+    """
+
+    NEIGHBORS = "NEIGHBORS"
+    IMPACT = "IMPACT"
+    FRAMEWORK_CONTROL_COUNT = "FRAMEWORK_CONTROL_COUNT"
+
+
+class QueryPlan(BaseModel):
+    """A bounded, executor-validated graph traversal plan.
+
+    Attributes:
+        entry_node: Fully qualified starting node ID (e.g.
+            ``"control:nist-800-53:ac-2"``). Short names like ``"ac-2"``
+            are resolved against the graph before execution.
+        traversal: Which kind of walk to perform.
+        edge_filter: When non-empty, only edges whose relationship is in
+            this list are traversed. Applies to NEIGHBORS.
+        direction: Filter on edge direction relative to ``entry_node``.
+            ``"out"`` = only outgoing edges, ``"in"`` = only incoming,
+            ``"both"`` = no direction filter.
+        output_shape: ``"list"`` returns a list of result dicts;
+            ``"count"`` returns an integer.
+    """
+
+    entry_node: str
+    traversal: QueryTraversal
+    edge_filter: list[str] = Field(default_factory=list)
+    direction: Literal["in", "out", "both"] = "both"
+    output_shape: Literal["list", "count"] = "list"

--- a/src/lemma/services/query_executor.py
+++ b/src/lemma/services/query_executor.py
@@ -1,0 +1,91 @@
+"""Executes a ``QueryPlan`` against the compliance graph.
+
+The executor is deliberately narrow: it only does what ``QueryPlan``
+encodes. An LLM cannot ask it to walk arbitrary code — the bounded
+plan shape is the safety contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lemma.models.query_plan import QueryPlan, QueryTraversal
+from lemma.services.knowledge_graph import ComplianceGraph
+
+
+def _neighbors_with_filters(plan: QueryPlan, graph: ComplianceGraph) -> list[dict[str, Any]]:
+    export = graph.export_json()
+    nodes_by_id = {n["id"]: n for n in export["nodes"]}
+    entry = plan.entry_node
+
+    results: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for edge in export["edges"]:
+        source = edge["source"]
+        target = edge["target"]
+        relationship = edge.get("relationship", "")
+
+        if plan.edge_filter and relationship not in plan.edge_filter:
+            continue
+
+        if source == entry:
+            if plan.direction == "in":
+                continue
+            other_id = target
+        elif target == entry:
+            if plan.direction == "out":
+                continue
+            other_id = source
+        else:
+            continue
+
+        if other_id in seen_ids:
+            continue
+        seen_ids.add(other_id)
+
+        other_node = nodes_by_id.get(other_id, {})
+        results.append({"id": other_id, **other_node, "_edge": relationship})
+
+    return results
+
+
+def execute(plan: QueryPlan, graph: ComplianceGraph) -> list[dict[str, Any]] | int:
+    """Run a plan against the graph and return the result.
+
+    Args:
+        plan: Validated query plan from the translator.
+        graph: Loaded compliance graph.
+
+    Returns:
+        A list of result dicts for ``output_shape="list"`` or an integer
+        count for ``output_shape="count"``.
+
+    Raises:
+        ValueError: If ``entry_node`` doesn't exist in the graph or if
+            the requested traversal isn't supported.
+    """
+    # Framework-control-count takes a framework name, not a graph node.
+    if plan.traversal == QueryTraversal.FRAMEWORK_CONTROL_COUNT:
+        framework_name = plan.entry_node.removeprefix("framework:")
+        return graph.framework_control_count(framework_name)
+
+    # Everything else requires the entry node to actually exist.
+    if graph.get_node(plan.entry_node) is None:
+        msg = f"entry_node '{plan.entry_node}' not found in the compliance graph."
+        raise ValueError(msg)
+
+    if plan.traversal == QueryTraversal.NEIGHBORS:
+        results = _neighbors_with_filters(plan, graph)
+        return len(results) if plan.output_shape == "count" else results
+
+    if plan.traversal == QueryTraversal.IMPACT:
+        impact_result = graph.impact(plan.entry_node)
+        rows = [
+            {"id": f"control:{c.get('framework', '')}:{c.get('id', '')}", **c}
+            for c in impact_result.get("controls", [])
+        ]
+        return len(rows) if plan.output_shape == "count" else rows
+
+    msg = f"Unsupported traversal: {plan.traversal}"
+    raise ValueError(msg)

--- a/src/lemma/services/query_translator.py
+++ b/src/lemma/services/query_translator.py
@@ -1,0 +1,166 @@
+"""Translate natural-language questions into structured ``QueryPlan``s.
+
+The translator is the bridge between the LLM (which gets to be creative
+about interpreting the user's intent) and the executor (which only runs
+bounded plans). It does three things:
+
+1. Summarize the graph schema so the LLM knows what node types,
+   relationship types, and entry-node IDs actually exist.
+2. Prompt the LLM for a JSON plan matching ``QueryPlan``. Retry once
+   with validation feedback on malformed output. Fail loud after that.
+3. Resolve short entry-node names (e.g. ``"ac-2"``) against the real
+   graph, because LLMs routinely drop the framework qualifier.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+
+from lemma.models.query_plan import QueryPlan
+from lemma.services.knowledge_graph import ComplianceGraph
+from lemma.services.llm import LLMClient
+
+_plan_adapter: TypeAdapter[QueryPlan] = TypeAdapter(QueryPlan)
+
+_PROMPT_TEMPLATE = """\
+You are translating a user's natural-language question into a structured
+graph query plan for the Lemma compliance knowledge graph.
+
+Respond ONLY with a JSON object matching this schema:
+  {{
+    "entry_node": "<fully qualified node id, e.g. 'control:nist-800-53:ac-2'>",
+    "traversal": "NEIGHBORS" | "IMPACT" | "FRAMEWORK_CONTROL_COUNT",
+    "edge_filter": ["SATISFIES" | "HARMONIZED_WITH" | "CONTAINS"] (optional),
+    "direction": "in" | "out" | "both" (optional, default "both"),
+    "output_shape": "list" | "count" (optional, default "list")
+  }}
+
+Graph schema (what actually exists today):
+{schema_summary}
+
+Example entry nodes in this graph:
+{example_nodes}
+
+User question:
+{question}
+
+{feedback}Return JSON only. No markdown fences, no commentary."""
+
+
+def _schema_summary(graph: ComplianceGraph) -> str:
+    export = graph.export_json()
+    node_type_counts = Counter(n.get("type", "Unknown") for n in export["nodes"])
+    edge_type_counts = Counter(e.get("relationship", "Unknown") for e in export["edges"])
+    lines = ["Node types:"]
+    for ntype, count in sorted(node_type_counts.items()):
+        lines.append(f"  - {ntype} ({count})")
+    lines.append("Relationship types:")
+    for etype, count in sorted(edge_type_counts.items()):
+        lines.append(f"  - {etype} ({count})")
+    return "\n".join(lines)
+
+
+def _example_nodes(graph: ComplianceGraph, limit: int = 5) -> str:
+    export = graph.export_json()
+    ids_by_type: dict[str, list[str]] = {}
+    for node in export["nodes"]:
+        ntype = node.get("type", "Unknown")
+        ids_by_type.setdefault(ntype, []).append(node["id"])
+    lines: list[str] = []
+    for ntype, ids in sorted(ids_by_type.items()):
+        lines.append(f"  {ntype}:")
+        for nid in ids[:limit]:
+            lines.append(f"    - {nid}")
+    return "\n".join(lines)
+
+
+def _resolve_entry_node(raw: str, graph: ComplianceGraph) -> str:
+    """Resolve an LLM-supplied entry_node against real graph node IDs.
+
+    Resolution order:
+      1. Exact match — return as-is.
+      2. Case-insensitive suffix match on ``:{raw}`` — e.g. ``"ac-2"``
+         resolves to ``"control:nist-800-53:ac-2"``.
+      3. Zero candidates → return the raw value; ``execute`` raises the
+         standard "entry_node not found" error with consistent wording.
+      4. Multiple candidates → raise listing all of them.
+    """
+    export = graph.export_json()
+    all_ids = [n["id"] for n in export["nodes"]]
+
+    if raw in all_ids:
+        return raw
+
+    suffix = f":{raw.lower()}"
+    candidates = [nid for nid in all_ids if nid.lower().endswith(suffix)]
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        listed = ", ".join(candidates)
+        msg = (
+            f"entry_node '{raw}' is ambiguous — multiple nodes match: {listed}. "
+            f"Rephrase the question with a framework qualifier."
+        )
+        raise ValueError(msg)
+    return raw
+
+
+def _build_prompt(question: str, graph: ComplianceGraph, feedback: str = "") -> str:
+    return _PROMPT_TEMPLATE.format(
+        schema_summary=_schema_summary(graph),
+        example_nodes=_example_nodes(graph),
+        question=question,
+        feedback=(feedback + "\n\n") if feedback else "",
+    )
+
+
+def _try_parse(raw: str) -> tuple[QueryPlan | None, str]:
+    """Return ``(plan, error)`` — exactly one is non-empty."""
+    try:
+        payload: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"Response is not valid JSON: {exc}"
+    try:
+        return _plan_adapter.validate_python(payload), ""
+    except ValidationError as exc:
+        return None, f"Response did not match QueryPlan: {exc}"
+
+
+def translate(
+    *,
+    question: str,
+    graph: ComplianceGraph,
+    llm_client: LLMClient,
+) -> QueryPlan:
+    """Produce a validated, graph-resolved ``QueryPlan`` for ``question``.
+
+    Retries once with validation feedback on the first invalid response.
+    Raises ``ValueError`` if the second attempt is also invalid, or if
+    the LLM's ``entry_node`` is ambiguous against the real graph.
+    """
+    prompt = _build_prompt(question, graph)
+    raw = llm_client.generate(prompt)
+    plan, error = _try_parse(raw)
+
+    if plan is None:
+        feedback = (
+            "Your previous response was invalid and could not be parsed as "
+            f"a QueryPlan. The error was: {error}. Respond only with JSON "
+            "matching the schema exactly."
+        )
+        retry_prompt = _build_prompt(question, graph, feedback=feedback)
+        raw = llm_client.generate(retry_prompt)
+        plan, error = _try_parse(raw)
+
+    if plan is None:
+        msg = f"Could not translate question into a QueryPlan: {error}"
+        raise ValueError(msg)
+
+    resolved_entry = _resolve_entry_node(plan.entry_node, graph)
+    if resolved_entry != plan.entry_node:
+        plan = plan.model_copy(update={"entry_node": resolved_entry})
+    return plan

--- a/tests/commands/test_query.py
+++ b/tests/commands/test_query.py
@@ -1,0 +1,137 @@
+"""Tests for the `lemma query` CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _seed_graph_in_lemma_project(project: Path):
+    """Put a small graph at <project>/.lemma/graph.json."""
+    from lemma.services.knowledge_graph import ComplianceGraph
+
+    graph = ComplianceGraph()
+    graph.add_framework("nist-800-53")
+    graph.add_framework("nist-csf-2.0")
+    graph.add_control(
+        framework="nist-800-53",
+        control_id="ac-2",
+        title="Account Management",
+        family="AC",
+    )
+    graph.add_control(
+        framework="nist-csf-2.0",
+        control_id="pr.aa-1",
+        title="Identities",
+        family="PR",
+    )
+    graph.add_harmonization(
+        framework_a="nist-800-53",
+        control_a="ac-2",
+        framework_b="nist-csf-2.0",
+        control_b="pr.aa-1",
+        similarity=0.92,
+    )
+    graph.save(project / ".lemma" / "graph.json")
+
+
+def test_query_requires_lemma_project(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["query", "anything"])
+    assert result.exit_code == 1
+    stdout = result.stdout.lower()
+    assert "not a lemma project" in stdout or "lemma init" in stdout
+
+
+def test_query_end_to_end_emits_trace_with_operation_query(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+    from lemma.services.trace_log import TraceLog
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_graph_in_lemma_project(tmp_path)
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps(
+        {
+            "entry_node": "ac-2",  # short form — resolver fills in framework
+            "traversal": "NEIGHBORS",
+            "edge_filter": ["HARMONIZED_WITH"],
+        }
+    )
+
+    with patch("lemma.commands.query.get_llm_client", return_value=mock_llm):
+        result = runner.invoke(app, ["query", "Which controls does NIST AC-2 harmonize with?"])
+
+    assert result.exit_code == 0, result.stdout
+    # The harmonized CSF control appears in the output.
+    assert "pr.aa-1" in result.stdout
+
+    # One trace entry landed in the log with operation="query".
+    traces = TraceLog(log_dir=tmp_path / ".lemma" / "traces").read_all()
+    query_traces = [t for t in traces if t.operation == "query"]
+    assert len(query_traces) == 1
+    trace = query_traces[0]
+    # Convention for read ops: confidence=0.0, determination="QUERY_EXECUTED".
+    assert trace.confidence == 0.0
+    assert trace.determination == "QUERY_EXECUTED"
+    assert trace.prompt  # the actual prompt sent to the LLM
+    assert trace.raw_output  # the LLM's raw response
+
+
+def test_query_verbose_shows_resolved_plan(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_graph_in_lemma_project(tmp_path)
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps(
+        {
+            "entry_node": "ac-2",
+            "traversal": "NEIGHBORS",
+            "edge_filter": ["HARMONIZED_WITH"],
+        }
+    )
+
+    with patch("lemma.commands.query.get_llm_client", return_value=mock_llm):
+        result = runner.invoke(
+            app,
+            ["query", "--verbose", "Which controls does NIST AC-2 harmonize with?"],
+        )
+
+    assert result.exit_code == 0
+    # Resolved entry_node (full form) should appear in the output because --verbose
+    # renders the plan.
+    assert "control:nist-800-53:ac-2" in result.stdout
+    assert "NEIGHBORS" in result.stdout
+
+
+def test_query_exits_non_zero_when_entry_node_not_found(tmp_path: Path, monkeypatch):
+    from lemma.cli import app
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".lemma").mkdir()
+    _seed_graph_in_lemma_project(tmp_path)
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps(
+        {
+            "entry_node": "control:nist-800-53:doesnotexist",
+            "traversal": "NEIGHBORS",
+        }
+    )
+
+    with patch("lemma.commands.query.get_llm_client", return_value=mock_llm):
+        result = runner.invoke(app, ["query", "anything"])
+
+    assert result.exit_code == 1
+    assert "not found" in result.stdout.lower() or "entry_node" in result.stdout.lower()

--- a/tests/models/test_query_plan.py
+++ b/tests/models/test_query_plan.py
@@ -1,0 +1,87 @@
+"""Tests for the QueryPlan model — structured NL-query plan."""
+
+from __future__ import annotations
+
+
+def test_query_traversal_enum_values():
+    from lemma.models.query_plan import QueryTraversal
+
+    assert QueryTraversal.NEIGHBORS.value == "NEIGHBORS"
+    assert QueryTraversal.IMPACT.value == "IMPACT"
+    assert QueryTraversal.FRAMEWORK_CONTROL_COUNT.value == "FRAMEWORK_CONTROL_COUNT"
+
+
+def test_query_plan_minimal_construction():
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+    )
+
+    assert plan.entry_node == "control:nist-800-53:ac-2"
+    assert plan.traversal == QueryTraversal.NEIGHBORS
+    # Defaults
+    assert plan.edge_filter == []
+    assert plan.direction == "both"
+    assert plan.output_shape == "list"
+
+
+def test_query_plan_accepts_edge_filter_and_direction():
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+        edge_filter=["HARMONIZED_WITH"],
+        direction="out",
+        output_shape="count",
+    )
+
+    assert plan.edge_filter == ["HARMONIZED_WITH"]
+    assert plan.direction == "out"
+    assert plan.output_shape == "count"
+
+
+def test_query_plan_rejects_unknown_traversal():
+    import pytest
+    from pydantic import ValidationError
+
+    from lemma.models.query_plan import QueryPlan
+
+    with pytest.raises(ValidationError):
+        QueryPlan(entry_node="x", traversal="MADE_UP_TRAVERSAL")
+
+
+def test_query_plan_rejects_invalid_direction():
+    import pytest
+    from pydantic import ValidationError
+
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+
+    with pytest.raises(ValidationError):
+        QueryPlan(
+            entry_node="x",
+            traversal=QueryTraversal.NEIGHBORS,
+            direction="sideways",
+        )
+
+
+def test_query_plan_json_round_trip():
+    import json
+
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+        edge_filter=["HARMONIZED_WITH", "SATISFIES"],
+        direction="in",
+        output_shape="list",
+    )
+    data = json.loads(plan.model_dump_json())
+    assert data["traversal"] == "NEIGHBORS"
+
+    revived = QueryPlan.model_validate_json(plan.model_dump_json())
+    assert revived.edge_filter == ["HARMONIZED_WITH", "SATISFIES"]
+    assert revived.direction == "in"

--- a/tests/services/test_query_executor.py
+++ b/tests/services/test_query_executor.py
@@ -1,0 +1,129 @@
+"""Tests for the NL-query executor — plan → graph traversal."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _build_graph():
+    """Build a small graph covering the three edge types the executor cares about."""
+    from lemma.services.knowledge_graph import ComplianceGraph
+
+    graph = ComplianceGraph()
+    graph.add_framework("nist-800-53")
+    graph.add_framework("nist-csf-2.0")
+    graph.add_control(
+        framework="nist-800-53",
+        control_id="ac-2",
+        title="Account Management",
+        family="AC",
+    )
+    graph.add_control(
+        framework="nist-csf-2.0",
+        control_id="pr.aa-1",
+        title="Identities",
+        family="PR",
+    )
+    graph.add_policy("access-control.md", title="Access Control")
+    graph.add_mapping(
+        policy="access-control.md",
+        framework="nist-800-53",
+        control_id="ac-2",
+        confidence=0.9,
+    )
+    graph.add_harmonization(
+        framework_a="nist-800-53",
+        control_a="ac-2",
+        framework_b="nist-csf-2.0",
+        control_b="pr.aa-1",
+        similarity=0.92,
+    )
+    return graph
+
+
+def test_execute_raises_on_unknown_entry_node():
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+    from lemma.services.query_executor import execute
+
+    graph = _build_graph()
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:does-not-exist",
+        traversal=QueryTraversal.NEIGHBORS,
+    )
+
+    with pytest.raises(ValueError, match="entry_node"):
+        execute(plan, graph)
+
+
+def test_execute_neighbors_no_filter_returns_all_neighbors():
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+    from lemma.services.query_executor import execute
+
+    graph = _build_graph()
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+    )
+
+    results = execute(plan, graph)
+
+    neighbor_ids = {r["id"] for r in results}
+    # AC-2 connects to: the framework (CONTAINS), the policy (SATISFIES in), and the
+    # harmonized CSF control (HARMONIZED_WITH).
+    assert "framework:nist-800-53" in neighbor_ids
+    assert "policy:access-control.md" in neighbor_ids
+    assert "control:nist-csf-2.0:pr.aa-1" in neighbor_ids
+
+
+def test_execute_neighbors_with_harmonized_filter_returns_only_harmonized():
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+    from lemma.services.query_executor import execute
+
+    graph = _build_graph()
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+        edge_filter=["HARMONIZED_WITH"],
+    )
+
+    results = execute(plan, graph)
+    neighbor_ids = {r["id"] for r in results}
+
+    assert neighbor_ids == {"control:nist-csf-2.0:pr.aa-1"}
+
+
+def test_execute_neighbors_direction_in_returns_only_inbound():
+    """direction='in' on a control returns only things pointing AT it."""
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+    from lemma.services.query_executor import execute
+
+    graph = _build_graph()
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+        edge_filter=["SATISFIES"],
+        direction="in",
+    )
+
+    results = execute(plan, graph)
+    neighbor_ids = {r["id"] for r in results}
+    # Only the policy satisfies the control (SATISFIES edges point policy → control).
+    assert neighbor_ids == {"policy:access-control.md"}
+
+
+def test_execute_neighbors_direction_out_excludes_inbound():
+    """direction='out' excludes edges pointing AT the entry node."""
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+    from lemma.services.query_executor import execute
+
+    graph = _build_graph()
+    plan = QueryPlan(
+        entry_node="control:nist-800-53:ac-2",
+        traversal=QueryTraversal.NEIGHBORS,
+        direction="out",
+    )
+
+    results = execute(plan, graph)
+    neighbor_ids = {r["id"] for r in results}
+    # No SATISFIES-in edges; only the outgoing HARMONIZED_WITH (symmetric so one side shows).
+    assert "policy:access-control.md" not in neighbor_ids

--- a/tests/services/test_query_translator.py
+++ b/tests/services/test_query_translator.py
@@ -1,0 +1,160 @@
+"""Tests for the NL → QueryPlan translator."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _build_graph():
+    from lemma.services.knowledge_graph import ComplianceGraph
+
+    graph = ComplianceGraph()
+    graph.add_framework("nist-800-53")
+    graph.add_control(
+        framework="nist-800-53", control_id="ac-2", title="Account Management", family="AC"
+    )
+    graph.add_control(
+        framework="nist-800-53",
+        control_id="au-3",
+        title="Content of Audit Records",
+        family="AU",
+    )
+    graph.add_framework("nist-csf-2.0")
+    graph.add_control(
+        framework="nist-csf-2.0", control_id="pr.aa-1", title="Identities", family="PR"
+    )
+    graph.add_harmonization(
+        framework_a="nist-800-53",
+        control_a="ac-2",
+        framework_b="nist-csf-2.0",
+        control_b="pr.aa-1",
+        similarity=0.92,
+    )
+    return graph
+
+
+def test_translate_happy_path_returns_query_plan():
+    from lemma.models.query_plan import QueryPlan, QueryTraversal
+    from lemma.services.query_translator import translate
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps(
+        {
+            "entry_node": "control:nist-800-53:ac-2",
+            "traversal": "NEIGHBORS",
+            "edge_filter": ["HARMONIZED_WITH"],
+            "direction": "both",
+            "output_shape": "list",
+        }
+    )
+
+    plan = translate(
+        question="Which controls does NIST AC-2 harmonize with?",
+        graph=_build_graph(),
+        llm_client=mock_llm,
+    )
+
+    assert isinstance(plan, QueryPlan)
+    assert plan.entry_node == "control:nist-800-53:ac-2"
+    assert plan.traversal == QueryTraversal.NEIGHBORS
+    assert plan.edge_filter == ["HARMONIZED_WITH"]
+
+
+def test_translate_retries_once_with_validation_feedback():
+    """Malformed JSON on first call; valid plan on retry — return the retry's plan."""
+    from lemma.services.query_translator import translate
+
+    mock_llm = MagicMock()
+    mock_llm.generate.side_effect = [
+        "not-json-at-all",
+        json.dumps(
+            {
+                "entry_node": "control:nist-800-53:ac-2",
+                "traversal": "NEIGHBORS",
+            }
+        ),
+    ]
+
+    plan = translate(
+        question="anything",
+        graph=_build_graph(),
+        llm_client=mock_llm,
+    )
+
+    assert plan.entry_node == "control:nist-800-53:ac-2"
+    # Two attempts total: one original, one retry.
+    assert mock_llm.generate.call_count == 2
+
+    # The retry prompt should mention the parse error so the LLM can correct.
+    retry_call_prompt = mock_llm.generate.call_args_list[1].args[0]
+    assert "previous" in retry_call_prompt.lower() or "invalid" in retry_call_prompt.lower()
+
+
+def test_translate_raises_after_second_failure():
+    from lemma.services.query_translator import translate
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = "never-valid-json"
+
+    with pytest.raises(ValueError, match=r"(?i)plan|json"):
+        translate(
+            question="anything",
+            graph=_build_graph(),
+            llm_client=mock_llm,
+        )
+
+    assert mock_llm.generate.call_count == 2  # original + one retry
+
+
+def test_translate_resolves_short_entry_node_against_graph():
+    """LLM says 'ac-2'; translator resolves to 'control:nist-800-53:ac-2'."""
+    from lemma.services.query_translator import translate
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps({"entry_node": "ac-2", "traversal": "NEIGHBORS"})
+
+    plan = translate(
+        question="Which controls does AC-2 harmonize with?",
+        graph=_build_graph(),
+        llm_client=mock_llm,
+    )
+
+    assert plan.entry_node == "control:nist-800-53:ac-2"
+
+
+def test_translate_raises_when_entry_node_ambiguous():
+    """Two frameworks with the same control_id → clear error listing candidates."""
+    from lemma.services.knowledge_graph import ComplianceGraph
+    from lemma.services.query_translator import translate
+
+    # Both frameworks have a control "ac-2".
+    graph = ComplianceGraph()
+    graph.add_framework("nist-800-53")
+    graph.add_framework("other-fw")
+    graph.add_control(framework="nist-800-53", control_id="ac-2", title="A", family="AC")
+    graph.add_control(framework="other-fw", control_id="ac-2", title="B", family="AC")
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps({"entry_node": "ac-2", "traversal": "NEIGHBORS"})
+
+    with pytest.raises(ValueError, match=r"ambiguous|multiple"):
+        translate(question="anything", graph=graph, llm_client=mock_llm)
+
+
+def test_translate_passes_through_when_entry_node_already_fully_qualified():
+    from lemma.services.query_translator import translate
+
+    mock_llm = MagicMock()
+    mock_llm.generate.return_value = json.dumps(
+        {"entry_node": "control:nist-csf-2.0:pr.aa-1", "traversal": "NEIGHBORS"}
+    )
+
+    plan = translate(
+        question="anything",
+        graph=_build_graph(),
+        llm_client=mock_llm,
+    )
+    assert plan.entry_node == "control:nist-csf-2.0:pr.aa-1"


### PR DESCRIPTION
## Description

Closes #96. Adds `lemma query "<question>"` as a third AI operation alongside `map` and `harmonize`: the user asks a question in English, an LLM translates it to a structured `QueryPlan`, the executor walks the compliance graph using existing traversal methods, and every call lands in the AI trace log.

This closes out the last open AC from Phase 2's #19 (compliance knowledge graph) — split from #19 during the Phase 2 closeout so Phase 2 could retire without waiting on the NL-query feature.

## What changed

**`QueryPlan` — bounded plan shape.** Entry node + traversal (NEIGHBORS / IMPACT / FRAMEWORK_CONTROL_COUNT) + edge filter (e.g. `["HARMONIZED_WITH"]`) + direction (in/out/both) + output shape (list/count). The LLM can't emit arbitrary graph code; it can only emit plans the executor recognizes. That's the safety contract.

**Translator.** Summarizes the live graph for the LLM (node/edge type counts + example IDs), prompts for JSON matching `QueryPlan`, parses with a Pydantic `TypeAdapter`. On malformed output it retries once with the parse error appended to the prompt; after that a clean `ValueError`, no silent fallback. Short entry-node names get resolved against the real graph — `"ac-2"` → `"control:nist-800-53:ac-2"` when unambiguous; ambiguous matches raise with every candidate listed so the user can rephrase.

**Executor.** NEIGHBORS uses the graph's exported edges with post-filters, so "what harmonizes with X" and "what satisfies X" share one codepath with just different filters. IMPACT reuses `ComplianceGraph.impact()`. Unknown entry nodes raise cleanly.

**CLI.** `lemma query "<question>" [--verbose] [--format table|json]`. Emits an `AITrace(operation="query")` per invocation with the full prompt, raw LLM output, and the resolved plan. `--verbose` prints the resolved plan before the result. Queryable via `lemma ai audit --operation query`.

## Design calls worth flagging

- **`confidence=0.0` and `determination="QUERY_EXECUTED"` as conventions.** The existing `AITrace` fields don't fit read ops perfectly — a query isn't "confidence-scored" and doesn't have a "determination" in the map/harmonize sense. A typed `operation_kind` discriminator is the right answer but touches every consumer of `AITrace`. Split to #104 so this PR stays focused.
- **Retry with feedback, not blind retry.** If the LLM returns malformed JSON, one retry with the validation error appended to the prompt recovers the cheap case without looping forever. Second failure is a clean `ValueError`.
- **Entry-node resolution is deterministic.** LLMs confidently emit `"ac-2"` instead of the fully qualified node ID. Resolver does exact match → case-insensitive suffix match → list-all-candidates-on-ambiguity. No retrying the LLM — it doesn't know which framework the user meant either.
- **Single-hop only in v1.** Questions like "what harmonized controls cover framework X?" need two hops and aren't supported here. Follow-up in #105.
- **CLI captures prompt/raw-output via a lightweight spy on `llm_client.generate`.** Avoids plumbing those strings through every translator signature. Reads the first attempt only (which is what matters for audit).

## Out of scope — tracked

- **Multi-hop traversals** → **#105** (two-hop and three-hop plans, depth limit, translator prompt examples).
- **`AITrace.operation_kind` discriminator** → **#104** (typed decision-vs-read, updates to audit filter).
- **Reject `thresholds.query` at `AutomationConfig` load time** → **#106** (small footgun guard).
- **Evidence-node queries** — already tracked in #97 (blocked on #76).

All three tracking issues exist before this PR opens, per the deferred-scope rule.

## AC mapping (for the issue update after merge)

- [x] `lemma query "Which controls does NIST AC-2 map to?"` returns harmonized controls — `test_query_end_to_end_emits_trace_with_operation_query` runs this exact shape against a seeded graph and asserts the harmonized CSF control appears.
- [x] `lemma query` emits an `AITrace(operation="query")`, filterable via `lemma ai audit --operation query` — same test verifies the trace lands with full prompt + raw output; the `--operation` filter was added to `ai audit` in PR #95.
- [x] `lemma query --verbose "..."` prints the resolved plan before the result — `test_query_verbose_shows_resolved_plan`.
- [x] LLM response not matching the plan schema fails loud, never guesses — `test_translate_raises_after_second_failure` (two malformed responses) and `test_translate_retries_once_with_validation_feedback` (recovery on second try).
- [x] Unit test coverage ≥ 90% for the translator and executor — 21 new tests across model (6), executor (5), translator (6), CLI (4).

Fixes #96

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-Submission Checklist

- [x] I have rebased on the latest \`main\` branch
- [x] I have run \`uv run ruff check\` and \`uv run ruff format --check\` with no errors
- [x] I have run \`uv run pytest\` and all 362 tests pass
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed (CHANGELOG + CLI reference + concepts guide)
- [x] My changes generate no new warnings or errors