### PR TITLE
feat(ci): sign releases with cosign + SLSA build provenance (#47)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
     name: Build and Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # create the release + upload assets
+      contents: write      # create the release + upload assets
+      id-token: write      # keyless cosign signing + SLSA provenance (OIDC)
+      attestations: write  # SLSA build-provenance attestations
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -47,6 +49,23 @@ jobs:
       - name: Generate AI BOM (CycloneDX 1.6)
         run: uv run lemma ai bom > aibom.cdx.json
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign release artifacts (keyless cosign)
+        run: |
+          # Keyless: signing identity is this workflow's OIDC token (no private
+          # key). Each artifact gets a Sigstore bundle verifiable with
+          # `cosign verify-blob --bundle <f>.cosign.bundle ...`.
+          for f in dist/* sbom.json aibom.cdx.json ai-system-card.json; do
+            cosign sign-blob --yes --bundle "${f}.cosign.bundle" "$f"
+          done
+
+      - name: Attest SLSA build provenance (Python artifacts)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*
+
       - name: Capture AI System Card version
         id: card_version
         run: |
@@ -66,8 +85,11 @@ jobs:
           files: |
             dist/*
             sbom.json
+            sbom.json.cosign.bundle
             aibom.cdx.json
+            aibom.cdx.json.cosign.bundle
             ai-system-card.json
+            ai-system-card.json.cosign.bundle
             ai-system-card.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/security/openssf-best-practices.md
+++ b/docs/security/openssf-best-practices.md
@@ -33,7 +33,7 @@ regression test (`tests/tools/test_workflow_security.py`):
 | Vulnerabilities | Met | Snyk SCA runs on every PR (`security.yml`) |
 | License | Met | `LICENSE` (Apache-2.0) |
 | Branch-Protection | **Repo setting** | enable on `main` in Settings → Branches (see below) |
-| Signed-Releases | Open | sigstore/cosign provenance tracked in #47 |
+| Signed-Releases | Met | keyless cosign signatures + SLSA build provenance on every release ([Verifying Releases](verifying-releases.md)) |
 | Code-Review | Partial | structurally limited on a solo-maintainer repo; mitigated by mandatory PR + self-review |
 
 ### Repo settings that aren't a code change
@@ -93,7 +93,8 @@ Status of each criterion group; **Met** items cite the satisfying artifact,
 
 - Register the project and record the ID above.
 - Enable branch protection + Dependabot security updates (repo settings).
-- Signed releases / SLSA provenance — #47.
+- ~~Signed releases / SLSA provenance~~ — done (#47): keyless cosign + SLSA
+  build provenance, see [Verifying Releases](verifying-releases.md).
 
 Silver and gold tiers (formal patch review by a second maintainer, multiple
 unaffiliated maintainers) are structurally hard on a solo-maintainer project

--- a/docs/security/verifying-releases.md
+++ b/docs/security/verifying-releases.md
@@ -1,0 +1,54 @@
+# Verifying Releases
+
+Every Lemma release is **signed** and carries **build provenance** so you can
+prove an artifact came from this repository's release workflow and wasn't
+tampered with in transit (Refs #47).
+
+## What ships with a release
+
+For each tagged release (`v*`), the workflow publishes:
+
+- the Python distributions (`dist/*.whl`, `dist/*.tar.gz`),
+- the SBOM (`sbom.json`) and AI BOM (`aibom.cdx.json`),
+- the AI System Card (`ai-system-card.json` / `.md`),
+- a **cosign signature bundle** (`*.cosign.bundle`) next to each signed artifact,
+- a **SLSA build-provenance attestation** for the Python distributions.
+
+Signing is **keyless** (sigstore): the signing identity is the release
+workflow's GitHub OIDC token — there is no long-lived private key to leak.
+
+## Verify a signature (cosign)
+
+Download an artifact and its `.cosign.bundle`, then:
+
+```bash
+cosign verify-blob \
+  --bundle lemma-<version>-py3-none-any.whl.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/JoshDoesIT/Lemma/\.github/workflows/release\.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  lemma-<version>-py3-none-any.whl
+```
+
+A `Verified OK` means the artifact was signed by this repo's release workflow
+on a tag. The same command works for `sbom.json`, `aibom.cdx.json`, and
+`ai-system-card.json` against their respective bundles.
+
+## Verify build provenance (SLSA)
+
+The Python distributions carry a SLSA build-provenance attestation (generated
+by `actions/attest-build-provenance`). Verify it with the GitHub CLI:
+
+```bash
+gh attestation verify lemma-<version>-py3-none-any.whl --repo JoshDoesIT/Lemma
+```
+
+This confirms the artifact was built by this repository's workflow and reports
+the source commit and build parameters recorded in the attestation.
+
+## Threat model
+
+Signing + provenance protect against a tampered or spoofed artifact: a file
+that wasn't produced by this repo's release workflow fails verification. They
+do **not** vouch for the *correctness* of the code that was released — only its
+origin and integrity. Always pin to a released version and verify before
+deploying in a regulated environment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - Security:
     - Evidence Integrity & Transport: security/evidence-and-transport.md
     - Connector Credentials: security/connector-secrets.md
+    - Verifying Releases: security/verifying-releases.md
     - OpenSSF Best Practices: security/openssf-best-practices.md
   - Contributing:
     - Developer Guide: contributing/index.md

--- a/tests/tools/test_release_signing.py
+++ b/tests/tools/test_release_signing.py
@@ -1,0 +1,50 @@
+"""Guard tests for signed releases + SLSA provenance (Refs #47).
+
+Encodes the supply-chain release ACs so a future edit to the release workflow
+can't silently drop them:
+
+- Release artifacts are signed with sigstore/cosign (keyless).
+- SLSA build provenance is attested for the built artifacts.
+- The release job holds the OIDC/attestation permissions both require.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_RELEASE = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+
+
+def _release_text() -> str:
+    return _RELEASE.read_text(encoding="utf-8")
+
+
+def _release_job() -> dict:
+    doc = yaml.safe_load(_release_text())
+    return doc["jobs"]["build-and-release"]
+
+
+def test_release_job_has_oidc_and_attestation_permissions() -> None:
+    perms = _release_job().get("permissions", {})
+    assert perms.get("id-token") == "write", "keyless cosign + provenance need id-token: write"
+    assert perms.get("attestations") == "write", "attest-build-provenance needs attestations: write"
+    # Still able to publish the release itself.
+    assert perms.get("contents") == "write"
+
+
+def test_release_signs_artifacts_with_cosign() -> None:
+    text = _release_text()
+    assert "sigstore/cosign-installer@" in text, "cosign must be installed"
+    assert "cosign sign-blob" in text, "release artifacts must be signed with cosign sign-blob"
+
+
+def test_release_generates_slsa_provenance() -> None:
+    text = _release_text()
+    assert "actions/attest-build-provenance@" in text, "SLSA build provenance must be attested"
+
+
+def test_signature_bundles_are_uploaded_with_the_release() -> None:
+    """The cosign bundles must ship as release assets so consumers can verify."""
+    assert "cosign.bundle" in _release_text()


### PR DESCRIPTION
## Description

Implements the **signed releases** supply-chain slice of #47 — the natural follow-on to container scanning (#246). On every `v*` tag, the release workflow now:

- **Signs every published artifact** with sigstore **cosign (keyless)** — Python dists, `sbom.json`, `aibom.cdx.json`, and the AI System Card — producing a Sigstore bundle (`<artifact>.cosign.bundle`) uploaded alongside the release. Verifiable with `cosign verify-blob --bundle …`.
- **Attests SLSA build provenance** for the Python distributions via `actions/attest-build-provenance`. Verifiable with `gh attestation verify <artifact> --repo JoshDoesIT/Lemma`.

Signing is **keyless**: the identity is the workflow's GitHub OIDC token, so there's no long-lived private key to manage or leak. The release job gains `id-token: write` + `attestations: write`; both new actions are SHA-pinned (passes the #238 workflow-guard test).

### Verification (and TDD)

- `tests/tools/test_release_signing.py` — regression guard asserting the workflow keeps the cosign signing step, the SLSA provenance step, and the OIDC/attestation permissions. Written failing first, then made green.
- All workflow-guard tests pass (14, now covering `release.yml`'s new pinned actions); both new action SHAs verified against their upstream tags.

### Docs

New `docs/security/verifying-releases.md` with the exact `cosign verify-blob` / `gh attestation verify` commands and the threat model; the OpenSSF Scorecard "Signed-Releases" row flips to **met**.

### Scope note

This is `Refs #47` (not `Fixes`) — #47 is a supply-chain umbrella whose remaining items are non-code/external (external security audit before Enterprise GA; a responsible-disclosure program e.g. HackerOne). Container scanning (#246) and now signed releases + SLSA provenance are the code-deliverable pieces.

The signing executes on the next tagged release (keyless OIDC only works in GitHub Actions); the workflow logic, permissions, and pins are validated here and by the guard test.

## Type of Change

- [x] New feature (CI / supply-chain security)
- [x] Documentation update

## Pre-Submission Checklist

- [x] Rebased on the latest `main`
- [x] `ruff check` / `ruff format --check` clean; workflow YAML valid
- [x] `pytest tests/tools/` passes (28); new guard test included
- [x] Both new actions SHA-pinned and verified against upstream tags
- [x] Docs updated