### PR TITLE
feat(connectors): first-party Wiz CSPM connector (#41)

### DIFF
--- a/docs/guides/connector-cookbook.md
+++ b/docs/guides/connector-cookbook.md
@@ -2,7 +2,7 @@
 
 Recipes for authors building production connectors, distilled from Lemma's
 first-party connectors (GitHub, Okta, AWS, Jira, ServiceNow, Azure DevOps,
-Azure, PagerDuty, Splunk). If you haven't written a connector yet, start with
+Azure, PagerDuty, Splunk, Wiz). If you haven't written a connector yet, start with
 [Build Your First Connector](build-your-first-connector.md); this page is the
 reference you reach for once you're integrating a real upstream API.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -476,7 +476,7 @@ List the available first-party connectors and their required configuration — t
 lemma connector registry
 ```
 
-Prints a table of each first-party connector (`github`, `okta`, `aws`, `jira`, `servicenow`, `azure-devops`, `azure`, `gcp`, `pagerduty`, `splunk`) with its producer, config keys, the environment variable holding its credential (if any), and a one-line description — so operators can discover what's available without reading code. A drift-guard test keeps this catalog in sync with the connector factory. Run a listed connector via [`lemma evidence collect`](#lemma-evidence-collect) or a `lemma_connector_config.yaml`.
+Prints a table of each first-party connector (`github`, `okta`, `aws`, `jira`, `servicenow`, `azure-devops`, `azure`, `gcp`, `pagerduty`, `splunk`, `wiz`) with its producer, config keys, the environment variable holding its credential (if any), and a one-line description — so operators can discover what's available without reading code. A drift-guard test keeps this catalog in sync with the connector factory. Run a listed connector via [`lemma evidence collect`](#lemma-evidence-collect) or a `lemma_connector_config.yaml`.
 
 ### `lemma connector validate`
 

--- a/src/lemma/commands/evidence.py
+++ b/src/lemma/commands/evidence.py
@@ -636,6 +636,7 @@ def _first_party_connector(
     project_id: str | None = None,
     access_token: str | None = None,
     subdomain: str | None = None,
+    api_url: str | None = None,
 ) -> Connector:
     """Instantiate a first-party connector by short name.
 
@@ -763,6 +764,20 @@ def _first_party_connector(
             raise ValueError(msg)
         return SplunkConnector(base_url=base_url)
 
+    if name == "wiz":
+        from lemma.sdk.connectors.wiz import WizConnector
+
+        if not api_url:
+            msg = "The wiz connector requires api_url=https://api.<region>.app.wiz.io/graphql."
+            raise ValueError(msg)
+        if not client_id:
+            msg = "The wiz connector requires client_id (the Wiz service-account id)."
+            raise ValueError(msg)
+        kwargs7: dict = {"api_url": api_url, "client_id": client_id}
+        if client_secret:
+            kwargs7["client_secret"] = client_secret
+        return WizConnector(**kwargs7)
+
     known = [
         "github",
         "okta",
@@ -774,6 +789,7 @@ def _first_party_connector(
         "gcp",
         "pagerduty",
         "splunk",
+        "wiz",
     ]
     msg = f"Unknown connector '{name}'. Known first-party connectors: {', '.join(known)}."
     raise ValueError(msg)
@@ -808,6 +824,7 @@ def _connector_from_config_dict(name: str, config: dict) -> Connector:
         project_id=config.get("project_id"),
         access_token=config.get("access_token"),
         subdomain=config.get("subdomain"),
+        api_url=config.get("api_url"),
     )
 
 

--- a/src/lemma/sdk/connectors/wiz.py
+++ b/src/lemma/sdk/connectors/wiz.py
@@ -1,0 +1,190 @@
+"""First-party Wiz CSPM connector (Refs #41).
+
+Pulls cloud-security-posture evidence from Wiz and emits one OCSF
+``ComplianceFinding`` summarizing **open issues by severity** — specifically
+the count of open ``CRITICAL`` and ``HIGH`` issues. It's the auditable signal a
+cloud-posture review wants: the CSPM is in place and there are (or aren't)
+unresolved high-severity exposures.
+
+Auth: Wiz uses an OAuth2 client-credentials exchange (service-account
+``client_id`` + ``client_secret``) against ``auth_url`` (default
+``https://auth.app.wiz.io/oauth/token``, ``audience=wiz-api``); the returned
+bearer token authorizes a GraphQL query to the tenant's ``api_url``. The client
+secret is required (set ``LEMMA_WIZ_CLIENT_SECRET`` in the environment or pass
+``client_secret=...``); a missing secret is a loud error at construction time.
+
+``metadata.uid`` is stable per ``(api host, UTC date)`` so same-day re-runs
+dedupe. Tests inject a custom ``httpx.Client`` with a ``MockTransport`` (routing
+by URL) so CI never touches a real Wiz tenant.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from urllib.parse import urlparse
+
+import httpx
+
+from lemma.models.connector_manifest import ConnectorManifest
+from lemma.models.ocsf import ComplianceFinding, OcsfBaseEvent
+from lemma.sdk.connector import Connector
+
+_PRODUCER = "Wiz"
+_DEFAULT_AUTH_URL = "https://auth.app.wiz.io/oauth/token"
+_AUDIENCE = "wiz-api"
+
+# Open issues with severity, for the posture rollup.
+_ISSUES_QUERY = """
+query LemmaIssues($filterBy: IssueFilters, $first: Int) {
+  issues(filterBy: $filterBy, first: $first) {
+    nodes { id severity status }
+    totalCount
+  }
+}
+""".strip()
+
+
+def _today_utc_iso_date() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+def _metadata(site: str, uid: str) -> dict:
+    return {
+        "version": "1.3.0",
+        "product": {"name": _PRODUCER, "vendor_name": "Wiz, Inc.", "uid": uid},
+        "site": site,
+        "uid": uid,
+    }
+
+
+class WizConnector(Connector):
+    """Collect cloud-security-posture issues from a Wiz tenant."""
+
+    def __init__(
+        self,
+        *,
+        api_url: str,
+        client_id: str,
+        client_secret: str | None = None,
+        auth_url: str = _DEFAULT_AUTH_URL,
+        client: httpx.Client | None = None,
+    ) -> None:
+        if not api_url:
+            msg = "WizConnector requires api_url=https://api.<region>.app.wiz.io/graphql."
+            raise ValueError(msg)
+        if not client_id:
+            msg = "WizConnector requires a client_id (Wiz service-account id)."
+            raise ValueError(msg)
+        self._client_secret = client_secret or os.environ.get("LEMMA_WIZ_CLIENT_SECRET") or None
+        if not self._client_secret:
+            msg = (
+                "WizConnector requires a client secret. Set LEMMA_WIZ_CLIENT_SECRET "
+                "in the environment or pass client_secret=... to the constructor."
+            )
+            raise ValueError(msg)
+
+        self._api_url = api_url
+        self._client_id = client_id
+        self._auth_url = auth_url
+        self._site = urlparse(api_url).netloc or api_url
+        self._client = client or httpx.Client()
+        self._token: str | None = None
+
+        self.manifest = ConnectorManifest(
+            name="wiz",
+            version="0.1.0",
+            producer=_PRODUCER,
+            description=("Wiz cloud-security-posture (CSPM): count of open CRITICAL/HIGH issues."),
+            capabilities=["cloud-posture"],
+        )
+
+    def _access_token(self) -> str:
+        if self._token is not None:
+            return self._token
+        response = self._client.post(
+            self._auth_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+                "audience": _AUDIENCE,
+            },
+        )
+        if not response.is_success:
+            msg = (
+                f"Wiz token exchange failed (HTTP {response.status_code}). "
+                "Check the client_id/secret and auth_url."
+            )
+            raise ValueError(msg)
+        token = response.json().get("access_token")
+        if not token:
+            msg = "Wiz token exchange returned no access_token."
+            raise ValueError(msg)
+        self._token = str(token)
+        return self._token
+
+    def _query_issues(self) -> list[dict]:
+        response = self._client.post(
+            self._api_url,
+            headers={"Authorization": f"Bearer {self._access_token()}"},
+            json={
+                "query": _ISSUES_QUERY,
+                "variables": {"filterBy": {"status": ["OPEN"]}, "first": 500},
+            },
+        )
+        if response.status_code == 429:
+            msg = "Wiz API rate-limit exceeded while querying issues. Retry after the quota resets."
+            raise ValueError(msg)
+        if not response.is_success:
+            return []
+        payload = response.json()
+        try:
+            nodes = payload["data"]["issues"]["nodes"]
+        except (KeyError, TypeError):
+            return []
+        return [n for n in nodes if isinstance(n, dict)]
+
+    def _cloud_posture_finding(self) -> ComplianceFinding:
+        nodes = self._query_issues()
+        uid = f"wiz:cloud-posture:{self._site}:{_today_utc_iso_date()}"
+
+        def _sev(node: dict) -> str:
+            return str(node.get("severity", "")).upper()
+
+        critical = sum(1 for n in nodes if _sev(n) == "CRITICAL")
+        high = sum(1 for n in nodes if _sev(n) == "HIGH")
+
+        if critical or high:
+            message = (
+                f"Wiz cloud posture on {self._site}: {critical} open CRITICAL and "
+                f"{high} open HIGH issue(s) of {len(nodes)} open issue(s) — remediate."
+            )
+            status_id = 2
+        else:
+            message = (
+                f"Wiz cloud posture on {self._site}: no open CRITICAL/HIGH issues "
+                f"({len(nodes)} open issue(s) total)."
+            )
+            status_id = 1
+
+        md = _metadata(self._site, uid)
+        md["open_critical_count"] = critical
+        md["open_high_count"] = high
+        md["open_issue_total"] = len(nodes)
+
+        return ComplianceFinding(
+            class_name="Compliance Finding",
+            category_uid=2000,
+            category_name="Findings",
+            type_uid=200301,
+            activity_id=1,
+            time=datetime.now(UTC),
+            message=message,
+            status_id=status_id,
+            metadata=md,
+        )
+
+    def collect(self) -> Iterable[OcsfBaseEvent]:
+        yield self._cloud_posture_finding()

--- a/src/lemma/services/connector_registry.py
+++ b/src/lemma/services/connector_registry.py
@@ -97,6 +97,14 @@ FIRST_PARTY_REGISTRY: list[ConnectorDescriptor] = [
         required_secret="LEMMA_SPLUNK_TOKEN",
         capabilities=["security-monitoring"],
     ),
+    ConnectorDescriptor(
+        name="wiz",
+        producer="Wiz",
+        description="Cloud-security posture (CSPM): count of open CRITICAL/HIGH issues.",
+        config_keys=["api_url", "client_id"],
+        required_secret="LEMMA_WIZ_CLIENT_SECRET",
+        capabilities=["cloud-posture"],
+    ),
 ]
 
 

--- a/tests/sdk/test_connector_conformance.py
+++ b/tests/sdk/test_connector_conformance.py
@@ -118,6 +118,17 @@ def _splunk():
     )
 
 
+def _wiz():
+    from lemma.sdk.connectors.wiz import WizConnector
+
+    return WizConnector(
+        api_url="https://api.test.app.wiz.io/graphql",
+        client_id="c",
+        client_secret="s",
+        client=_client("https://api.test.app.wiz.io"),
+    )
+
+
 _FACTORIES = {
     "github": _github,
     "okta": _okta,
@@ -127,6 +138,7 @@ _FACTORIES = {
     "azure": _azure,
     "pagerduty": _pagerduty,
     "splunk": _splunk,
+    "wiz": _wiz,
 }
 
 

--- a/tests/sdk/test_wiz_connector.py
+++ b/tests/sdk/test_wiz_connector.py
@@ -1,0 +1,131 @@
+"""Tests for the first-party Wiz CSPM connector (Refs #41)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+_AUTH_PREFIX = "https://auth.app.wiz.io/oauth/token"
+_API_URL = "https://api.test.app.wiz.io/graphql"
+
+
+def _token_response(token: str = "wiz_access_token") -> dict[str, Any]:
+    return {"access_token": token, "token_type": "Bearer", "expires_in": 3600}
+
+
+def _issues(*severities: str) -> dict[str, Any]:
+    nodes = [{"id": f"i{i}", "severity": s} for i, s in enumerate(severities)]
+    return {"data": {"issues": {"nodes": nodes, "totalCount": len(nodes)}}}
+
+
+def _mock_transport(handlers: dict[str, Any], capture: list[httpx.Request] | None = None):
+    def _handle(request: httpx.Request) -> httpx.Response:
+        if capture is not None:
+            capture.append(request)
+        url = str(request.url)
+        for prefix, body in handlers.items():
+            if url.startswith(prefix):
+                if isinstance(body, int):
+                    return httpx.Response(body)
+                return httpx.Response(200, json=body)
+        return httpx.Response(404, json={"errors": [{"message": f"unmatched: {url}"}]})
+
+    return httpx.MockTransport(_handle)
+
+
+def _client(handlers: dict[str, Any], capture: list[httpx.Request] | None = None) -> httpx.Client:
+    return httpx.Client(transport=_mock_transport(handlers, capture))
+
+
+def _conn(handlers, capture=None, **kw):
+    from lemma.sdk.connectors.wiz import WizConnector
+
+    return WizConnector(
+        api_url=_API_URL,
+        client_id="cid",
+        client_secret="csecret",
+        client=_client(handlers, capture),
+        **kw,
+    )
+
+
+def test_constructor_requires_client_secret(monkeypatch) -> None:
+    from lemma.sdk.connectors.wiz import WizConnector
+
+    monkeypatch.delenv("LEMMA_WIZ_CLIENT_SECRET", raising=False)
+    with pytest.raises(ValueError, match="LEMMA_WIZ_CLIENT_SECRET"):
+        WizConnector(api_url=_API_URL, client_id="cid")
+
+
+def test_constructor_requires_api_url() -> None:
+    from lemma.sdk.connectors.wiz import WizConnector
+
+    with pytest.raises(ValueError, match="api_url"):
+        WizConnector(api_url="", client_id="cid", client_secret="s")
+
+
+def test_collect_emits_posture_finding_with_open_criticals() -> None:
+    """Open CRITICAL/HIGH cloud-posture issues → a failing ComplianceFinding."""
+    handlers = {
+        _AUTH_PREFIX: _token_response(),
+        _API_URL: _issues("CRITICAL", "HIGH", "HIGH", "LOW"),
+    }
+    events = list(_conn(handlers).collect())
+    assert len(events) == 1
+    event = events[0]
+    assert event.class_uid == 2003
+    md = event.metadata
+    assert md["product"]["name"] == "Wiz"
+    assert md["site"] == "api.test.app.wiz.io"
+    assert md["open_critical_count"] == 1
+    assert md["open_high_count"] == 2
+    assert md["open_issue_total"] == 4
+    assert event.status_id == 2  # open criticals → fail
+
+
+def test_collect_no_open_criticals_is_pass() -> None:
+    handlers = {_AUTH_PREFIX: _token_response(), _API_URL: _issues("LOW", "INFORMATIONAL")}
+    events = list(_conn(handlers).collect())
+    assert events[0].metadata["open_critical_count"] == 0
+    assert events[0].metadata["open_high_count"] == 0
+    assert events[0].status_id == 1
+
+
+def test_exchanges_token_then_queries_graphql_with_bearer() -> None:
+    capture: list[httpx.Request] = []
+    handlers = {_AUTH_PREFIX: _token_response("tok-123"), _API_URL: _issues()}
+    list(_conn(handlers, capture=capture).collect())
+
+    # First the token exchange, then the GraphQL call carrying the bearer token.
+    assert str(capture[0].url).startswith(_AUTH_PREFIX)
+    graphql_req = next(r for r in capture if str(r.url) == _API_URL)
+    assert graphql_req.method == "POST"
+    assert graphql_req.headers.get("authorization") == "Bearer tok-123"
+
+
+def test_collect_rate_limit_raises() -> None:
+    handlers = {_AUTH_PREFIX: _token_response(), _API_URL: 429}
+    with pytest.raises(ValueError, match="rate-limit"):
+        list(_conn(handlers).collect())
+
+
+def test_dedupe_uid_stable_per_site_and_date() -> None:
+    handlers = {_AUTH_PREFIX: _token_response(), _API_URL: _issues()}
+    e1 = next(iter(_conn(handlers).collect()))
+    e2 = next(iter(_conn(handlers).collect()))
+    assert e1.metadata["uid"] == e2.metadata["uid"]
+
+
+def test_secret_never_appears_in_emitted_event(monkeypatch) -> None:
+    secret = "SUPER_SECRET_WIZ"
+    monkeypatch.setenv("LEMMA_WIZ_CLIENT_SECRET", secret)
+    handlers = {_AUTH_PREFIX: _token_response("tok"), _API_URL: _issues("CRITICAL")}
+    from lemma.sdk.connectors.wiz import WizConnector
+
+    conn = WizConnector(api_url=_API_URL, client_id="cid", client=_client(handlers))
+    event = next(iter(conn.collect()))
+    dumped = event.model_dump_json()
+    assert secret not in dumped
+    assert "tok" not in dumped

--- a/tests/services/test_connector_registry.py
+++ b/tests/services/test_connector_registry.py
@@ -19,6 +19,7 @@ def test_registry_matches_first_party_factory():
         "pagerduty",
         "servicenow",
         "splunk",
+        "wiz",
     ]
     assert registry_names() == sorted(known)
 


### PR DESCRIPTION
## Description

Adds a first-party **Wiz** connector — closing #41's **CSPM** acceptance criterion ("at least 1 CSPM integration (Wiz or Defender for Cloud) ingests cloud posture findings as evidence").

It emits one OCSF `ComplianceFinding` for **cloud-security posture**: the count of open **CRITICAL** and **HIGH** issues in the Wiz tenant — pass when none are open, fail when high-severity exposures remain.

- Auth: Wiz's OAuth2 client-credentials exchange (service-account `client_id` + `client_secret` → bearer token) followed by a GraphQL query for open issues. Modeled on the Azure connector's OAuth pattern (`httpx.Client` with absolute URLs).
- Client secret required via `LEMMA_WIZ_CLIENT_SECRET` or `client_secret=` (loud error at construction).
- `metadata.uid` stable per `(api host, UTC date)` so same-day re-runs dedupe.
- Registered in `FIRST_PARTY_REGISTRY` and the `evidence collect` factory → `lemma evidence collect wiz --api-url ... --client-id ...` or a config file.
- Hermetic tests (httpx `MockTransport` routing by URL, 8 cases incl. token exchange, bearer auth, rate-limit, secret-never-in-evidence); covered by the conformance suite and registry drift guard.

Full suite: **1475 passed, 4 skipped**.

## Scope

Maps directly to a tracked AC — #41's CSPM integration. Emits a posture-summary `ComplianceFinding` (no OCSF model expansion needed). The deeper "vuln findings mapped to specific controls automatically" AC and a richer `VulnerabilityFinding` OCSF class (#89) remain separate, larger work.

Refs #41

## Type of Change

- [x] New feature (first-party connector)

## Pre-Submission Checklist

- [x] Rebased on the latest `main`
- [x] `ruff check` / `ruff format --check` clean
- [x] Full suite green (1475 passed); connector tests + conformance + registry drift included
- [x] Docs updated (cookbook + CLI reference)