### PR TITLE
feat(connectors): first-party PagerDuty connector

### DIFF
--- a/docs/guides/connector-cookbook.md
+++ b/docs/guides/connector-cookbook.md
@@ -2,7 +2,7 @@
 
 Recipes for authors building production connectors, distilled from Lemma's
 first-party connectors (GitHub, Okta, AWS, Jira, ServiceNow, Azure DevOps,
-Azure). If you haven't written a connector yet, start with
+Azure, PagerDuty). If you haven't written a connector yet, start with
 [Build Your First Connector](build-your-first-connector.md); this page is the
 reference you reach for once you're integrating a real upstream API.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -476,7 +476,7 @@ List the available first-party connectors and their required configuration — t
 lemma connector registry
 ```
 
-Prints a table of each first-party connector (`github`, `okta`, `aws`, `jira`, `servicenow`, `azure-devops`, `azure`, `gcp`) with its producer, config keys, the environment variable holding its credential (if any), and a one-line description — so operators can discover what's available without reading code. A drift-guard test keeps this catalog in sync with the connector factory. Run a listed connector via [`lemma evidence collect`](#lemma-evidence-collect) or a `lemma_connector_config.yaml`.
+Prints a table of each first-party connector (`github`, `okta`, `aws`, `jira`, `servicenow`, `azure-devops`, `azure`, `gcp`, `pagerduty`) with its producer, config keys, the environment variable holding its credential (if any), and a one-line description — so operators can discover what's available without reading code. A drift-guard test keeps this catalog in sync with the connector factory. Run a listed connector via [`lemma evidence collect`](#lemma-evidence-collect) or a `lemma_connector_config.yaml`.
 
 ### `lemma connector validate`
 

--- a/src/lemma/commands/evidence.py
+++ b/src/lemma/commands/evidence.py
@@ -635,6 +635,7 @@ def _first_party_connector(
     subscription_id: str | None = None,
     project_id: str | None = None,
     access_token: str | None = None,
+    subdomain: str | None = None,
 ) -> Connector:
     """Instantiate a first-party connector by short name.
 
@@ -743,7 +744,25 @@ def _first_party_connector(
             kwargs5["access_token"] = access_token
         return GCPConnector(**kwargs5)
 
-    known = ["github", "okta", "aws", "jira", "servicenow", "azure-devops", "azure", "gcp"]
+    if name == "pagerduty":
+        from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+        kwargs6: dict = {}
+        if subdomain:
+            kwargs6["subdomain"] = subdomain
+        return PagerDutyConnector(**kwargs6)
+
+    known = [
+        "github",
+        "okta",
+        "aws",
+        "jira",
+        "servicenow",
+        "azure-devops",
+        "azure",
+        "gcp",
+        "pagerduty",
+    ]
     msg = f"Unknown connector '{name}'. Known first-party connectors: {', '.join(known)}."
     raise ValueError(msg)
 
@@ -776,6 +795,7 @@ def _connector_from_config_dict(name: str, config: dict) -> Connector:
         subscription_id=config.get("subscription_id"),
         project_id=config.get("project_id"),
         access_token=config.get("access_token"),
+        subdomain=config.get("subdomain"),
     )
 
 

--- a/src/lemma/sdk/connectors/pagerduty.py
+++ b/src/lemma/sdk/connectors/pagerduty.py
@@ -1,0 +1,152 @@
+"""First-party PagerDuty connector (Refs #41).
+
+Pulls incident-response posture from PagerDuty and emits one
+``ComplianceFinding`` aggregating escalation-policy and active on-call
+coverage — the auditable signal a SOC 2 CC7.x (incident response) review
+wants: there is a defined escalation path and someone is actually on call.
+
+Auth: PagerDuty's REST API uses ``Authorization: Token token=<API_TOKEN>``.
+The token is required (set ``LEMMA_PAGERDUTY_TOKEN`` in the environment or pass
+``token=...`` to the constructor); a missing token is a loud error at
+construction time, not a cryptic 401 later.
+
+``subdomain`` is a label used only to make ``metadata.uid`` stable per
+``(subdomain, UTC date)`` so same-day re-runs dedupe against themselves; the
+REST host is the shared ``api.pagerduty.com`` for every account.
+
+Tests inject a custom ``httpx.Client`` with a ``MockTransport`` so CI never
+touches a real PagerDuty account.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+import httpx
+
+from lemma.models.connector_manifest import ConnectorManifest
+from lemma.models.ocsf import ComplianceFinding, OcsfBaseEvent
+from lemma.sdk.connector import Connector
+
+_PRODUCER = "PagerDuty"
+_BASE_URL = "https://api.pagerduty.com"
+
+
+def _today_utc_iso_date() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+def _metadata(subdomain: str, uid: str) -> dict:
+    return {
+        "version": "1.3.0",
+        "product": {"name": _PRODUCER, "vendor_name": "PagerDuty", "uid": uid},
+        "subdomain": subdomain,
+        "uid": uid,
+    }
+
+
+def _count(payload: object, key: str) -> int:
+    """Length of ``payload[key]`` when it's a list, else 0."""
+    if isinstance(payload, dict):
+        items = payload.get(key)
+        if isinstance(items, list):
+            return len(items)
+    return 0
+
+
+class PagerDutyConnector(Connector):
+    """Collect incident-response posture from a PagerDuty account."""
+
+    def __init__(
+        self,
+        *,
+        subdomain: str = "pagerduty",
+        token: str | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._token = token or os.environ.get("LEMMA_PAGERDUTY_TOKEN") or None
+        if not self._token:
+            msg = (
+                "PagerDutyConnector requires an API token. "
+                "Set LEMMA_PAGERDUTY_TOKEN in the environment or pass token=... "
+                "to the constructor."
+            )
+            raise ValueError(msg)
+
+        self._subdomain = subdomain
+        self._client = client or httpx.Client(base_url=_BASE_URL)
+
+        self.manifest = ConnectorManifest(
+            name="pagerduty",
+            version="0.1.0",
+            producer=_PRODUCER,
+            description=(
+                "PagerDuty incident-response posture (SOC 2 CC7.x): escalation "
+                "policies defined and active on-call coverage."
+            ),
+            capabilities=["incident-response"],
+        )
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Token token={self._token}",
+        }
+
+    def _get(self, path: str, params: dict[str, str] | None = None) -> httpx.Response:
+        response = self._client.get(path, headers=self._headers(), params=params)
+        if response.status_code == 429:
+            msg = (
+                f"PagerDuty API rate-limit exceeded while fetching {path}. "
+                "Retry after the quota resets."
+            )
+            raise ValueError(msg)
+        return response
+
+    def _incident_response_finding(self) -> ComplianceFinding:
+        ep_resp = self._get("/escalation_policies", params={"limit": "100"})
+        oc_resp = self._get("/oncalls", params={"limit": "100"})
+        uid = f"pagerduty:incident-response:{self._subdomain}:{_today_utc_iso_date()}"
+
+        policies = _count(ep_resp.json() if ep_resp.is_success else None, "escalation_policies")
+        oncalls = _count(oc_resp.json() if oc_resp.is_success else None, "oncalls")
+
+        if policies and oncalls:
+            message = (
+                f"PagerDuty incident-response posture on {self._subdomain}: "
+                f"{policies} escalation policy(ies) with {oncalls} active on-call(s)."
+            )
+            status_id = 1
+        elif policies:
+            message = (
+                f"PagerDuty has {policies} escalation policy(ies) on {self._subdomain} "
+                "but no active on-call coverage — gaps leave incidents unrouted."
+            )
+            status_id = 2
+        else:
+            message = (
+                f"No PagerDuty escalation policies on {self._subdomain}; the "
+                "incident-response escalation path is undefined."
+            )
+            status_id = 2
+
+        md = _metadata(self._subdomain, uid)
+        md["escalation_policy_count"] = policies
+        md["active_oncall_count"] = oncalls
+
+        return ComplianceFinding(
+            class_name="Compliance Finding",
+            category_uid=2000,
+            category_name="Findings",
+            type_uid=200301,
+            activity_id=1,
+            time=datetime.now(UTC),
+            message=message,
+            status_id=status_id,
+            metadata=md,
+        )
+
+    def collect(self) -> Iterable[OcsfBaseEvent]:
+        yield self._incident_response_finding()

--- a/src/lemma/services/connector_registry.py
+++ b/src/lemma/services/connector_registry.py
@@ -81,6 +81,14 @@ FIRST_PARTY_REGISTRY: list[ConnectorDescriptor] = [
         required_secret="LEMMA_AZURE_CLIENT_SECRET",
         capabilities=["entra-mfa", "activity-log", "azure-policy"],
     ),
+    ConnectorDescriptor(
+        name="pagerduty",
+        producer="PagerDuty",
+        description="Incident-response posture (SOC 2 CC7.x): escalation policies + on-call.",
+        config_keys=["subdomain"],
+        required_secret="LEMMA_PAGERDUTY_TOKEN",
+        capabilities=["incident-response"],
+    ),
 ]
 
 

--- a/tests/sdk/test_connector_conformance.py
+++ b/tests/sdk/test_connector_conformance.py
@@ -100,6 +100,14 @@ def _azure():
     )
 
 
+def _pagerduty():
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    return PagerDutyConnector(
+        subdomain="acme", token="t", client=_client("https://api.pagerduty.com")
+    )
+
+
 _FACTORIES = {
     "github": _github,
     "okta": _okta,
@@ -107,6 +115,7 @@ _FACTORIES = {
     "servicenow": _servicenow,
     "azure-devops": _azure_devops,
     "azure": _azure,
+    "pagerduty": _pagerduty,
 }
 
 

--- a/tests/sdk/test_pagerduty_connector.py
+++ b/tests/sdk/test_pagerduty_connector.py
@@ -1,0 +1,133 @@
+"""Tests for the first-party PagerDuty connector (Refs #41)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+def _mock_transport(handlers: dict[str, dict | int]) -> httpx.MockTransport:
+    """Return canned responses keyed by path prefix (a dict body → 200,
+    an int → that status with an empty body)."""
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        for prefix, body in handlers.items():
+            if path == prefix or path.startswith(prefix):
+                if isinstance(body, int):
+                    return httpx.Response(body)
+                return httpx.Response(200, json=body)
+        return httpx.Response(404, json={"error": {"message": f"unmatched: {path}"}})
+
+    return httpx.MockTransport(_handle)
+
+
+def _client(handlers: dict[str, dict | int]) -> httpx.Client:
+    return httpx.Client(base_url="https://api.pagerduty.com", transport=_mock_transport(handlers))
+
+
+def test_constructor_requires_token(monkeypatch) -> None:
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    monkeypatch.delenv("LEMMA_PAGERDUTY_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="LEMMA_PAGERDUTY_TOKEN"):
+        PagerDutyConnector(subdomain="acme")
+
+
+def test_collect_emits_incident_response_finding(monkeypatch) -> None:
+    """The connector pulls escalation policies + active on-calls and emits one
+    ComplianceFinding — the auditable signal a SOC 2 CC7.x incident-response
+    review wants."""
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    monkeypatch.setenv("LEMMA_PAGERDUTY_TOKEN", "tok")
+    handlers = {
+        "/escalation_policies": {
+            "escalation_policies": [{"id": "EP1", "name": "Primary"}, {"id": "EP2"}],
+            "total": 2,
+        },
+        "/oncalls": {"oncalls": [{"user": {"id": "U1"}}, {"user": {"id": "U2"}}]},
+    }
+
+    connector = PagerDutyConnector(subdomain="acme", client=_client(handlers))
+    events = list(connector.collect())
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.class_uid == 2003
+    md = event.metadata
+    assert md["product"]["name"] == "PagerDuty"
+    assert md["subdomain"] == "acme"
+    assert md["escalation_policy_count"] == 2
+    assert md["active_oncall_count"] == 2
+    assert event.status_id == 1  # policies defined + active coverage
+
+
+def test_collect_no_escalation_policies_is_failed(monkeypatch) -> None:
+    """No escalation policies → an IR process gap, surfaced as status_id 2."""
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    monkeypatch.setenv("LEMMA_PAGERDUTY_TOKEN", "tok")
+    handlers = {
+        "/escalation_policies": {"escalation_policies": [], "total": 0},
+        "/oncalls": {"oncalls": []},
+    }
+
+    connector = PagerDutyConnector(subdomain="acme", client=_client(handlers))
+    events = list(connector.collect())
+    assert len(events) == 1
+    assert events[0].metadata["escalation_policy_count"] == 0
+    assert events[0].status_id == 2
+
+
+def test_collect_rate_limit_raises(monkeypatch) -> None:
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    monkeypatch.setenv("LEMMA_PAGERDUTY_TOKEN", "tok")
+    connector = PagerDutyConnector(subdomain="acme", client=_client({"/escalation_policies": 429}))
+    with pytest.raises(ValueError, match="rate-limit"):
+        list(connector.collect())
+
+
+def test_uses_token_auth_header(monkeypatch) -> None:
+    """PagerDuty REST uses `Authorization: Token token=<API_TOKEN>`."""
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    monkeypatch.setenv("LEMMA_PAGERDUTY_TOKEN", "secret-tok")
+    captured: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(request.headers))
+        return httpx.Response(200, json={})
+
+    client = httpx.Client(
+        base_url="https://api.pagerduty.com", transport=httpx.MockTransport(_capture)
+    )
+    connector = PagerDutyConnector(subdomain="acme", client=client)
+    list(connector.collect())
+
+    assert captured.get("authorization") == "Token token=secret-tok"
+
+
+def test_dedupe_uid_stable_per_subdomain_and_date(monkeypatch) -> None:
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    monkeypatch.setenv("LEMMA_PAGERDUTY_TOKEN", "tok")
+    handlers = {"/escalation_policies": {"escalation_policies": []}, "/oncalls": {"oncalls": []}}
+    e1 = next(iter(PagerDutyConnector(subdomain="acme", client=_client(handlers)).collect()))
+    e2 = next(iter(PagerDutyConnector(subdomain="acme", client=_client(handlers)).collect()))
+    assert e1.metadata["uid"] == e2.metadata["uid"]
+
+
+def test_token_never_appears_in_emitted_event(monkeypatch) -> None:
+    """The API token is used only for auth, never serialized into evidence."""
+    from lemma.sdk.connectors.pagerduty import PagerDutyConnector
+
+    token = "SUPER_SECRET_PD_TOKEN"
+    monkeypatch.setenv("LEMMA_PAGERDUTY_TOKEN", token)
+    handlers = {
+        "/escalation_policies": {"escalation_policies": [{"id": "EP1"}]},
+        "/oncalls": {"oncalls": [{"user": {"id": "U1"}}]},
+    }
+    event = next(iter(PagerDutyConnector(subdomain="acme", client=_client(handlers)).collect()))
+    assert token not in event.model_dump_json()

--- a/tests/services/test_connector_registry.py
+++ b/tests/services/test_connector_registry.py
@@ -9,7 +9,16 @@ def test_registry_matches_first_party_factory():
     from lemma.services.connector_registry import registry_names
 
     # The factory's known list (kept in sync with _first_party_connector).
-    known = ["aws", "azure", "azure-devops", "github", "jira", "okta", "servicenow"]
+    known = [
+        "aws",
+        "azure",
+        "azure-devops",
+        "github",
+        "jira",
+        "okta",
+        "pagerduty",
+        "servicenow",
+    ]
     assert registry_names() == sorted(known)
 
 


### PR DESCRIPTION
## Description

Extends the first-party connector roster with **PagerDuty**, emitting one OCSF `ComplianceFinding` for **incident-response posture** (SOC 2 CC7.x): the count of escalation policies and active on-calls — pass when both are present, fail when the escalation path is undefined or has no active on-call coverage.

- Auth: PagerDuty's `Authorization: Token token=<API_TOKEN>` header; token required via `LEMMA_PAGERDUTY_TOKEN` or `token=` (loud error at construction).
- `metadata.uid` stable per `(subdomain, UTC date)` so same-day re-runs dedupe.
- Registered in `FIRST_PARTY_REGISTRY` and the `evidence collect` factory → runs via `lemma evidence collect pagerduty` or a `lemma_connector_config.yaml`.
- Hermetic tests (httpx `MockTransport`, 7 cases incl. token-required, rate-limit, no-token-in-evidence); covered by the cross-connector conformance suite and the registry drift guard.
- Docs: connector cookbook + `lemma connector registry` reference updated.

Full suite: **1455 passed, 4 skipped**.

## Scope note (please read)

This connector was an **autonomous roster extension**, not a specific tracked AC. #27's planned roster is already complete, and #41's advanced-integration ACs are SIEM/CSPM/POA&M-sync/vuln-specific — PagerDuty (incident response) maps cleanly to neither's checkboxes. Filed as `Refs #27` (the first-party-connectors umbrella) and added to #27's roster as a new shipped entry. If you'd prefer roadmapped connector work instead (e.g. a CSPM or SIEM under #41), say the word — happy to pivot.

Refs #27

## Type of Change

- [x] New feature (first-party connector)

## Pre-Submission Checklist

- [x] Rebased on the latest `main`
- [x] `ruff check` / `ruff format --check` clean
- [x] Full suite green (1455 passed); new connector tests + conformance + registry drift included
- [x] Docs updated (cookbook + CLI reference)