### PR TITLE
feat(connectors): first-party Splunk SIEM connector (#41)

### DIFF
--- a/docs/guides/connector-cookbook.md
+++ b/docs/guides/connector-cookbook.md
@@ -2,7 +2,7 @@
 
 Recipes for authors building production connectors, distilled from Lemma's
 first-party connectors (GitHub, Okta, AWS, Jira, ServiceNow, Azure DevOps,
-Azure, PagerDuty). If you haven't written a connector yet, start with
+Azure, PagerDuty, Splunk). If you haven't written a connector yet, start with
 [Build Your First Connector](build-your-first-connector.md); this page is the
 reference you reach for once you're integrating a real upstream API.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -476,7 +476,7 @@ List the available first-party connectors and their required configuration — t
 lemma connector registry
 ```
 
-Prints a table of each first-party connector (`github`, `okta`, `aws`, `jira`, `servicenow`, `azure-devops`, `azure`, `gcp`, `pagerduty`) with its producer, config keys, the environment variable holding its credential (if any), and a one-line description — so operators can discover what's available without reading code. A drift-guard test keeps this catalog in sync with the connector factory. Run a listed connector via [`lemma evidence collect`](#lemma-evidence-collect) or a `lemma_connector_config.yaml`.
+Prints a table of each first-party connector (`github`, `okta`, `aws`, `jira`, `servicenow`, `azure-devops`, `azure`, `gcp`, `pagerduty`, `splunk`) with its producer, config keys, the environment variable holding its credential (if any), and a one-line description — so operators can discover what's available without reading code. A drift-guard test keeps this catalog in sync with the connector factory. Run a listed connector via [`lemma evidence collect`](#lemma-evidence-collect) or a `lemma_connector_config.yaml`.
 
 ### `lemma connector validate`
 

--- a/src/lemma/commands/evidence.py
+++ b/src/lemma/commands/evidence.py
@@ -752,6 +752,17 @@ def _first_party_connector(
             kwargs6["subdomain"] = subdomain
         return PagerDutyConnector(**kwargs6)
 
+    if name == "splunk":
+        from lemma.sdk.connectors.splunk import SplunkConnector
+
+        if not base_url:
+            msg = (
+                "The splunk connector requires base_url=https://<host>:8089 "
+                "(the Splunk management endpoint)."
+            )
+            raise ValueError(msg)
+        return SplunkConnector(base_url=base_url)
+
     known = [
         "github",
         "okta",
@@ -762,6 +773,7 @@ def _first_party_connector(
         "azure",
         "gcp",
         "pagerduty",
+        "splunk",
     ]
     msg = f"Unknown connector '{name}'. Known first-party connectors: {', '.join(known)}."
     raise ValueError(msg)

--- a/src/lemma/sdk/connectors/splunk.py
+++ b/src/lemma/sdk/connectors/splunk.py
@@ -1,0 +1,170 @@
+"""First-party Splunk connector (Refs #41).
+
+Pulls security-monitoring posture from a Splunk deployment and emits one
+``ComplianceFinding`` counting the **enabled, scheduled saved searches** — the
+alert/correlation rules that actually run. It's the auditable signal a SOC 2
+CC7.2 (system monitoring) review wants: the entity operates monitoring that
+detects anomalous activity, and those rules are active rather than disabled.
+
+Auth: Splunk's REST API accepts a bearer token
+(``Authorization: Bearer <API_TOKEN>``). The token is required (set
+``LEMMA_SPLUNK_TOKEN`` in the environment or pass ``token=...`` to the
+constructor); a missing token is a loud error at construction time, not a
+cryptic 401 later. The REST API defaults to XML, so every request asks for
+``output_mode=json``.
+
+``base_url`` is the Splunk management endpoint (e.g.
+``https://splunk.example.com:8089``); its host is used to make ``metadata.uid``
+stable per ``(site, UTC date)`` so same-day re-runs dedupe.
+
+Tests inject a custom ``httpx.Client`` with a ``MockTransport`` so CI never
+touches a real Splunk deployment.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+import httpx
+
+from lemma.models.connector_manifest import ConnectorManifest
+from lemma.models.ocsf import ComplianceFinding, OcsfBaseEvent
+from lemma.sdk.connector import Connector
+
+_PRODUCER = "Splunk"
+
+
+def _today_utc_iso_date() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+def _site_from(base_url: str) -> str:
+    return urlparse(base_url).netloc or base_url
+
+
+def _metadata(site: str, uid: str) -> dict:
+    return {
+        "version": "1.3.0",
+        "product": {"name": _PRODUCER, "vendor_name": "Splunk", "uid": uid},
+        "site": site,
+        "uid": uid,
+    }
+
+
+def _truthy(value: object) -> bool:
+    """Splunk REST returns booleans as JSON ``true``/``false`` on newer
+    versions but ``"1"``/``"0"`` on others — accept both."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return False
+
+
+class SplunkConnector(Connector):
+    """Collect security-monitoring posture from a Splunk deployment."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        token: str | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._token = token or os.environ.get("LEMMA_SPLUNK_TOKEN") or None
+        if not self._token:
+            msg = (
+                "SplunkConnector requires an API token. "
+                "Set LEMMA_SPLUNK_TOKEN in the environment or pass token=... "
+                "to the constructor."
+            )
+            raise ValueError(msg)
+
+        self._base_url = base_url
+        self._site = _site_from(base_url)
+        self._client = client or httpx.Client(base_url=base_url)
+
+        self.manifest = ConnectorManifest(
+            name="splunk",
+            version="0.1.0",
+            producer=_PRODUCER,
+            description=(
+                "Splunk security-monitoring posture (SOC 2 CC7.2): enabled, "
+                "scheduled saved-search alert rules."
+            ),
+            capabilities=["security-monitoring"],
+        )
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self._token}",
+        }
+
+    def _get(self, path: str, params: dict[str, str] | None = None) -> httpx.Response:
+        response = self._client.get(path, headers=self._headers(), params=params)
+        if response.status_code == 429:
+            msg = (
+                f"Splunk API rate-limit exceeded while fetching {path}. "
+                "Retry after the quota resets."
+            )
+            raise ValueError(msg)
+        return response
+
+    def _security_monitoring_finding(self) -> ComplianceFinding:
+        response = self._get(
+            "/services/saved/searches",
+            params={"output_mode": "json", "count": "0"},
+        )
+        uid = f"splunk:security-monitoring:{self._site}:{_today_utc_iso_date()}"
+
+        entries: list[dict] = []
+        if response.is_success:
+            payload = response.json()
+            if isinstance(payload, dict) and isinstance(payload.get("entry"), list):
+                entries = [e for e in payload["entry"] if isinstance(e, dict)]
+
+        def _is_enabled_alert(entry: dict) -> bool:
+            content = entry.get("content")
+            if not isinstance(content, dict):
+                return False
+            return _truthy(content.get("is_scheduled")) and not _truthy(content.get("disabled"))
+
+        alert_count = sum(1 for e in entries if _is_enabled_alert(e))
+
+        if alert_count:
+            message = (
+                f"Splunk security monitoring on {self._site}: {alert_count} enabled "
+                f"scheduled alert search(es) of {len(entries)} saved search(es)."
+            )
+            status_id = 1
+        else:
+            message = (
+                f"No enabled scheduled alert searches on Splunk {self._site} "
+                f"({len(entries)} saved search(es) total) — no active security monitoring."
+            )
+            status_id = 2
+
+        md = _metadata(self._site, uid)
+        md["saved_search_total"] = len(entries)
+        md["scheduled_alert_count"] = alert_count
+
+        return ComplianceFinding(
+            class_name="Compliance Finding",
+            category_uid=2000,
+            category_name="Findings",
+            type_uid=200301,
+            activity_id=1,
+            time=datetime.now(UTC),
+            message=message,
+            status_id=status_id,
+            metadata=md,
+        )
+
+    def collect(self) -> Iterable[OcsfBaseEvent]:
+        yield self._security_monitoring_finding()

--- a/src/lemma/services/connector_registry.py
+++ b/src/lemma/services/connector_registry.py
@@ -89,6 +89,14 @@ FIRST_PARTY_REGISTRY: list[ConnectorDescriptor] = [
         required_secret="LEMMA_PAGERDUTY_TOKEN",
         capabilities=["incident-response"],
     ),
+    ConnectorDescriptor(
+        name="splunk",
+        producer="Splunk",
+        description="Security-monitoring posture (SOC 2 CC7.2): enabled scheduled alert searches.",
+        config_keys=["base_url"],
+        required_secret="LEMMA_SPLUNK_TOKEN",
+        capabilities=["security-monitoring"],
+    ),
 ]
 
 

--- a/tests/sdk/test_connector_conformance.py
+++ b/tests/sdk/test_connector_conformance.py
@@ -108,6 +108,16 @@ def _pagerduty():
     )
 
 
+def _splunk():
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    return SplunkConnector(
+        base_url="https://splunk.acme.com:8089",
+        token="t",
+        client=_client("https://splunk.acme.com:8089"),
+    )
+
+
 _FACTORIES = {
     "github": _github,
     "okta": _okta,
@@ -116,6 +126,7 @@ _FACTORIES = {
     "azure-devops": _azure_devops,
     "azure": _azure,
     "pagerduty": _pagerduty,
+    "splunk": _splunk,
 }
 
 

--- a/tests/sdk/test_splunk_connector.py
+++ b/tests/sdk/test_splunk_connector.py
@@ -1,0 +1,141 @@
+"""Tests for the first-party Splunk connector (Refs #41)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+_BASE = "https://splunk.acme.com:8089"
+
+
+def _mock_transport(handlers: dict[str, dict | int]) -> httpx.MockTransport:
+    def _handle(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        for prefix, body in handlers.items():
+            if path == prefix or path.startswith(prefix):
+                if isinstance(body, int):
+                    return httpx.Response(body)
+                return httpx.Response(200, json=body)
+        return httpx.Response(404, json={"messages": [{"text": f"unmatched: {path}"}]})
+
+    return httpx.MockTransport(_handle)
+
+
+def _client(handlers: dict[str, dict | int]) -> httpx.Client:
+    return httpx.Client(base_url=_BASE, transport=_mock_transport(handlers))
+
+
+def _searches(*entries: dict) -> dict:
+    return {"entry": list(entries)}
+
+
+def _search(name: str, *, scheduled: bool = True, disabled: bool = False) -> dict:
+    return {"name": name, "content": {"is_scheduled": scheduled, "disabled": disabled}}
+
+
+def test_constructor_requires_token(monkeypatch) -> None:
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.delenv("LEMMA_SPLUNK_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="LEMMA_SPLUNK_TOKEN"):
+        SplunkConnector(base_url=_BASE)
+
+
+def test_collect_emits_monitoring_finding(monkeypatch) -> None:
+    """Counts enabled scheduled saved searches — the auditable signal that
+    security monitoring is configured (SOC 2 CC7.2)."""
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", "tok")
+    handlers = {
+        "/services/saved/searches": _searches(
+            _search("Failed Logins", scheduled=True, disabled=False),
+            _search("Privilege Escalation", scheduled=True, disabled=False),
+            _search("Ad-hoc report", scheduled=False, disabled=False),  # not an alert
+            _search("Old rule", scheduled=True, disabled=True),  # disabled
+        )
+    }
+    connector = SplunkConnector(base_url=_BASE, client=_client(handlers))
+    events = list(connector.collect())
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.class_uid == 2003
+    md = event.metadata
+    assert md["product"]["name"] == "Splunk"
+    assert md["site"] == "splunk.acme.com:8089"
+    assert md["saved_search_total"] == 4
+    assert md["scheduled_alert_count"] == 2  # only enabled + scheduled
+    assert event.status_id == 1
+
+
+def test_collect_no_enabled_alerts_is_failed(monkeypatch) -> None:
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", "tok")
+    handlers = {"/services/saved/searches": _searches(_search("Old", disabled=True))}
+    connector = SplunkConnector(base_url=_BASE, client=_client(handlers))
+    events = list(connector.collect())
+    assert len(events) == 1
+    assert events[0].metadata["scheduled_alert_count"] == 0
+    assert events[0].status_id == 2
+
+
+def test_uses_bearer_auth_header(monkeypatch) -> None:
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", "secret-tok")
+    captured: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured.update(dict(request.headers))
+        return httpx.Response(200, json={"entry": []})
+
+    client = httpx.Client(base_url=_BASE, transport=httpx.MockTransport(_capture))
+    list(SplunkConnector(base_url=_BASE, client=client).collect())
+    assert captured.get("authorization") == "Bearer secret-tok"
+
+
+def test_requests_json_output_mode(monkeypatch) -> None:
+    """Splunk REST defaults to XML; the connector must ask for JSON."""
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", "tok")
+    captured: list[str] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured.append(str(request.url))
+        return httpx.Response(200, json={"entry": []})
+
+    client = httpx.Client(base_url=_BASE, transport=httpx.MockTransport(_capture))
+    list(SplunkConnector(base_url=_BASE, client=client).collect())
+    assert "output_mode=json" in captured[0]
+
+
+def test_collect_rate_limit_raises(monkeypatch) -> None:
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", "tok")
+    connector = SplunkConnector(base_url=_BASE, client=_client({"/services/saved/searches": 429}))
+    with pytest.raises(ValueError, match="rate-limit"):
+        list(connector.collect())
+
+
+def test_dedupe_uid_stable_per_site_and_date(monkeypatch) -> None:
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", "tok")
+    handlers = {"/services/saved/searches": _searches()}
+    e1 = next(iter(SplunkConnector(base_url=_BASE, client=_client(handlers)).collect()))
+    e2 = next(iter(SplunkConnector(base_url=_BASE, client=_client(handlers)).collect()))
+    assert e1.metadata["uid"] == e2.metadata["uid"]
+
+
+def test_token_never_appears_in_emitted_event(monkeypatch) -> None:
+    from lemma.sdk.connectors.splunk import SplunkConnector
+
+    token = "SUPER_SECRET_SPLUNK_TOKEN"
+    monkeypatch.setenv("LEMMA_SPLUNK_TOKEN", token)
+    handlers = {"/services/saved/searches": _searches(_search("Alert"))}
+    event = next(iter(SplunkConnector(base_url=_BASE, client=_client(handlers)).collect()))
+    assert token not in event.model_dump_json()

--- a/tests/services/test_connector_registry.py
+++ b/tests/services/test_connector_registry.py
@@ -18,6 +18,7 @@ def test_registry_matches_first_party_factory():
         "okta",
         "pagerduty",
         "servicenow",
+        "splunk",
     ]
     assert registry_names() == sorted(known)
 


### PR DESCRIPTION
## Description

Adds a first-party **Splunk** connector — closing #41's **SIEM** acceptance criterion ("at least 1 SIEM integration (Splunk or Elastic) ingests security events as compliance evidence").

It emits one OCSF `ComplianceFinding` for **security-monitoring posture** (SOC 2 CC7.2): the count of **enabled, scheduled saved-search alert rules** out of the deployment's total saved searches — pass when at least one active monitoring rule exists, fail when none do (monitoring isn't actually running).

- Auth: Splunk's `Authorization: Bearer <API_TOKEN>` header; token required via `LEMMA_SPLUNK_TOKEN` or `token=` (loud error at construction).
- Every request asks for `output_mode=json` (Splunk REST defaults to XML); booleans are accepted as JSON `true`/`false` *or* `"1"`/`"0"` across Splunk versions.
- `metadata.uid` stable per `(site, UTC date)` so same-day re-runs dedupe.
- Registered in `FIRST_PARTY_REGISTRY` and the `evidence collect` factory → runs via `lemma evidence collect splunk --base-url https://<host>:8089` or a config file.
- Hermetic tests (httpx `MockTransport`, 8 cases incl. token-required, bearer auth, json output-mode, rate-limit, no-token-in-evidence); covered by the cross-connector conformance suite and the registry drift guard.
- Docs: connector cookbook + `lemma connector registry` reference updated.

Full suite: **1465 passed, 4 skipped**.

## Scope

Unlike the PagerDuty connector (#249, a roster extension), this one maps directly to a tracked AC — #41's SIEM integration. Filed `Refs #41`; the SIEM checkbox/AC are ticked in the issue.

Refs #41

## Type of Change

- [x] New feature (first-party connector)

## Pre-Submission Checklist

- [x] Rebased on the latest `main`
- [x] `ruff check` / `ruff format --check` clean
- [x] Full suite green (1465 passed); new connector tests + conformance + registry drift included
- [x] Docs updated (cookbook + CLI reference)