### PR TITLE
feat(connectors): pluggable secret backends (Vault, AWS Secrets Manager, OS keyring) (#227)

### DIFF
--- a/docs/security/connector-secrets.md
+++ b/docs/security/connector-secrets.md
@@ -7,22 +7,23 @@ one leaks.
 
 ## Where credentials can live
 
-Lemma supports two homes for a connector credential, both keeping it out of
-your connector code and out of git:
+Lemma keeps a connector credential out of your connector code and out of git.
+A credential can come from the environment or from a **secret backend**, both
+referenced inside `lemma_connector_config.yaml`:
 
-| Backend | Reference in config | When to use |
-|---------|--------------------|-------------|
+| Source | Reference in config | When to use |
+|--------|--------------------|-------------|
 | **Environment variable** | `${ENV_VAR}` | CI runners and orchestrators that already inject secrets as env vars. |
-| **Encrypted secret store** | `${secret:NAME}` | Workstations and long-lived hosts where you want credentials encrypted at rest rather than exported into the process environment. |
+| **Secret backend** | `${secret:NAME}` | Anywhere you'd rather not export the credential into the process environment. The *backend* behind `${secret:NAME}` is selectable (see below) — local encrypted store by default, or Vault / AWS Secrets Manager / OS keyring. |
 
-Both are resolved at config-load time (`lemma_connector_config.yaml`). A
-missing env var or missing stored secret raises a clean error rather than
-silently substituting an empty string.
+Both are resolved at config-load time. A missing env var or missing stored
+secret raises a clean error rather than silently substituting an empty string.
 
-> **Pluggable remote backends** (OS keyring, HashiCorp Vault, AWS Secrets
-> Manager) are intentionally deferred. The encrypted file store is the local
-> canonical store those backends will slot behind without changing the
-> `${secret:NAME}` reference syntax.
+The key property: `${secret:NAME}` is **backend-agnostic**. Switching from the
+local store to Vault (or AWS Secrets Manager, or the OS keyring) is a one-line
+environment change — `LEMMA_SECRET_BACKEND` — and never touches the config
+file's `${secret:NAME}` references. See [Remote secret
+backends](#remote-secret-backends).
 
 ## The encrypted secret store
 
@@ -52,7 +53,93 @@ config:
   token: ${secret:JIRA_TOKEN} # from the encrypted store
 ```
 
+## Remote secret backends
+
+For hosts where credentials should live in a central secret manager rather than
+a local file, set `LEMMA_SECRET_BACKEND` to source `${secret:NAME}` from a
+remote backend instead. The config file is unchanged — only the environment of
+the process running `lemma connector run` / `lemma evidence collect --config`
+differs.
+
+| `LEMMA_SECRET_BACKEND` | Backend | Extra install |
+|------------------------|---------|---------------|
+| _(unset)_ / `local` | Encrypted file store (default) | — |
+| `vault` | HashiCorp Vault (KV v2) | `pip install 'lemma[secrets]'` |
+| `aws-secrets-manager` | AWS Secrets Manager | — (boto3 ships with Lemma) |
+| `keyring` | OS keyring (Keychain / Secret Service / Credential Manager) | `pip install 'lemma[secrets]'` |
+
+Remote backends are **read-only sources**: Lemma resolves `${secret:NAME}` from
+them but never writes to them. Create and rotate those secrets with the
+backend's own tooling (`vault kv put`, the AWS console/CLI, your OS keychain).
+The `lemma connector set-secret` / `list-secrets` / `rm-secret` commands manage
+the local store only.
+
+Every backend reads from one configurable location holding a `{name: value}`
+namespace, so `${secret:JIRA_TOKEN}` maps to the `JIRA_TOKEN` entry regardless
+of backend.
+
+### HashiCorp Vault
+
+```bash
+export LEMMA_SECRET_BACKEND=vault
+export VAULT_ADDR='https://vault.example:8200'
+export VAULT_TOKEN='s.xxxxx'                  # or any auth hvac picks up
+export LEMMA_VAULT_MOUNT='secret'             # KV v2 mount (default: secret)
+export LEMMA_VAULT_PATH='lemma/connectors'    # path holding the secret map
+# vault kv put secret/lemma/connectors JIRA_TOKEN=…
+```
+
+`${secret:JIRA_TOKEN}` reads key `JIRA_TOKEN` from the KV v2 secret at
+`LEMMA_VAULT_MOUNT/LEMMA_VAULT_PATH`.
+
+### AWS Secrets Manager
+
+```bash
+export LEMMA_SECRET_BACKEND=aws-secrets-manager
+export AWS_REGION='us-east-1'
+export LEMMA_AWS_SECRET_ID='lemma/connectors' # one secret, JSON {name: value}
+# aws secretsmanager put-secret-value --secret-id lemma/connectors \
+#   --secret-string '{"JIRA_TOKEN":"…"}'
+```
+
+Credentials use boto3's default chain (env vars, profile, instance role).
+`${secret:JIRA_TOKEN}` reads the `JIRA_TOKEN` key from the JSON document in the
+`LEMMA_AWS_SECRET_ID` secret.
+
+### OS keyring
+
+```bash
+export LEMMA_SECRET_BACKEND=keyring
+export LEMMA_KEYRING_SERVICE='lemma-connectors'   # default
+# keyring set lemma-connectors JIRA_TOKEN
+```
+
+`${secret:JIRA_TOKEN}` reads the password stored under service
+`LEMMA_KEYRING_SERVICE`, username `JIRA_TOKEN`, from the platform keyring.
+
+### Per-backend threat model
+
+The backend choice moves *where the credential lives and who can read it*; it
+does not change the fact that Lemma uses the credential only in upstream auth
+headers and never writes it to the evidence log.
+
+| Backend | Trust anchor | What a Lemma-host compromise exposes | Notes |
+|---------|--------------|--------------------------------------|-------|
+| **Local store** | `LEMMA_SECRET_PASSPHRASE` (not on disk) | The passphrase in env/memory ⇒ every stored secret. | Best when there's no central manager; see the [threat model](#threat-model) below. |
+| **Vault** | `VAULT_TOKEN` + Vault policy | Read access to exactly the configured KV path, for the token's TTL. | Scope the token's policy to the one path; short TTLs + Vault's audit log bound and record exposure. Lemma never holds a root token. |
+| **AWS Secrets Manager** | IAM identity of the host | `secretsmanager:GetSecretValue` on the configured secret only, if the role allows it. | Grant `GetSecretValue` on the single `LEMMA_AWS_SECRET_ID` ARN — not `*`. CloudTrail records each read. |
+| **OS keyring** | Local OS user session | Whatever the unlocked keychain grants the user — typically all entries for that user. | Strongest on a single trusted workstation; weakest for shared/headless hosts where the keyring may be unlocked for any process the user runs. |
+
+Because remote backends are read-only to Lemma, a compromised Lemma host can
+read the secrets it's pointed at but cannot delete or overwrite them in the
+backend, and cannot reach secrets outside the configured path/secret/service.
+Scope the backend credential (Vault policy, IAM statement) to exactly the one
+location Lemma needs.
+
 ## Threat model
+
+This section covers the **local encrypted store**; per-backend trade-offs for
+remote backends are in the [table above](#per-backend-threat-model).
 
 What the encrypted store **does** protect against:
 
@@ -69,7 +156,9 @@ What it does **not** protect against (out of scope for this layer):
 
 - An attacker who has **both** `secrets.json` and the passphrase (or the live
   process memory). Protect the passphrase with the same care as any root
-  secret; prefer a real KMS/keyring backend (deferred) for high-value hosts.
+  secret; prefer a [remote backend](#remote-secret-backends) (Vault / AWS
+  Secrets Manager / keyring) for high-value hosts so the credential never lives
+  on the Lemma host at all.
 - A **compromised upstream** that issued the token, or a malicious connector.
 - Passphrase brute-force if the passphrase is weak. Use a long, random
   passphrase; PBKDF2 at 600k iterations raises the cost but is not a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ ingest = [
 cloud = [
     "openai>=1.0",
 ]
+secrets = [
+    # Remote secret backends for connector credentials (#227). The AWS Secrets
+    # Manager backend uses boto3, which is already a core dependency; only the
+    # Vault and OS-keyring backends need these extras.
+    "hvac>=2.0",
+    "keyring>=24.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/src/lemma/commands/connector.py
+++ b/src/lemma/commands/connector.py
@@ -292,17 +292,17 @@ def run_command(
     from lemma.services.connector_config import load_connector_config
     from lemma.services.cron import CronSchedule
     from lemma.services.evidence_log import EvidenceLog
-    from lemma.services.secret_store import SecretStore
+    from lemma.services.secret_backends import resolve_secret_backend
 
     project = Path.cwd()
     if not (project / ".lemma").exists():
         _fail("Not a Lemma project. Run `lemma init` first.")
 
-    secret_store = None
-    if os.environ.get("LEMMA_SECRET_PASSPHRASE"):
-        secret_store = SecretStore(project / ".lemma" / "secrets.json")
-
     try:
+        # Backend selected via LEMMA_SECRET_BACKEND (default: the local store,
+        # used only when LEMMA_SECRET_PASSPHRASE is set so plain ${ENV_VAR}
+        # configs keep working with no passphrase).
+        secret_store = resolve_secret_backend(project_root=project, env=os.environ)
         cfg = load_connector_config(Path(config), secret_store=secret_store)
     except (FileNotFoundError, ValueError) as exc:
         _fail(str(exc))

--- a/src/lemma/commands/evidence.py
+++ b/src/lemma/commands/evidence.py
@@ -822,15 +822,13 @@ def collect_command(
     # file-declared and CLI-declared values).
     if config:
         from lemma.services.connector_config import load_connector_config
-        from lemma.services.secret_store import SecretStore
-
-        # Only hand the loader a secret store when a passphrase is present, so
-        # configs that use plain ${ENV_VAR} keep working with no passphrase.
-        secret_store = None
-        if os.environ.get("LEMMA_SECRET_PASSPHRASE"):
-            secret_store = SecretStore(project_dir / ".lemma" / "secrets.json")
+        from lemma.services.secret_backends import resolve_secret_backend
 
         try:
+            # Backend selected via LEMMA_SECRET_BACKEND (default: the local
+            # store, used only when LEMMA_SECRET_PASSPHRASE is set so plain
+            # ${ENV_VAR} configs keep working with no passphrase).
+            secret_store = resolve_secret_backend(project_root=project_dir, env=os.environ)
             cfg = load_connector_config(Path(config), secret_store=secret_store)
         except (FileNotFoundError, ValueError) as exc:
             console.print(f"[red]Error:[/red] {exc}")

--- a/src/lemma/services/connector_config.py
+++ b/src/lemma/services/connector_config.py
@@ -30,12 +30,14 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
-    from lemma.services.secret_store import SecretStore
+    from lemma.services.secret_backends import SecretBackend
 
 _ENV_VAR_RE = re.compile(r"\$\{([A-Z_][A-Z0-9_]*)\}")
-# ``${secret:NAME}`` pulls from the encrypted SecretStore (#117) rather than
-# the environment. Names are case-insensitive in the regex but resolved as
-# written; resolved before the ${ENV_VAR} pass so the two never clash.
+# ``${secret:NAME}`` pulls from the selected secret backend (#117, #227) —
+# the local encrypted store by default, or Vault / AWS Secrets Manager / OS
+# keyring — rather than the environment. Names are case-insensitive in the
+# regex but resolved as written; resolved before the ${ENV_VAR} pass so the
+# two never clash.
 _SECRET_REF_RE = re.compile(r"\$\{secret:([A-Za-z_][A-Za-z0-9_]*)\}")
 
 
@@ -52,7 +54,7 @@ class ConnectorConfig(BaseModel):
 
 
 def load_connector_config(
-    path: Path, *, secret_store: SecretStore | None = None
+    path: Path, *, secret_store: SecretBackend | None = None
 ) -> ConnectorConfig:
     """Load, validate, and interpolate a connector config file.
 
@@ -91,7 +93,7 @@ def load_connector_config(
         raise ValueError(msg) from exc
 
 
-def _interpolate(value: Any, *, source: str, secret_store: SecretStore | None) -> Any:
+def _interpolate(value: Any, *, source: str, secret_store: SecretBackend | None) -> Any:
     """Walk a parsed YAML structure and replace ``${...}`` refs in strings.
 
     Strict: unset env vars / missing secrets raise ``ValueError`` rather than
@@ -109,7 +111,7 @@ def _interpolate(value: Any, *, source: str, secret_store: SecretStore | None) -
     return value
 
 
-def _interpolate_string(value: str, *, source: str, secret_store: SecretStore | None) -> str:
+def _interpolate_string(value: str, *, source: str, secret_store: SecretBackend | None) -> str:
     def secret_repl(match: re.Match[str]) -> str:
         name = match.group(1)
         if secret_store is None:

--- a/src/lemma/services/secret_backends.py
+++ b/src/lemma/services/secret_backends.py
@@ -182,9 +182,7 @@ class KeyringSecretBackend:
         return cls(service=env.get("LEMMA_KEYRING_SERVICE", _KEYRING_DEFAULT_SERVICE))
 
 
-def resolve_secret_backend(
-    *, project_root: Path, env: Mapping[str, str]
-) -> SecretBackend | None:
+def resolve_secret_backend(*, project_root: Path, env: Mapping[str, str]) -> SecretBackend | None:
     """Pick a secret backend from ``LEMMA_SECRET_BACKEND`` (default ``local``).
 
     Returns ``None`` for the local backend when no ``LEMMA_SECRET_PASSPHRASE``

--- a/src/lemma/services/secret_backends.py
+++ b/src/lemma/services/secret_backends.py
@@ -1,0 +1,218 @@
+"""Pluggable secret backends for connector credentials (Refs #227).
+
+The local encrypted store (``SecretStore``, #117) is the canonical home for
+connector credentials, resolved through ``${secret:NAME}`` references in
+``lemma_connector_config.yaml``. This module slots **remote** backends behind
+that same reference syntax so an operator can source secrets from where their
+org already keeps them:
+
+- ``vault`` — HashiCorp Vault (KV v2).
+- ``aws-secrets-manager`` — AWS Secrets Manager (one JSON secret).
+- ``keyring`` — the OS keyring (Keychain / Secret Service / Credential Manager).
+
+Selection is via ``LEMMA_SECRET_BACKEND`` (default ``local``); the
+``${secret:NAME}`` syntax never changes, so swapping backends is a config/env
+change, not a config-file rewrite.
+
+**Injectable client seam.** Every remote backend takes a ``client=`` (or
+``keyring=``) argument. Tests inject a fake, so CI never touches a live secret
+store. Real clients are built lazily — the third-party library (``hvac`` for
+Vault, ``keyring`` for the OS keyring; ``boto3`` ships with Lemma) is imported
+only when a backend actually resolves a secret with no injected client, so the
+module imports cleanly whether or not the optional extras are installed.
+
+**Read-only by design.** Remote backends only *source* secrets; ``lemma
+connector set-secret`` / ``list-secrets`` / ``rm-secret`` continue to manage
+the local store. Lemma never writes to your Vault / AWS / keyring — secrets in
+those systems are managed there, which keeps the blast radius of a Lemma
+compromise to read-only access to the specific path you point it at.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+# Vault KV v2 read defaults — a single path holds a ``{name: value}`` bag,
+# mirroring the local store's single-envelope model.
+_VAULT_DEFAULT_MOUNT = "secret"
+_VAULT_DEFAULT_PATH = "lemma/connectors"
+# AWS Secrets Manager: one secret whose ``SecretString`` is a JSON ``{name: value}`` map.
+_AWS_DEFAULT_SECRET_ID = "lemma/connectors"
+# OS keyring: secrets stored under one service, keyed by secret name.
+_KEYRING_DEFAULT_SERVICE = "lemma-connectors"
+
+
+@runtime_checkable
+class SecretBackend(Protocol):
+    """A read-only source for ``${secret:NAME}`` resolution.
+
+    The resolution seam in ``connector_config`` needs only ``get``; the local
+    ``SecretStore`` satisfies this protocol (and additionally supports the
+    write CLI), as do all the remote backends here.
+    """
+
+    def get(self, name: str) -> str | None:
+        """Return the secret's value, or ``None`` if it isn't present."""
+        ...
+
+
+class VaultSecretBackend:
+    """Source secrets from a HashiCorp Vault KV v2 path (a ``{name: value}`` bag)."""
+
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        mount_point: str = _VAULT_DEFAULT_MOUNT,
+        path: str = _VAULT_DEFAULT_PATH,
+        url: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self._client = client
+        self._mount_point = mount_point
+        self._path = path
+        self._url = url
+        self._token = token
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            import hvac  # lazy: only when no client is injected
+
+            self._client = hvac.Client(url=self._url, token=self._token)
+        return self._client
+
+    def get(self, name: str) -> str | None:
+        client = self._ensure_client()
+        try:
+            response = client.secrets.kv.v2.read_secret_version(
+                path=self._path, mount_point=self._mount_point
+            )
+        except Exception as exc:  # narrowed to InvalidPath by class name below
+            # ``hvac.exceptions.InvalidPath`` means the whole path is absent;
+            # treat that like a missing secret so resolution gives the clear
+            # "not in store" error rather than a stack trace. Anything else
+            # (auth, network) is a real failure and propagates.
+            if type(exc).__name__ == "InvalidPath":
+                return None
+            raise
+        data = response["data"]["data"]
+        value = data.get(name)
+        return None if value is None else str(value)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> VaultSecretBackend:
+        return cls(
+            url=env.get("VAULT_ADDR"),
+            token=env.get("VAULT_TOKEN"),
+            mount_point=env.get("LEMMA_VAULT_MOUNT", _VAULT_DEFAULT_MOUNT),
+            path=env.get("LEMMA_VAULT_PATH", _VAULT_DEFAULT_PATH),
+        )
+
+
+class AwsSecretsManagerBackend:
+    """Source secrets from one AWS Secrets Manager JSON secret (a ``{name: value}`` map)."""
+
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        secret_id: str = _AWS_DEFAULT_SECRET_ID,
+        region: str | None = None,
+    ) -> None:
+        self._client = client
+        self._secret_id = secret_id
+        self._region = region
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            import boto3  # ships with Lemma
+
+            self._client = boto3.client("secretsmanager", region_name=self._region)
+        return self._client
+
+    def get(self, name: str) -> str | None:
+        client = self._ensure_client()
+        try:
+            response = client.get_secret_value(SecretId=self._secret_id)
+        except client.exceptions.ResourceNotFoundException:
+            # The secret id itself doesn't exist — treat as a missing secret.
+            return None
+        payload = json.loads(response["SecretString"])
+        value = payload.get(name)
+        return None if value is None else str(value)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> AwsSecretsManagerBackend:
+        return cls(
+            secret_id=env.get("LEMMA_AWS_SECRET_ID", _AWS_DEFAULT_SECRET_ID),
+            region=env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION"),
+        )
+
+
+class KeyringSecretBackend:
+    """Source secrets from the OS keyring, one entry per secret name under a service."""
+
+    def __init__(
+        self,
+        *,
+        keyring: Any | None = None,
+        service: str = _KEYRING_DEFAULT_SERVICE,
+    ) -> None:
+        self._keyring = keyring
+        self._service = service
+
+    def _ensure_keyring(self) -> Any:
+        if self._keyring is None:
+            import keyring  # lazy: only when no keyring is injected
+
+            self._keyring = keyring
+        return self._keyring
+
+    def get(self, name: str) -> str | None:
+        keyring = self._ensure_keyring()
+        return keyring.get_password(self._service, name)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str]) -> KeyringSecretBackend:
+        return cls(service=env.get("LEMMA_KEYRING_SERVICE", _KEYRING_DEFAULT_SERVICE))
+
+
+def resolve_secret_backend(
+    *, project_root: Path, env: Mapping[str, str]
+) -> SecretBackend | None:
+    """Pick a secret backend from ``LEMMA_SECRET_BACKEND`` (default ``local``).
+
+    Returns ``None`` for the local backend when no ``LEMMA_SECRET_PASSPHRASE``
+    is set, preserving the existing behaviour where a config that uses only
+    plain ``${ENV_VAR}`` references works with no passphrase. Remote backends
+    are always returned (inert until first ``get``) so a misconfigured remote
+    surfaces at resolution time with a clear error.
+
+    Raises:
+        ValueError: If ``LEMMA_SECRET_BACKEND`` names an unknown backend.
+    """
+    name = (env.get("LEMMA_SECRET_BACKEND") or "local").strip().lower()
+
+    if name in ("", "local"):
+        if not env.get("LEMMA_SECRET_PASSPHRASE"):
+            return None
+        from lemma.services.secret_store import SecretStore
+
+        return SecretStore(Path(project_root) / ".lemma" / "secrets.json")
+    if name == "vault":
+        return VaultSecretBackend.from_env(env)
+    if name in ("aws-secrets-manager", "aws"):
+        return AwsSecretsManagerBackend.from_env(env)
+    if name == "keyring":
+        return KeyringSecretBackend.from_env(env)
+
+    msg = (
+        f"Unknown LEMMA_SECRET_BACKEND '{name}'. Valid values: "
+        "local, vault, aws-secrets-manager, keyring."
+    )
+    raise ValueError(msg)

--- a/tests/commands/test_connector.py
+++ b/tests/commands/test_connector.py
@@ -316,3 +316,40 @@ class TestConnectorRun:
         assert result.exit_code == 0
         assert "disabled" in result.stdout.lower()
         assert calls == []
+
+    def test_run_resolves_secret_via_selected_backend(self, tmp_path: Path, monkeypatch):
+        """`connector run` honors LEMMA_SECRET_BACKEND and resolves
+        ``${secret:NAME}`` from the selected remote backend (#227)."""
+        from lemma.cli import app
+        from lemma.services import secret_backends
+
+        self._init_project(tmp_path, monkeypatch)
+
+        # Inject a fake OS keyring so CI never touches a live store.
+        class _FakeKeyring:
+            def get_password(self, service, name):
+                return "kr-secret" if (service, name) == ("lemma-connectors", "TOK") else None
+
+        monkeypatch.setattr(
+            secret_backends.KeyringSecretBackend,
+            "_ensure_keyring",
+            lambda self: _FakeKeyring(),
+        )
+        monkeypatch.setenv("LEMMA_SECRET_BACKEND", "keyring")
+
+        captured: dict = {}
+
+        def _capture(connector_name, config_dict):
+            captured["config"] = config_dict
+            return self._stub_connector([])
+
+        monkeypatch.setattr(
+            "lemma.commands.evidence._connector_from_config_dict", _capture
+        )
+
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text("connector: stub\nconfig:\n  token: ${secret:TOK}\n")
+
+        result = runner.invoke(app, ["connector", "run", "--config", str(cfg), "--once"])
+        assert result.exit_code == 0, result.stdout
+        assert captured["config"] == {"token": "kr-secret"}

--- a/tests/commands/test_connector.py
+++ b/tests/commands/test_connector.py
@@ -343,9 +343,7 @@ class TestConnectorRun:
             captured["config"] = config_dict
             return self._stub_connector([])
 
-        monkeypatch.setattr(
-            "lemma.commands.evidence._connector_from_config_dict", _capture
-        )
+        monkeypatch.setattr("lemma.commands.evidence._connector_from_config_dict", _capture)
 
         cfg = tmp_path / "c.yaml"
         cfg.write_text("connector: stub\nconfig:\n  token: ${secret:TOK}\n")

--- a/tests/services/test_secret_backends.py
+++ b/tests/services/test_secret_backends.py
@@ -84,9 +84,7 @@ class TestVaultBackend:
         from lemma.services.secret_backends import VaultSecretBackend
 
         client = _FakeHvacClient({"lemma/connectors": {"JIRA_TOKEN": "vault-tok"}})
-        backend = VaultSecretBackend(
-            client=client, mount_point="secret", path="lemma/connectors"
-        )
+        backend = VaultSecretBackend(client=client, mount_point="secret", path="lemma/connectors")
         assert backend.get("JIRA_TOKEN") == "vault-tok"
         # Read from the configured mount + path, not a hard-coded default.
         assert client.secrets.kv.v2.calls == [("secret", "lemma/connectors")]
@@ -115,9 +113,7 @@ class TestAwsSecretsManagerBackend:
     def test_get_returns_value_from_json_secret(self) -> None:
         from lemma.services.secret_backends import AwsSecretsManagerBackend
 
-        client = _FakeSecretsManager(
-            {"lemma/connectors": json.dumps({"JIRA_TOKEN": "aws-tok"})}
-        )
+        client = _FakeSecretsManager({"lemma/connectors": json.dumps({"JIRA_TOKEN": "aws-tok"})})
         backend = AwsSecretsManagerBackend(client=client, secret_id="lemma/connectors")
         assert backend.get("JIRA_TOKEN") == "aws-tok"
         assert client.calls == ["lemma/connectors"]
@@ -181,9 +177,7 @@ class TestProtocol:
         )
 
         assert isinstance(VaultSecretBackend(client=_FakeHvacClient({})), SecretBackend)
-        assert isinstance(
-            AwsSecretsManagerBackend(client=_FakeSecretsManager({})), SecretBackend
-        )
+        assert isinstance(AwsSecretsManagerBackend(client=_FakeSecretsManager({})), SecretBackend)
         assert isinstance(KeyringSecretBackend(keyring=_FakeKeyring({})), SecretBackend)
 
 
@@ -259,9 +253,7 @@ class TestResolveBackend:
         from lemma.services.secret_backends import resolve_secret_backend
 
         with pytest.raises(ValueError, match=r"(?i)LEMMA_SECRET_BACKEND|unknown|nope"):
-            resolve_secret_backend(
-                project_root=tmp_path, env={"LEMMA_SECRET_BACKEND": "nope"}
-            )
+            resolve_secret_backend(project_root=tmp_path, env={"LEMMA_SECRET_BACKEND": "nope"})
 
     def test_selection_is_case_insensitive(self, tmp_path: Path) -> None:
         from lemma.services.secret_backends import VaultSecretBackend, resolve_secret_backend

--- a/tests/services/test_secret_backends.py
+++ b/tests/services/test_secret_backends.py
@@ -1,0 +1,295 @@
+"""Tests for pluggable secret backends (Refs #227).
+
+Backends source connector credentials behind the existing ``${secret:NAME}``
+resolution (#117) so secrets can come from HashiCorp Vault, AWS Secrets
+Manager, or an OS keyring instead of the local encrypted store — selectable
+via ``LEMMA_SECRET_BACKEND`` without changing the reference syntax.
+
+Every backend exposes an injectable client seam so CI never touches a live
+secret store: each test wires a fake client/keyring in and asserts ``get``
+behaviour against it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# --------------------------------------------------------------------------
+# Fakes — stand in for hvac / boto3 / keyring so CI never touches a live store
+# --------------------------------------------------------------------------
+
+
+class _FakeKvV2:
+    def __init__(self, store: dict[str, dict[str, str]]) -> None:
+        self._store = store
+        self.calls: list[tuple[str, str]] = []
+
+    def read_secret_version(self, *, path: str, mount_point: str, **_: object):
+        self.calls.append((mount_point, path))
+        if path not in self._store:
+            raise InvalidPath(f"no secret at {mount_point}/{path}")
+        return {"data": {"data": dict(self._store[path])}}
+
+
+class InvalidPath(Exception):  # noqa: N818 — mirrors hvac.exceptions.InvalidPath exactly
+    """Stand-in for ``hvac.exceptions.InvalidPath`` — same class name, which is
+    what the Vault backend keys on to map a missing path to ``None``."""
+
+
+class _FakeHvacClient:
+    def __init__(self, store: dict[str, dict[str, str]]) -> None:
+        self.secrets = type("S", (), {})()
+        self.secrets.kv = type("KV", (), {})()
+        self.secrets.kv.v2 = _FakeKvV2(store)
+
+
+class _FakeBotoExceptions:
+    class ResourceNotFoundException(Exception):  # noqa: N818 — mirrors boto3's name
+        pass
+
+
+class _FakeSecretsManager:
+    def __init__(self, secret_strings: dict[str, str]) -> None:
+        self._secret_strings = secret_strings
+        self.exceptions = _FakeBotoExceptions()
+        self.calls: list[str] = []
+
+    def get_secret_value(self, *, SecretId: str):  # noqa: N803 — boto3 kwarg name
+        self.calls.append(SecretId)
+        if SecretId not in self._secret_strings:
+            raise self.exceptions.ResourceNotFoundException(f"no secret {SecretId}")
+        return {"SecretString": self._secret_strings[SecretId]}
+
+
+class _FakeKeyring:
+    def __init__(self, store: dict[tuple[str, str], str]) -> None:
+        self._store = store
+        self.calls: list[tuple[str, str]] = []
+
+    def get_password(self, service: str, name: str) -> str | None:
+        self.calls.append((service, name))
+        return self._store.get((service, name))
+
+
+# --------------------------------------------------------------------------
+# Vault backend
+# --------------------------------------------------------------------------
+
+
+class TestVaultBackend:
+    def test_get_returns_value_from_kv_v2_path(self) -> None:
+        from lemma.services.secret_backends import VaultSecretBackend
+
+        client = _FakeHvacClient({"lemma/connectors": {"JIRA_TOKEN": "vault-tok"}})
+        backend = VaultSecretBackend(
+            client=client, mount_point="secret", path="lemma/connectors"
+        )
+        assert backend.get("JIRA_TOKEN") == "vault-tok"
+        # Read from the configured mount + path, not a hard-coded default.
+        assert client.secrets.kv.v2.calls == [("secret", "lemma/connectors")]
+
+    def test_get_missing_name_returns_none(self) -> None:
+        from lemma.services.secret_backends import VaultSecretBackend
+
+        client = _FakeHvacClient({"lemma/connectors": {"OTHER": "x"}})
+        backend = VaultSecretBackend(client=client, path="lemma/connectors")
+        assert backend.get("ABSENT") is None
+
+    def test_get_missing_path_returns_none(self) -> None:
+        from lemma.services.secret_backends import VaultSecretBackend
+
+        client = _FakeHvacClient({})  # the path itself does not exist
+        backend = VaultSecretBackend(client=client, path="lemma/connectors")
+        assert backend.get("ANY") is None
+
+
+# --------------------------------------------------------------------------
+# AWS Secrets Manager backend
+# --------------------------------------------------------------------------
+
+
+class TestAwsSecretsManagerBackend:
+    def test_get_returns_value_from_json_secret(self) -> None:
+        from lemma.services.secret_backends import AwsSecretsManagerBackend
+
+        client = _FakeSecretsManager(
+            {"lemma/connectors": json.dumps({"JIRA_TOKEN": "aws-tok"})}
+        )
+        backend = AwsSecretsManagerBackend(client=client, secret_id="lemma/connectors")
+        assert backend.get("JIRA_TOKEN") == "aws-tok"
+        assert client.calls == ["lemma/connectors"]
+
+    def test_get_missing_name_returns_none(self) -> None:
+        from lemma.services.secret_backends import AwsSecretsManagerBackend
+
+        client = _FakeSecretsManager({"lemma/connectors": json.dumps({"A": "1"})})
+        backend = AwsSecretsManagerBackend(client=client, secret_id="lemma/connectors")
+        assert backend.get("ABSENT") is None
+
+    def test_get_missing_secret_id_returns_none(self) -> None:
+        from lemma.services.secret_backends import AwsSecretsManagerBackend
+
+        client = _FakeSecretsManager({})  # the secret id does not exist
+        backend = AwsSecretsManagerBackend(client=client, secret_id="lemma/connectors")
+        assert backend.get("ANY") is None
+
+
+# --------------------------------------------------------------------------
+# OS keyring backend
+# --------------------------------------------------------------------------
+
+
+class TestKeyringBackend:
+    def test_get_returns_value_from_keyring(self) -> None:
+        from lemma.services.secret_backends import KeyringSecretBackend
+
+        kr = _FakeKeyring({("lemma-connectors", "JIRA_TOKEN"): "kr-tok"})
+        backend = KeyringSecretBackend(keyring=kr, service="lemma-connectors")
+        assert backend.get("JIRA_TOKEN") == "kr-tok"
+        assert kr.calls == [("lemma-connectors", "JIRA_TOKEN")]
+
+    def test_get_missing_name_returns_none(self) -> None:
+        from lemma.services.secret_backends import KeyringSecretBackend
+
+        kr = _FakeKeyring({})
+        backend = KeyringSecretBackend(keyring=kr, service="lemma-connectors")
+        assert backend.get("ABSENT") is None
+
+
+# --------------------------------------------------------------------------
+# Protocol conformance
+# --------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_local_secret_store_satisfies_backend_protocol(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import SecretBackend
+        from lemma.services.secret_store import SecretStore
+
+        store = SecretStore(tmp_path / ".lemma" / "secrets.json", passphrase="p")
+        assert isinstance(store, SecretBackend)
+
+    def test_remote_backends_satisfy_backend_protocol(self) -> None:
+        from lemma.services.secret_backends import (
+            AwsSecretsManagerBackend,
+            KeyringSecretBackend,
+            SecretBackend,
+            VaultSecretBackend,
+        )
+
+        assert isinstance(VaultSecretBackend(client=_FakeHvacClient({})), SecretBackend)
+        assert isinstance(
+            AwsSecretsManagerBackend(client=_FakeSecretsManager({})), SecretBackend
+        )
+        assert isinstance(KeyringSecretBackend(keyring=_FakeKeyring({})), SecretBackend)
+
+
+# --------------------------------------------------------------------------
+# Backend selection (AC1) — selectable via env without changing ${secret:NAME}
+# --------------------------------------------------------------------------
+
+
+class TestResolveBackend:
+    def test_default_local_with_passphrase_returns_secret_store(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import resolve_secret_backend
+        from lemma.services.secret_store import SecretStore
+
+        backend = resolve_secret_backend(
+            project_root=tmp_path, env={"LEMMA_SECRET_PASSPHRASE": "p"}
+        )
+        assert isinstance(backend, SecretStore)
+
+    def test_default_local_without_passphrase_returns_none(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import resolve_secret_backend
+
+        assert resolve_secret_backend(project_root=tmp_path, env={}) is None
+
+    def test_explicit_local_selects_secret_store(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import resolve_secret_backend
+        from lemma.services.secret_store import SecretStore
+
+        backend = resolve_secret_backend(
+            project_root=tmp_path,
+            env={"LEMMA_SECRET_BACKEND": "local", "LEMMA_SECRET_PASSPHRASE": "p"},
+        )
+        assert isinstance(backend, SecretStore)
+
+    def test_vault_selected_via_env(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import VaultSecretBackend, resolve_secret_backend
+
+        backend = resolve_secret_backend(
+            project_root=tmp_path,
+            env={
+                "LEMMA_SECRET_BACKEND": "vault",
+                "VAULT_ADDR": "https://vault.example:8200",
+                "VAULT_TOKEN": "s.xxx",
+                "LEMMA_VAULT_PATH": "team/lemma",
+                "LEMMA_VAULT_MOUNT": "kv",
+            },
+        )
+        assert isinstance(backend, VaultSecretBackend)
+
+    def test_aws_secrets_manager_selected_via_env(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import (
+            AwsSecretsManagerBackend,
+            resolve_secret_backend,
+        )
+
+        backend = resolve_secret_backend(
+            project_root=tmp_path,
+            env={
+                "LEMMA_SECRET_BACKEND": "aws-secrets-manager",
+                "LEMMA_AWS_SECRET_ID": "lemma/connectors",
+            },
+        )
+        assert isinstance(backend, AwsSecretsManagerBackend)
+
+    def test_keyring_selected_via_env(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import KeyringSecretBackend, resolve_secret_backend
+
+        backend = resolve_secret_backend(
+            project_root=tmp_path, env={"LEMMA_SECRET_BACKEND": "keyring"}
+        )
+        assert isinstance(backend, KeyringSecretBackend)
+
+    def test_unknown_backend_raises_clear_error(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import resolve_secret_backend
+
+        with pytest.raises(ValueError, match=r"(?i)LEMMA_SECRET_BACKEND|unknown|nope"):
+            resolve_secret_backend(
+                project_root=tmp_path, env={"LEMMA_SECRET_BACKEND": "nope"}
+            )
+
+    def test_selection_is_case_insensitive(self, tmp_path: Path) -> None:
+        from lemma.services.secret_backends import VaultSecretBackend, resolve_secret_backend
+
+        backend = resolve_secret_backend(
+            project_root=tmp_path, env={"LEMMA_SECRET_BACKEND": "Vault"}
+        )
+        assert isinstance(backend, VaultSecretBackend)
+
+
+# --------------------------------------------------------------------------
+# Integration (AC1) — ${secret:NAME} resolves from a remote backend unchanged
+# --------------------------------------------------------------------------
+
+
+class TestSecretRefResolvesFromRemoteBackend:
+    def test_vault_backend_resolves_secret_reference_in_config(self, tmp_path: Path) -> None:
+        from lemma.services.connector_config import load_connector_config
+        from lemma.services.secret_backends import VaultSecretBackend
+
+        client = _FakeHvacClient({"lemma/connectors": {"JIRA_TOKEN": "from-vault"}})
+        backend = VaultSecretBackend(client=client, path="lemma/connectors")
+
+        cfg_path = tmp_path / "lemma_connector_config.yaml"
+        cfg_path.write_text(
+            "connector: jira\nconfig:\n  token: ${secret:JIRA_TOKEN}\n",
+            encoding="utf-8",
+        )
+
+        cfg = load_connector_config(cfg_path, secret_store=backend)
+        assert cfg.config == {"token": "from-vault"}


### PR DESCRIPTION
## Description

Adds pluggable remote **secret backends** behind the existing `${secret:NAME}`
resolution so connector credentials can be sourced from a central secret
manager instead of (or alongside) the local encrypted store. The backend is
selected via `LEMMA_SECRET_BACKEND` — `local` (default), `vault`,
`aws-secrets-manager`, or `keyring` — and the `lemma_connector_config.yaml`
`${secret:NAME}` references never change, so swapping backends is purely an
environment change.

This is the deferred "Optional: pluggable secret-backend interface" task from
#117 (closed). The local canonical store shipped in #226; the `${secret:NAME}`
syntax was designed so remote backends slot behind it without a config format
change, which this PR realizes.

### What's here

- `src/lemma/services/secret_backends.py`
  - `SecretBackend` protocol (read-only `get`), which the existing `SecretStore`
    already satisfies.
  - `VaultSecretBackend` (Vault KV v2), `AwsSecretsManagerBackend` (one JSON
    secret), `KeyringSecretBackend` (OS keyring) — each exposing the same
    `{name: value}` namespace as the local store.
  - `resolve_secret_backend(...)` factory keyed on `LEMMA_SECRET_BACKEND`,
    case-insensitive, with a clear error on an unknown value.
- Wired the factory into `connector run` and `evidence collect --config`,
  replacing the inline `SecretStore` construction. The local default still
  returns `None` without `LEMMA_SECRET_PASSPHRASE`, so plain `${ENV_VAR}`
  configs keep working with no passphrase.
- `[secrets]` optional-dependency extra (`hvac`, `keyring`); boto3 is already
  core, so the AWS backend needs no extra.
- Docs: a backend-selection guide plus a per-backend threat model in
  `docs/security/connector-secrets.md`.

### Design notes worth flagging

- **Injectable client seam (AC):** every remote backend takes a
  `client=`/`keyring=` argument and builds its real client lazily, so the
  module imports cleanly without `hvac`/`keyring` installed and the tests inject
  fakes — CI never touches a live secret store.
- **Read-only by design:** remote backends only *source* secrets. `set-secret`
  / `list-secrets` / `rm-secret` continue to manage the local store only, which
  keeps a Lemma-host compromise to read-only access to the single configured
  Vault path / AWS secret / keyring service. This is documented in the
  per-backend threat-model table.

### Out of scope / heads-up (not introduced here)

`tests/commands/test_evidence.py::test_collect_runs_aws_connector...` and
`...okta_connector...` fail on `main` independent of this branch (verified by
stashing): the AWS/Okta connectors were expanded to more services in #229 but
those two test mocks weren't updated, so they `KeyError` on a service the mock
doesn't provide. Untouched by this PR; called out so it isn't mistaken for a
regression. Tracked in #235.

Fixes #227

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run the linter (`ruff check`) with no errors on changed files
- [x] I have run `ruff format`
- [x] I have run the test suite — new tests pass; the only failures are the two
      pre-existing `test_evidence.py` AWS/Okta cases described above (#235)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors