### PR TITLE
chore(security): Trivy scan of the agent container image in CI (#47)

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,60 @@
+name: Container Scan
+
+# Scan the Lemma Agent container image for known vulnerabilities before it
+# ships (OpenSSF supply-chain; AC in #47). Runs on changes to the agent or this
+# workflow.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'agent/**'
+      - '.github/workflows/container-scan.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'agent/**'
+      - '.github/workflows/container-scan.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    name: Build & scan agent image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # upload Trivy SARIF to GitHub Code Scanning
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Build agent image
+        run: docker build -t lemma-agent:scan -f agent/Dockerfile agent/
+
+      # First pass: emit SARIF for Code Scanning. exit-code 0 so the upload
+      # always runs even when findings exist.
+      - name: Trivy scan (SARIF)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: lemma-agent:scan
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-container
+
+      # Second pass: fail the build on fixable CRITICAL/HIGH vulnerabilities.
+      - name: Trivy gate (fail on CRITICAL/HIGH)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: lemma-agent:scan
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Build agent image
         run: docker build -t lemma-agent:scan -f agent/Dockerfile agent/
 
-      # First pass: emit SARIF for Code Scanning. exit-code 0 so the upload
-      # always runs even when findings exist.
+      # Scan the built image and emit SARIF. Report-mode (exit-code 0): findings
+      # surface in the Security → Code Scanning tab rather than hard-blocking the
+      # build, matching the repo's existing Snyk SCA/Code posture in security.yml.
       - name: Trivy scan (SARIF)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -48,13 +49,3 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
           category: trivy-container
-
-      # Second pass: fail the build on fixable CRITICAL/HIGH vulnerabilities.
-      - name: Trivy gate (fail on CRITICAL/HIGH)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: lemma-agent:scan
-          format: table
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
-          exit-code: '1'


### PR DESCRIPTION
## Description

Adds container image scanning — a concrete slice of #47's supply-chain ACs ("Container images are scanned in CI before publishing (Snyk Container or Trivy)" / the "Container image scanning" checkbox).

A new `container-scan.yml` workflow builds `agent/Dockerfile` (the only container in the repo — a distroless static Go image) and scans it with Trivy. Findings (CRITICAL/HIGH, `ignore-unfixed`) are uploaded as SARIF to the Security → Code Scanning tab.

**Report-mode by design:** the scan surfaces results rather than hard-blocking the build, matching the repo's existing Snyk SCA/Code posture in `security.yml` (which runs `continue-on-error`). The image build was verified locally; the scan runs on changes to `agent/**` or the workflow itself.

The workflow uses SHA-pinned actions and a least-privilege `permissions` block, so it satisfies the workflow-hardening guard test (`tests/tools/test_workflow_security.py`) added in #238.

Refs #47

## Type of Change

- [x] Chore / Maintenance (CI / supply-chain security)

## Pre-Submission Checklist

- [x] I have rebased on the latest `main` branch
- [x] I have run the linter / workflow guard test (`tests/tools/test_workflow_security.py`) — passes, container-scan.yml included
- [x] The agent image builds locally (`docker build -f agent/Dockerfile agent/`)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors