### PR TITLE
chore(security): harden workflows for OpenSSF Scorecard (#140)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
       - "type: chore"
       - "scope: dependencies"
 
+  # Maintain Python dependencies (managed with uv; reads pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "type: chore"
+      - "scope: dependencies"
+
   # Maintain dependencies for npm (Phase 1 platform core/UI)
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,17 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Least privilege: every job here only reads the checkout (OpenSSF
+# Token-Permissions). Elevate per-job if a future job needs write access.
+permissions:
+  contents: read
+
 jobs:
   validate-governance:
     name: Validate Governance Artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       
       - name: Check required files
         run: |
@@ -26,10 +31,10 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12
@@ -47,10 +52,10 @@ jobs:
     name: CLI Documentation Drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12
@@ -65,10 +70,10 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12
@@ -83,10 +88,10 @@ jobs:
     name: Agent Build (Go)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.23'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,17 +8,22 @@ on:
       - 'README.md'
       - '.github/workflows/docs.yml'
 
+# Read-only by default; the deploy job elevates to contents: write for
+# `mkdocs gh-deploy` (OpenSSF Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     name: Build and Deploy Documentation
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write  # push to the gh-pages branch
     steps:
-      - uses: actions/checkout@v6.0.3
-      
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,24 @@ on:
     tags:
       - 'v*'
 
+# Read-only by default; the release job elevates to contents: write to create
+# the GitHub Release and upload assets (OpenSSF Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   build-and-release:
     name: Build and Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
+      contents: write  # create the release + upload assets
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12
@@ -50,7 +54,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           generate_release_notes: true
           append_body: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,15 +8,20 @@ on:
   schedule:
     - cron: '0 0 * * 1' # Run weekly on Mondays
 
+# All jobs only read the checkout and report to external services via secrets
+# (OpenSSF Token-Permissions).
+permissions:
+  contents: read
+
 jobs:
   snyk-scan:
     name: Snyk SCA & Code Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12
@@ -25,7 +30,7 @@ jobs:
         run: uv venv && uv pip install -e ".[dev]"
 
       - name: Run Snyk SCA (Open Source)
-        uses: snyk/actions/python-3.10@master
+        uses: snyk/actions/python-3.10@8e119fbb6c251787721d34ba683ed48eba792766 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -33,7 +38,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Snyk Code (SAST)
-        uses: snyk/actions/python-3.10@master
+        uses: snyk/actions/python-3.10@8e119fbb6c251787721d34ba683ed48eba792766 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
@@ -44,10 +49,10 @@ jobs:
     name: License Compliance Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12
@@ -65,10 +70,10 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Setup Python
         run: uv python install 3.12

--- a/docs/security/openssf-best-practices.md
+++ b/docs/security/openssf-best-practices.md
@@ -1,0 +1,100 @@
+# OpenSSF Best Practices
+
+Lemma tracks two distinct OpenSSF programs:
+
+- **[Scorecard](https://securityscorecards.dev/)** — an automated scan of repo
+  configuration (pinned dependencies, token permissions, branch protection,
+  …). Run by `.github/workflows/scorecard.yml`; the ≥ 7/10 target lives in #47.
+- **[Best Practices](https://www.bestpractices.dev/)** — a *self-attested*
+  questionnaire across three tiers (passing → silver → gold).
+
+This page is the reproducible record of the **passing-tier** answers, so the
+questionnaire can be refiled if the project ID is ever lost or migrated. It is
+not the badge itself — the live badge is earned by submitting these answers at
+[bestpractices.dev](https://www.bestpractices.dev/projects/new).
+
+> **Project ID:** _not yet registered_. After registering, record the ID here
+> and add the badge to `README.md` sourced from
+> `https://www.bestpractices.dev/projects/<id>/badge` (never a static
+> shields.io placeholder — see #178 for why).
+
+## Scorecard configuration (this repo)
+
+The configuration-level Scorecard checks are enforced in code and guarded by a
+regression test (`tests/tools/test_workflow_security.py`):
+
+| Check | Status | Where |
+|-------|--------|-------|
+| Pinned-Dependencies | Met | every action in `.github/workflows/*.yml` is pinned to a full commit SHA |
+| Token-Permissions | Met | every workflow declares an explicit `permissions:` block; jobs elevate only where needed |
+| Dependency-Update-Tool | Met | `.github/dependabot.yml` monitors `uv` (Python), `github-actions`, and `npm` |
+| Dangerous-Workflow | Met | no `pull_request_target` / untrusted-checkout patterns |
+| SAST | Met | Snyk Code runs on every PR (`security.yml`) |
+| Vulnerabilities | Met | Snyk SCA runs on every PR (`security.yml`) |
+| License | Met | `LICENSE` (Apache-2.0) |
+| Branch-Protection | **Repo setting** | enable on `main` in Settings → Branches (see below) |
+| Signed-Releases | Open | sigstore/cosign provenance tracked in #47 |
+| Code-Review | Partial | structurally limited on a solo-maintainer repo; mitigated by mandatory PR + self-review |
+
+### Repo settings that aren't a code change
+
+These are configured in the GitHub UI / API, not a PR:
+
+- **Branch protection on `main`** — require a PR before merge, require status
+  checks (CI, Security Scans, Scorecard), and require linear history. Verify:
+  `gh api repos/JoshDoesIT/Lemma/branches/main/protection`.
+- **Dependabot security updates** — enable in Settings → Code security.
+
+## Best Practices passing-tier questionnaire
+
+Status of each criterion group; **Met** items cite the satisfying artifact,
+**Open** items link the tracking issue.
+
+### Basics
+- **Project description / homepage** — Met (`README.md`).
+- **Contribution process documented** — Met (`CONTRIBUTING.md`).
+- **OSS license (OSI-approved, FLOSS)** — Met (`LICENSE`, Apache-2.0).
+- **License location** — Met (`LICENSE` at repo root).
+- **Documentation (basics + interface)** — Met (`docs/` site, MkDocs Material).
+- **Code of conduct** — Met (`CODE_OF_CONDUCT.md`).
+
+### Change control
+- **Public version-controlled source** — Met (GitHub; full history).
+- **Unique version numbering** — Met (semver; `pyproject.toml` / Git tags).
+- **Release notes** — Met (`release.yml` generates GitHub Release notes per tag).
+
+### Reporting
+- **Bug-reporting process** — Met (GitHub Issues; templates under `.github/`).
+- **Vulnerability-reporting process** — Met (`SECURITY.md`).
+- **Vulnerability report response** — Met (`SECURITY.md` states the SLA).
+
+### Quality
+- **Working build system** — Met (`pyproject.toml`; `uv` / `hatch`).
+- **Automated test suite** — Met (`pytest`, run in `ci.yml`).
+- **Tests added for new functionality (policy)** — Met (TDD; see
+  `docs/contributing/testing-standards.md`).
+- **Warning flags / linters** — Met (`ruff check` + `ruff format --check` in CI).
+
+### Security
+- **Secure development knowledge** — Met (this page + `docs/security/`).
+- **Good cryptographic practice** — Met (Ed25519 signing, Fernet/PBKDF2 for the
+  secret store; no home-rolled primitives).
+- **Secured delivery against MITM** — Met (HTTPS/TLS; mTLS for agent forward).
+- **Publicly known vulnerabilities fixed** — Met (Snyk SCA + Dependabot).
+- **No leaked credentials** — Met (secrets never committed; `${secret:NAME}`
+  resolution + encrypted store, see `security/connector-secrets.md`).
+
+### Analysis
+- **Static analysis** — Met (Snyk Code; `ruff`).
+- **Dynamic analysis** — Partial (test suite exercises runtime paths; dedicated
+  fuzzing is a silver-tier stretch).
+
+## Open items before the badge is fully green
+
+- Register the project and record the ID above.
+- Enable branch protection + Dependabot security updates (repo settings).
+- Signed releases / SLSA provenance — #47.
+
+Silver and gold tiers (formal patch review by a second maintainer, multiple
+unaffiliated maintainers) are structurally hard on a solo-maintainer project
+and are deferred to Phase 4 community work.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - Security:
     - Evidence Integrity & Transport: security/evidence-and-transport.md
     - Connector Credentials: security/connector-secrets.md
+    - OpenSSF Best Practices: security/openssf-best-practices.md
   - Contributing:
     - Developer Guide: contributing/index.md
     - Testing Standards: contributing/testing-standards.md

--- a/tests/tools/test_workflow_security.py
+++ b/tests/tools/test_workflow_security.py
@@ -1,0 +1,59 @@
+"""Guard tests for GitHub Actions workflow hardening (Refs #140).
+
+These encode two OpenSSF Scorecard checks so a future workflow edit can't
+silently regress them:
+
+- **Pinned-Dependencies**: every third-party action is pinned to a full commit
+  SHA, not a floating tag (``@v4``) or branch (``@master``).
+- **Token-Permissions**: every workflow declares an explicit ``permissions``
+  block (top-level, or on every job), instead of inheriting broad repo
+  defaults.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_WORKFLOW_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(\S+)", re.MULTILINE)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _workflow_files() -> list[Path]:
+    files = sorted(_WORKFLOW_DIR.glob("*.yml")) + sorted(_WORKFLOW_DIR.glob("*.yaml"))
+    assert files, f"no workflow files found under {_WORKFLOW_DIR}"
+    return files
+
+
+@pytest.mark.parametrize("workflow", _workflow_files(), ids=lambda p: p.name)
+def test_external_actions_are_sha_pinned(workflow: Path) -> None:
+    text = workflow.read_text(encoding="utf-8")
+    unpinned: list[str] = []
+    for ref in _USES_RE.findall(text):
+        if ref.startswith("./"):
+            continue  # local action — no version to pin
+        _, _, version = ref.partition("@")
+        if not _SHA_RE.match(version):
+            unpinned.append(ref)
+    assert not unpinned, (
+        f"{workflow.name}: these actions must be pinned to a full commit SHA "
+        f"(OpenSSF Pinned-Dependencies): {unpinned}"
+    )
+
+
+@pytest.mark.parametrize("workflow", _workflow_files(), ids=lambda p: p.name)
+def test_workflow_declares_explicit_permissions(workflow: Path) -> None:
+    doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    if "permissions" in doc:
+        return  # explicit top-level permissions
+    jobs = doc.get("jobs", {})
+    missing = [name for name, job in jobs.items() if "permissions" not in job]
+    assert not missing, (
+        f"{workflow.name}: declare an explicit `permissions:` block at the "
+        f"workflow level or on every job (OpenSSF Token-Permissions). "
+        f"Jobs missing it: {missing}"
+    )


### PR DESCRIPTION
## Description

Implements the **"Easy wins (~1 PR)"** section of #140 — the configuration-level OpenSSF Scorecard checks that don't need repo-admin access — plus a regression guard and the reproducible Best Practices questionnaire. The Scorecard *workflow* itself was already pinned in #139; this brings the older workflows in line.

### Changes

- **Pinned-Dependencies:** every third-party action in `ci.yml`, `docs.yml`, `release.yml`, and `security.yml` is now pinned to a full commit SHA (was floating `@v*` tags; `snyk/actions` was `@master`). Each pin keeps a trailing version comment so Dependabot can still bump it. Every SHA was verified to resolve to the named tag.
- **Token-Permissions:** every workflow declares an explicit `permissions:` block — top-level `contents: read`, with narrow per-job elevation only where required (`docs` keeps `contents: write` for `gh-deploy`; the release job keeps `contents: write` and drops the unused `packages: write`).
- **Dependency-Update-Tool:** added the `uv` ecosystem to `.github/dependabot.yml` so Python deps (`pyproject.toml` + `uv.lock`) are monitored alongside `github-actions` and `npm`. (The repo's Dependabot history already uses `uv`; the committed config was missing the entry.)
- **Dangerous-Workflow:** audited — no `pull_request_target` / untrusted-checkout patterns present.

### Regression guard (TDD)

`tests/tools/test_workflow_security.py` asserts every external `uses:` is SHA-pinned and every workflow declares explicit permissions, so a future edit can't silently regress these checks. Written failing first against the floating-tag workflows, then made green.

### Docs

`docs/security/openssf-best-practices.md` captures the reproducible passing-tier questionnaire (so it can be refiled if the project ID is lost) and records the Scorecard configuration status.

### Out of scope — handed off (the issue scopes these as "repo Settings UI, not a code PR")

These #140 ACs require repo-admin or an external account and can't land in a PR — they're documented in the new doc with exact steps:

- Enable branch protection on `main` (required PR + status checks + linear history) — `gh api repos/JoshDoesIT/Lemma/branches/main/protection` to verify.
- Enable Dependabot security updates in Settings.
- Register the project at bestpractices.dev, capture the project ID, and add the real badge to `README.md`.
- Signed releases / SLSA provenance — already tracked in #47.

Because those remain, this is `Refs #140` (not `Fixes`); the issue stays open with the code items checked off and the admin items called out.

### Note on CI

This branch is cut from current `main`, which still carries the two pre-existing `test_evidence.py` AWS/Okta failures (#235, fixed in the not-yet-merged #237). They're unrelated to this PR; the 10 new workflow-guard tests pass and nothing else regressed.

Refs #140

## Type of Change

- [x] Chore / Maintenance (tooling, dependencies, CI hardening)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run the linter (`ruff check`) and formatter check with no errors
- [x] I have run the test suite — the 10 new guard tests pass; the only failures are the pre-existing #235 cases (fixed in #237)
- [x] I have performed a self-review of my code
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings or errors